### PR TITLE
Add .ccls-cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,4 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 build
+.ccls-cache


### PR DESCRIPTION
Adds .ccls-cache (a directory used by a code completion tool which is used by some editors) to the .gitignore file.