### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,5 +4,7 @@ NamespaceIndentation: All
 SortIncludes: 'false'
 IndentWidth: 4
 AccessModifierOffset: -4
+DerivePointerAlignment: false
+PointerAlignment: Left
 
 ...


### PR DESCRIPTION
Made * and & align left instead of right