### PR TITLE
Fix google test configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,15 +40,15 @@ set(CUBOS_ENTRYPOINT
 )
 
 # Create Cubos Library
-add_library(cubos_lib ${CUBOS_SOURCE} ${CUBOS_INCLUDE})
-target_include_directories(cubos_lib PUBLIC "include")
-set_property(TARGET cubos_lib PROPERTY CXX_STANDARD 20)
+add_library(cubos-core ${CUBOS_SOURCE} ${CUBOS_INCLUDE})
+target_include_directories(cubos-core PUBLIC "include")
+set_property(TARGET cubos-core PROPERTY CXX_STANDARD 20)
 
 # Dependencies
 if(WITH_OPENGL)
     add_subdirectory(lib/glad)
-    target_link_libraries(cubos_lib glad)
-    target_compile_definitions(cubos_lib PRIVATE WITH_OPENGL)
+    target_link_libraries(cubos-core glad)
+    target_compile_definitions(cubos-core PRIVATE WITH_OPENGL)
 endif()
 
 if(WITH_GLFW)
@@ -61,8 +61,8 @@ if(WITH_GLFW)
         find_package(glfw3 REQUIRED)
     endif()
 
-    target_link_libraries(cubos_lib glfw)
-    target_compile_definitions(cubos_lib PRIVATE WITH_GLFW)
+    target_link_libraries(cubos-core glfw)
+    target_compile_definitions(cubos-core PRIVATE WITH_GLFW)
 endif()
 
 if(GLM_USE_SUBMODULE)
@@ -93,9 +93,9 @@ else()
     find_package(spdlog REQUIRED)
 endif()
 
-target_link_libraries(cubos_lib glm glad yaml-cpp spdlog ${CMAKE_DL_LIBS})
+target_link_libraries(cubos-core glm glad yaml-cpp spdlog ${CMAKE_DL_LIBS})
 
-# Add the tests for cubos_lib
+# Add the tests for cubos-core
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_ENGINE_TESTS) 
     include(CTest)
     enable_testing()
@@ -109,9 +109,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_ENGINE_TESTS)
 endif()
 
 # Create cubos library
-add_library(cubos ${CUBOS_ENTRYPOINT})
-target_link_libraries(cubos cubos_lib)
-set_property(TARGET cubos PROPERTY CXX_STANDARD 20)
+add_library(cubos-engine ${CUBOS_ENTRYPOINT})
+target_link_libraries(cubos-engine cubos-core)
+set_property(TARGET cubos-engine PROPERTY CXX_STANDARD 20)
 
 # Add samples
 if (BUILD_SAMPLES)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(empty empty.cpp)
-target_link_libraries(empty cubos)
+target_link_libraries(empty cubos-engine)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,12 +2,12 @@ set(CUBOS_TESTS_SOURCE
     "test_settings.cpp"
 )
 
-add_executable(cubos_tests ${CUBOS_TESTS_SOURCE})
+add_executable(cubos-core-tests ${CUBOS_TESTS_SOURCE})
 
 target_link_libraries(
-    cubos_tests 
-    cubos_lib
+    cubos-core-tests 
+    cubos-core
     gtest_main
 )
 
-gtest_add_tests(TARGET cubos_tests)
+gtest_add_tests(TARGET cubos-core-tests)


### PR DESCRIPTION
This PR focuses on solving the issues related with generating and running the test executables that rely on googletest #35 and #34.

The cmake source for generating tests was moved to a CMakeLists.txt inside `tests` directory.

The root CMakeLists.txt file defines an option `BUILD_ENGINE_TESTS` to determine if the tests should be build. 
If so, the entry.cpp is removed from the source files - to remove the entry.cpp:main() - and the `tests` directory is added as a subdirectory.
