### PR TITLE
FileSystem and STDArchive

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,6 +31,10 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/memory/yaml_serializer.cpp"
     "src/cubos/memory/yaml_deserializer.cpp"
 
+    "src/cubos/data/file.cpp"
+    "src/cubos/data/file_system.cpp"
+    "src/cubos/data/std_archive.cpp"
+
     "src/cubos/io/window.cpp"
     "src/cubos/io/glfw_window.hpp"
     "src/cubos/io/glfw_window.cpp"
@@ -47,20 +51,23 @@ set(CUBOS_CORE_INCLUDE
     "include/cubos/memory/stream.hpp"
     "include/cubos/memory/std_stream.hpp"
     "include/cubos/memory/buffer_stream.hpp"
-    
-    "include/cubos/memory/stream.hpp"
-    "include/cubos/memory/serialization_map.hpp"
     "include/cubos/memory/serializer.hpp"
     "include/cubos/memory/deserializer.hpp"
     "include/cubos/memory/yaml_serializer.hpp"
     "include/cubos/memory/yaml_deserializer.hpp"
+    "include/cubos/memory/serialization_map.hpp"
+    
+    "include/cubos/data/file.hpp"
+    "include/cubos/data/file_stream.hpp"
+    "include/cubos/data/file_system.hpp"
+    "include/cubos/data/archive.hpp"
+    "include/cubos/data/std_archive.hpp"
 
     "include/cubos/io/window.hpp"
 
     "include/cubos/gl/debug.hpp"
     "include/cubos/gl/render_device.hpp"
 )
-
 
 # Create core library
 
@@ -119,7 +126,7 @@ else()
     find_package(spdlog REQUIRED)
 endif()
 
-target_link_libraries(cubos-core PUBLIC glm spdlog yaml-cpp ${CMAKE_DL_LIBS})
+target_link_libraries(cubos-core PUBLIC glm::glm spdlog yaml-cpp ${CMAKE_DL_LIBS} pthread)
 target_link_libraries(cubos-core PRIVATE glad)
 
 # Add core tests

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -126,8 +126,11 @@ else()
     find_package(spdlog REQUIRED)
 endif()
 
-target_link_libraries(cubos-core PUBLIC glm::glm spdlog yaml-cpp ${CMAKE_DL_LIBS} pthread)
-target_link_libraries(cubos-core PRIVATE glad)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+target_link_libraries(cubos-core PUBLIC glm::glm spdlog yaml-cpp ${CMAKE_DL_LIBS})
+target_link_libraries(cubos-core PRIVATE glad Threads::Threads)
 
 # Add core tests
 

--- a/core/include/cubos/data/archive.hpp
+++ b/core/include/cubos/data/archive.hpp
@@ -1,0 +1,71 @@
+#ifndef CUBOS_DATA_ARCHIVE_HPP
+#define CUBOS_DATA_ARCHIVE_HPP
+
+#include <cubos/data/file.hpp>
+
+namespace cubos::data
+{
+    /// Represents an archive in the virtual file system.
+    /// This class is meant to only be used internally by the virtual file system.
+    ///
+    /// Each file in an archive is represented by a unique integer identifier.
+    /// The identifier 0 is reserved for errors, and the identifier 1 is reserved for the root file/directory.
+    class Archive
+    {
+    public:
+        Archive() = default;
+        virtual ~Archive() = default;
+
+    protected:
+        friend File;
+
+        /// Creates a new file in the archive. If the file already exists, or if the path is relative, 0 is returned.
+        /// @param parent The parent directory of the new file.
+        /// @param name The name of the new file.
+        /// @return The identifier of the file, or 0 if the file could not be created.
+        virtual size_t create(size_t parent, std::string_view name, bool directory = false) = 0;
+
+        /// Destroys a file in the archive. If the file doesn't exist, or if it's a non-empty directory, 0 is returned.
+        /// @param id The identifier of the file to delete.
+        /// @return True if the file was destroyed, false otherwise.
+        virtual bool destroy(size_t id) = 0;
+
+        /// Gets the name of a file.
+        /// @param id The identifier of the file.
+        /// @return The name of the file.
+        virtual std::string getName(size_t id) const = 0;
+
+        /// Checks if a file is a directory.
+        /// @param id The identifier of the file.
+        /// @return True if the file is a directory, false otherwise.
+        virtual bool isDirectory(size_t id) const = 0;
+
+        /// Checks if the archive is read-only.
+        /// @return True if the archive is read-only, false otherwise.
+        virtual bool isReadOnly() const = 0;
+
+        /// Gets the parent of a file.
+        /// @param id The identifier of the file.
+        /// @return The identifier of the parent file, or 0 if the file is the root file.
+        virtual size_t getParent(size_t id) const = 0;
+
+        /// Gets the next sibling of a file.
+        /// @param id The identifier of the file.
+        /// @return The identifier of the next sibling, or 0 if the file is the last child of its parent.
+        virtual size_t getSibling(size_t id) const = 0;
+
+        /// Gets the first child of a directory.
+        /// @param id The identifier of the directory.
+        /// @return The identifier of the first child, or 0 if the file is not a directory or if it is empty.
+        virtual size_t getChild(size_t id) const = 0;
+
+        /// Opens a file in the archive.
+        /// If the file does not exist, or the archive is read-only, nullptr is returned.
+        /// @param file The handle of the file.
+        /// @param mode The mode to open the file in.
+        /// @return The file stream, or nullptr if the file could not be opened.
+        virtual std::unique_ptr<memory::Stream> open(File::Handle file, File::OpenMode mode) = 0;
+    };
+} // namespace cubos::data
+
+#endif // CUBOS_DATA_ARCHIVE_HPP

--- a/core/include/cubos/data/file.hpp
+++ b/core/include/cubos/data/file.hpp
@@ -1,0 +1,173 @@
+#ifndef CUBOS_DATA_FILE_HPP
+#define CUBOS_DATA_FILE_HPP
+
+#include <cubos/memory/stream.hpp>
+
+#include <string_view>
+#include <memory>
+#include <mutex>
+
+namespace cubos::data
+{
+    class Archive;
+    class FileSystem;
+
+    /// Represents a file in the virtual file system of the engine.
+    /// The virtual file system is a tree of files where you can mount archives.
+    /// Examples of possible archive types are a simple single file archive or a zipped archive.
+    /// Files which are not in an archive must be directories.
+    ///
+    /// Usage example:
+    ///     File::mount("/", ...);
+    ///     File::mount("/assets", ...);
+    ///     ...
+    ///     auto settingsStream = root->find("./settings.yaml")->open(File::OpenMode::Read);
+    ///     ...
+    ///     auto cubeStream = root->find("/assets/models/cube.obj")->open(File::OpenMode::Read);
+    ///
+    /// Paths must not have a trailing slash.
+    class File final : public std::enable_shared_from_this<File>
+    {
+    public:
+        /// Handle to a file. This is a smart shared pointer, so that the file won't be deleted while it is still in
+        /// use.
+        using Handle = std::shared_ptr<File>;
+
+        /// The possible modes to open files in.
+        enum class OpenMode
+        {
+            Read,  ///< Open the file for reading.
+            Write, ///< Open the file for writing.
+        };
+
+        ~File();
+
+        /// Mounts an archive to a path relative to this file in the virtual file system of the engine.
+        /// The directory which contains the path must exist, but the path itself must not (unless it is the root).
+        /// Archives can be mounted to the root path ("/") or to any other path.
+        ///
+        /// If the path isn't relative, or if the parent directory of the path doesn't exist, or if there's already an
+        /// archive mounted at the path, abort() is called.
+        /// @param path The path to mount the archive to.
+        /// @param archive The archive to mount.
+        void mount(std::string_view path, std::shared_ptr<Archive> archive);
+
+        /// Unmounts an archive from a path relative to this file in the virtual file system of the engine.
+        /// If no archive is mounted at the given path, nothing is done.
+        /// @param path The path to unmount the archive from.
+        void unmount(std::string_view path);
+
+        /// Searches for a file relative to this file in the virtual file system.
+        /// @param path The path to the file (relative to this file).
+        /// @return A handle to the file, or nullptr if the file does not exist or if the path is not relative.
+        Handle find(std::string_view path);
+
+        /// Creates a new file relative to this file in the virtual file system. The given path must be within a mounted
+        /// writable archive. If the file already exists, or if the path is absolute, or if the directory doesn't exist,
+        /// the function returns nullptr.
+        /// @param path The relative path to the file.
+        /// @param directory Whether the file is a directory.
+        /// @return A handle to the file, or nullptr if the creation failed.
+        Handle create(std::string_view path, bool directory = false);
+
+        /// Marks this file for destruction. The file will be deleted when no more references to it are held.
+        /// All children of this file will be marked for deletion as well.
+        /// If the archive where the file is is read-only, or if this function is called on a mount point, abort() is
+        /// called.
+        void destroy();
+
+        /// Opens this file for reading or writing.
+        /// If the archive where the file is is read-only, or if the file is a directory, nullptr is returned.
+        /// @param mode The mode to open the file in.
+        /// @return A handle to a file stream, or nullptr if the file could not be opened.
+        std::unique_ptr<memory::Stream> open(OpenMode mode);
+
+        /// Gets the name of this file.
+        std::string_view getName() const;
+
+        /// Gets the path of this file.
+        std::string_view getPath() const;
+
+        /// Checks if this file is a directory.
+        bool isDirectory() const;
+
+        /// Gets the archive this file is in.
+        /// @return The archive this file is in, or nullptr if the file is not in an archive.
+        std::shared_ptr<Archive> getArchive() const;
+
+        /// Gets the identifier of this file, used to identify the file in its archive.
+        /// @return The identifier of this file, or 0 if the file is not in an archive.
+        size_t getId() const;
+
+        /// Gets the parent directory of this file.
+        /// @return A handle to the parent directory, or nullptr if this file is the root file.
+        Handle getParent() const;
+
+        /// Gets the next sibling of this file.
+        /// @return A handle to the next sibling, or nullptr if this file is the last child of its parent.
+        Handle getSibling() const;
+
+        /// Gets the first child of this directory.
+        /// @return A handle to the first child, or nullptr if this file is not a directory or if it is empty.
+        Handle getChild() const;
+
+    private:
+        friend FileSystem;
+
+        /// @param parent The parent file handle.
+        /// @param name The name of the file.
+        File(Handle parent, std::string_view name);
+
+        /// @param parent The parent file handle.
+        /// @param archive The archive this file is in.
+        /// @param id The identifier of this file in its archive.
+        File(Handle parent, std::shared_ptr<Archive> archive, size_t id);
+
+        /// @param parent The parent file handle.
+        /// @param archive The archive mounted on this file.
+        /// @param name The name of this file.
+        File(Handle parent, std::shared_ptr<Archive> archive, std::string_view name);
+
+        /// Recursively generates an archive's files to the virtual file system.
+        /// Called after the archive has been mounted.
+        void generateArchive();
+
+        /// Recursively destroys the archive's files from the virtual file system.
+        /// Called after the archive is unmounted.
+        void destroyArchive();
+
+        /// Adds a child file to this file.
+        /// @param child The child file to add.
+        void addChild(File::Handle child);
+
+        /// Removes a child file from this file.
+        /// @param child The child file to remove.
+        void removeChild(File::Handle child);
+
+        /// Finds a child file in this file.
+        /// @param name The name of the child file to find.
+        /// @return A handle to the child file, or nullptr if the child file does not exist.
+        File::Handle findChild(std::string_view name) const;
+
+        /// Recursively destroys a file and its children from the virtual file system.
+        /// Called after the file is destroyed.
+        void destroyRecursive();
+
+        std::string path; ///< The path of this file.
+        std::string name; ///< The name of this file.
+        bool directory;   ///< Whether this file is a directory.
+
+        std::shared_ptr<Archive> archive; ///< The archive this file belongs to.
+        size_t id;                        ///< The id of this file in its archive.
+
+        Handle parent;  ///< The parent file handle.
+        Handle sibling; ///< The next sibling file handle.
+        Handle child;   ///< The first child file handle.
+
+        bool destroyed; ///< Whether this file has been marked for deletion.
+
+        std::mutex mutex; ///< The mutex used to synchronize changing properties of this file.
+    };
+} // namespace cubos::data
+
+#endif // CUBOS_DATA_FILE_HPP

--- a/core/include/cubos/data/file.hpp
+++ b/core/include/cubos/data/file.hpp
@@ -72,9 +72,8 @@ namespace cubos::data
 
         /// Marks this file for destruction. The file will be deleted when no more references to it are held.
         /// All children of this file will be marked for deletion as well.
-        /// If the archive where the file is is read-only, or if this function is called on a mount point, abort() is
-        /// called.
-        void destroy();
+        /// @return True if the file was marked for destroyed, false if it couldn't be destroyed.
+        bool destroy();
 
         /// Opens this file for reading or writing.
         /// If the archive where the file is is read-only, or if the file is a directory, nullptr is returned.

--- a/core/include/cubos/data/file_stream.hpp
+++ b/core/include/cubos/data/file_stream.hpp
@@ -1,0 +1,87 @@
+#ifndef CUBOS_DATA_FILE_STREAM_HPP
+#define CUBOS_DATA_FILE_STREAM_HPP
+
+#include <cubos/data/file.hpp>
+#include <cubos/memory/stream.hpp>
+#include <cubos/log.hpp>
+
+namespace cubos::data
+{
+    /// Represents a stream of data from/to a file.
+    /// Acts as a wrapper around a specific file stream, while maintaining a reference to the file so that it
+    /// can be destroyed automatically when the stream is destroyed.
+    /// @tparam T The type of internal stream in the stream.
+    template <typename T> class FileStream final : public memory::Stream
+    {
+    public:
+        /// @param file The file which the stream is reading/writing from/to.
+        /// @param mode The mode to open the file in.
+        /// @param stream The stream to read/write from/to.
+        FileStream(File::Handle file, File::OpenMode mode, T&& stream);
+        virtual ~FileStream() override = default;
+
+        virtual size_t read(void* buffer, size_t size) override;
+        virtual size_t write(const void* buffer, size_t size) override;
+        virtual size_t tell() const override;
+        virtual void seek(int64_t offset, memory::SeekOrigin origin) override;
+        virtual bool eof() const override;
+        virtual char peek() const override;
+
+    private:
+        File::Handle file;
+        File::OpenMode mode;
+        T stream;
+    };
+
+    // Implementation
+
+    template <typename T>
+    inline FileStream<T>::FileStream(File::Handle file, File::OpenMode mode, T&& stream)
+        : file(file), mode(mode), stream(std::move(stream))
+    {
+    }
+
+    template <typename T> inline size_t FileStream<T>::read(void* buffer, size_t size)
+    {
+        if (this->mode != File::OpenMode::Read)
+        {
+            logError("Attempted to read from a file stream opened for writing.");
+            abort();
+        }
+
+        return stream.read(buffer, size);
+    }
+
+    template <typename T> inline size_t FileStream<T>::write(const void* buffer, size_t size)
+    {
+        if (this->mode != File::OpenMode::Write)
+        {
+            logError("Attempted to write to a file stream opened for reading.");
+            abort();
+        }
+
+        return stream.write(buffer, size);
+    }
+
+    template <typename T> inline size_t FileStream<T>::tell() const
+    {
+        return stream.tell();
+    }
+
+    template <typename T> inline void FileStream<T>::seek(int64_t offset, memory::SeekOrigin origin)
+    {
+        stream.seek(offset, origin);
+    }
+
+    template <typename T> inline bool FileStream<T>::eof() const
+    {
+        return stream.eof();
+    }
+
+    template <typename T> inline char FileStream<T>::peek() const
+    {
+        return stream.peek();
+    }
+} // namespace cubos::data
+
+#endif // CUBOS_DATA_FILE_STREAM_HPP

--- a/core/include/cubos/data/file_system.hpp
+++ b/core/include/cubos/data/file_system.hpp
@@ -1,0 +1,77 @@
+#ifndef CUBOS_DATA_FILE_SYSTEM_HPP
+#define CUBOS_DATA_FILE_SYSTEM_HPP
+
+#include <cubos/data/file.hpp>
+
+namespace cubos::data
+{
+    /// Represents the virtual file system of the engine.
+    /// This class is never instantiated, and is only used to provide static methods.
+    ///
+    /// Example 1:
+    ///     FileSystem::mount("/assets", ...);
+    ///     ...
+    ///     auto modelsDir = FileSystem::find("/assets/models");
+    ///     if (modelsDir != nullptr && modelsDir->isDirectory())
+    ///         for (auto model = modelsDir->getChild(); model != nullptr; model = model->getSibling())
+    ///             loadModel(*model->open(File::OpenMode::Read));
+    ///     ...
+    ///     FileSystem::unmount("/assets");
+    ///
+    /// Example 2:
+    ///     FileSystem::mount("/settings.yaml", ...);
+    ///     ...
+    ///     auto settingsFile = FileSystem::root()->find("settings.yaml");
+    ///     if (settingsFile)
+    ///         loadSettings(*model->open(File::OpenMode::Read));
+    ///     ...
+    class FileSystem final
+    {
+    public:
+        FileSystem() = delete;
+        ~FileSystem() = delete;
+
+        /// Gets a handle to the root file.
+        static File::Handle root();
+
+        /// Mounts an archive to a path in the virtual file system of the engine.
+        /// The directory which contains the path must exist, but the path itself must not (unless it is the root).
+        /// Archives can be mounted to the root path ("/") or to any other path.
+        ///
+        /// If the path isn't absolute, or if the parent directory of the path doesn't exist, or if there's already an
+        /// archive mounted at the path, abort() is called.
+        /// @param path The path to mount the archive to.
+        /// @param archive The archive to mount.
+        static void mount(std::string_view path, std::shared_ptr<Archive> archive);
+
+        /// Unmounts an archive from a path in the virtual file system of the engine.
+        /// If no archive is mounted at the given path, nothing is done.
+        /// @param path The path to unmount the archive from.
+        static void unmount(std::string_view path);
+
+        /// Finds a file in the virtual file system, given its absolute path.
+        /// @param path The absolute path to the file.
+        /// @return A handle to the file, or nullptr if the file does not exist or the path is relative.
+        static File::Handle find(std::string_view path);
+
+        /// Creates a new file in the virtual file system.
+        /// @param path The absolute path to the file.
+        /// @param directory True if the file should be a directory, false otherwise.
+        /// @return A handle to the file, or nullptr if the file could not be created or the path is relative.
+        static File::Handle create(std::string_view path, bool directory = false);
+
+        /// Destroys a file in the virtual file system. If the file is a directory, all children of the directory are
+        /// destroyed as well.
+        /// @param path The absolute path of the file to destroy.
+        /// @return True if the file was marked for destruction, false otherwise.
+        static bool destroy(std::string_view path);
+
+        /// Opens a file in the virtual file system.
+        /// @param path The absolute path to the file.
+        /// @param mode The mode to open the file in.
+        /// @return A handle to the file stream, or nullptr if an error occurred.
+        static std::unique_ptr<memory::Stream> open(std::string_view path, File::OpenMode mode);
+    };
+} // namespace cubos::data
+
+#endif // CUBOS_DATA_FILE_SYSTEM_HPP

--- a/core/include/cubos/data/std_archive.hpp
+++ b/core/include/cubos/data/std_archive.hpp
@@ -1,0 +1,54 @@
+#ifndef CUBOS_DATA_STD_ARCHIVE_HPP
+#define CUBOS_DATA_STD_ARCHIVE_HPP
+
+#include <cubos/data/archive.hpp>
+
+#include <unordered_map>
+#include <filesystem>
+
+namespace cubos::data
+{
+    /// Archive implementation which represents a file/directory in the OS file system, implemented with the standard
+    /// library.
+    class STDArchive : public Archive
+    {
+    public:
+        /// @param osPath The path to the file/directory in the real file system.
+        /// @param isDirectory Whether the path is a directory or a file.
+        /// @param readOnly True if the archive is read-only, false otherwise.
+        STDArchive(const std::filesystem::path& osPath, bool isDirectory, bool readOnly);
+        virtual ~STDArchive() = default;
+
+    protected:
+        virtual size_t create(size_t parent, std::string_view name, bool directory = false) override;
+        virtual bool destroy(size_t id) override;
+        virtual std::string getName(size_t id) const override;
+        virtual bool isDirectory(size_t id) const override;
+        virtual bool isReadOnly() const override;
+        virtual size_t getParent(size_t id) const override;
+        virtual size_t getSibling(size_t id) const override;
+        virtual size_t getChild(size_t id) const override;
+        virtual std::unique_ptr<memory::Stream> open(File::Handle file, File::OpenMode mode) override;
+
+    private:
+        /// Information about a file in the directory.
+        struct FileInfo
+        {
+            std::filesystem::path osPath; ///< The path to the file in the real file system.
+            size_t parent;                ///< The identifier of the parent file.
+            size_t sibling;               ///< The identifier of the next sibling file.
+            size_t child;                 ///< The identifier of the first child file.
+            bool directory;               ///< True if the file is a directory, false otherwise.
+        };
+
+        /// Recursively adds all files in the directory to the archive.
+        void generate(size_t parent);
+
+        std::filesystem::path osPath;               ///< The path to the directory in the real file system.
+        bool readOnly;                              ///< True if the archive is read-only, false otherwise.
+        std::unordered_map<size_t, FileInfo> files; ///< Maps file identifiers to file info.
+        size_t nextId;                              ///< The next identifier to assign to a file.
+    };
+} // namespace cubos::data
+
+#endif // CUBOS_DATA_ARCHIVE_HPP

--- a/core/include/cubos/memory/buffer_stream.hpp
+++ b/core/include/cubos/memory/buffer_stream.hpp
@@ -16,6 +16,8 @@ namespace cubos::memory
         /// @param buffer The buffer to read/write from.
         /// @param size The size of the buffer.
         BufferStream(const void* buffer, size_t size);
+        
+        BufferStream(BufferStream&&);
 
         virtual size_t read(void* data, size_t size) override;
         virtual size_t write(const void* data, size_t size) override;
@@ -29,6 +31,7 @@ namespace cubos::memory
         size_t size;     ///< Size of the buffer.
         size_t position; ///< Current position in the buffer.
         bool readOnly;   ///< Whether the buffer is read-only.
+        bool reachedEof; ///< Whether the end of the buffer has been reached.
     };
 } // namespace cubos::memory
 

--- a/core/include/cubos/memory/std_stream.hpp
+++ b/core/include/cubos/memory/std_stream.hpp
@@ -14,6 +14,7 @@ namespace cubos::memory
         /// @param file Stdio file to read/write from.
         /// @param close Should the file be closed when this stream is destructed?
         StdStream(FILE* file, bool close = false);
+        StdStream(StdStream&&);
         virtual ~StdStream() override;
 
         virtual size_t read(void* data, size_t size) override;

--- a/core/include/cubos/memory/stream.hpp
+++ b/core/include/cubos/memory/stream.hpp
@@ -19,6 +19,9 @@ namespace cubos::memory
     class Stream
     {
     public:
+        Stream() = default;
+        Stream(Stream&&) = default;
+        Stream(const Stream&) = delete;
         virtual ~Stream() = default;
 
         static Stream& stdIn;  ///< Stream wrapper for stdin.

--- a/core/src/cubos/data/file.cpp
+++ b/core/src/cubos/data/file.cpp
@@ -1,0 +1,449 @@
+#include <cubos/data/file.hpp>
+#include <cubos/data/archive.hpp>
+#include <cubos/log.hpp>
+
+using namespace cubos;
+using namespace cubos::data;
+
+File::File(Handle parent, std::string_view name)
+{
+    this->name = name;
+    this->directory = true; // Files outside of archives are always directories.
+    this->archive = nullptr;
+    this->id = 0;
+    this->parent = parent;
+    this->destroyed = false;
+    if (this->parent)
+        this->path = this->parent->path + "/" + std::string(this->name);
+}
+
+File::File(Handle parent, std::shared_ptr<Archive> archive, size_t id)
+{
+    this->name = archive->getName(id);
+    this->directory = archive->isDirectory(id);
+    this->archive = archive;
+    this->id = id;
+    this->parent = parent;
+    this->destroyed = false;
+    if (this->parent)
+        this->path = this->parent->path + "/" + std::string(this->name);
+}
+
+File::File(Handle parent, std::shared_ptr<Archive> archive, std::string_view name)
+{
+    this->name = name;
+    this->directory = archive->isDirectory(1);
+    this->archive = archive;
+    this->id = 1;
+    this->parent = parent;
+    this->destroyed = false;
+    if (this->parent)
+        this->path = this->parent->path + "/" + std::string(this->name);
+}
+
+void File::mount(std::string_view path, std::shared_ptr<Archive> archive)
+{
+    // Remove trailing slashes.
+    while (path.ends_with('/'))
+        path.remove_suffix(1);
+
+    // Split path and find the parent directory.
+    auto i = path.find_last_of('/');
+    auto dir = this->find(i == std::string::npos ? "" : path.substr(0, i));
+    auto name = i == std::string::npos ? path : path.substr(i);
+
+    // Check if the directory exists.
+    if (!dir)
+    {
+        logError("Could not mount archive at path '{}' relative to '{}', the parent directory '{}' does not exist",
+                 path, this->path, path.substr(0, i));
+        abort();
+    }
+
+    // Lock mutex of the directory.
+    std::lock_guard<std::mutex> dir_lock(dir->mutex);
+
+    // Mount the archive in the directory itself (must be the root directory).
+    if (name.empty())
+    {
+        if (dir->parent != nullptr)
+        {
+            logError("Could not mount archive at path '{}', a file already exists at that path", dir->path);
+            abort();
+        }
+
+        if (dir->archive != nullptr)
+        {
+            logError("Could not mount archive at root, an archive has already been mounted at root");
+            abort();
+        }
+
+        if (!archive->isDirectory(1))
+        {
+            logError("Could not mount archive at root, archive must be a directory to be mounted at root");
+            abort();
+        }
+
+        dir->archive = archive;
+        dir->id = 1;
+        dir->generateArchive();
+    }
+    // Mount the archive as a child of 'dir'.
+    else
+    {
+        if (dir->findChild(name) != nullptr)
+        {
+            logError("Could not mount archive at path '{}', a file already exists at that path",
+                     dir->path + "/" + std::string(name));
+            abort();
+        }
+
+        // Add mount point to the directory.
+        auto file = std::shared_ptr<File>(new File(this->shared_from_this(), archive, name));
+        file->generateArchive();
+        file->sibling = dir->child;
+        dir->child = file;
+    }
+}
+
+void File::generateArchive()
+{
+    if (this->archive == nullptr || !this->directory)
+        return;
+
+    auto child = this->archive->getChild(this->id);
+    while (child != 0)
+    {
+        auto file = std::shared_ptr<File>(new File(this->shared_from_this(), this->archive, child));
+        file->sibling = this->child;
+        this->child = file;
+        file->generateArchive();
+        child = this->archive->getSibling(child);
+    }
+}
+
+void File::unmount(std::string_view path)
+{
+    // Find mount point.
+    auto mountPoint = this->find(path);
+    if (mountPoint == nullptr)
+    {
+        logError("Could not unmount archive at path '{}', no mount point exists at that path", path);
+        return;
+    }
+
+    // Lock the mount point mutex.
+    std::lock_guard<std::mutex> lock(mountPoint->mutex);
+
+    // Check if the file is a mount point.
+    if (mountPoint->archive == nullptr)
+    {
+        logError("Could not unmount archive at path '{}', no archive mounted on that path");
+        return;
+    }
+
+    // Check if the mount point is the root directory of an archive.
+    if (mountPoint->parent != nullptr && mountPoint->archive == mountPoint->parent->archive)
+    {
+        logError("Could not unmount archive at path '{}', the path must be the mount point (root) of an archive", path);
+        return;
+    }
+
+    // Recursively unmount all children.
+    while (mountPoint->child)
+    {
+        mountPoint->child->destroyArchive();
+        mountPoint->removeChild(mountPoint->child);
+    }
+
+    // Remove the mount point its parent directory.
+    if (mountPoint->parent != nullptr)
+    {
+        // Lock the parent directory mutex.
+        std::lock_guard<std::mutex> dir_lock(mountPoint->parent->mutex);
+        mountPoint->parent->removeChild(mountPoint);
+        mountPoint->parent = nullptr;
+    }
+
+    mountPoint->archive = nullptr;
+    mountPoint->id = 0;
+}
+
+void File::destroyArchive()
+{
+    // Lock the mutex of this file.
+    std::lock_guard<std::mutex> lock(this->mutex);
+
+    if (this->archive != this->parent->archive)
+    {
+        logError("Could not unmount archive, a file within the archive is mounted on a different archive, which "
+                 "must be unmounted first");
+        abort();
+    }
+
+    while (this->child)
+    {
+        this->child->destroyArchive();
+        this->removeChild(this->child);
+    }
+
+    this->parent = nullptr;
+    this->archive = nullptr;
+    this->id = 0;
+}
+
+File::Handle File::find(std::string_view path)
+{
+    if (path.starts_with("./"))
+        path.remove_prefix(2);
+
+    // If the path is empty, return this file.
+    if (path.empty())
+        return this->shared_from_this();
+
+    // If the path is absolute, or if this file isn't a directory, return nullptr.
+    else if (!path.empty() && path[0] == '/' || !this->directory)
+        return nullptr;
+
+    // Get name of the first component in the path.
+    size_t i = 0;
+    for (; i < path.size(); i++)
+        if (path[i] == '/')
+            break;
+    auto name = path.substr(0, i);
+
+    // Remove extra slashes.
+    for (; i < path.size(); i++)
+        if (path[i] != '/')
+            break;
+
+    // Lock the mutex of this file.
+    std::lock_guard<std::mutex> lock(this->mutex);
+
+    // Search for the first child with the given name.
+    auto child = this->findChild(name);
+    if (child)
+        return child->find(path.substr(i));
+    else
+        return nullptr;
+}
+
+File::Handle File::create(std::string_view path, bool directory)
+{
+    // Remove trailing slashes.
+    while (path.ends_with('/'))
+        path.remove_suffix(1);
+
+    // Split path and find the parent directory.
+    auto i = path.find_last_of('/');
+    auto dir = this->find(i == std::string::npos ? "" : path.substr(0, i));
+    auto name = i == std::string::npos ? path : path.substr(i);
+
+    // Check if the directory exists.
+    if (dir == nullptr)
+    {
+        logWarning("Could not create file at path '{}' relative to '{}', the parent directory '{}' does not exist",
+                   path, this->path, path.substr(0, i));
+        return nullptr;
+    }
+
+    // Lock the directory mutex.
+    std::lock_guard<std::mutex> dir_lock(dir->mutex);
+
+    // Check if the file already exists.
+    if (dir->findChild(name) != nullptr)
+    {
+        logWarning("Could not create file at path '{}', a file already exists at that path",
+                   dir->path + "/" + std::string(name));
+        return nullptr;
+    }
+
+    // Check if the directory is mounted on an archive.
+    if (dir->archive == nullptr)
+    {
+        logWarning("Could not create file at path '{}', parent directory must be mounted on an archive",
+                   dir->path + "/" + std::string(name));
+        return nullptr;
+    }
+
+    // Check if the archive is read-only.
+    if (dir->archive->isReadOnly())
+    {
+        logWarning("Could not create file at path '{}', parent directory is mounted on a read-only archive",
+                   dir->path + "/" + std::string(name));
+        return nullptr;
+    }
+
+    // Create the file.
+    size_t id = dir->archive->create(dir->id, name, directory);
+    if (id == 0)
+    {
+        logWarning("Could not create file at path '{}', internal archive error", dir->path + "/" + std::string(name));
+        return nullptr;
+    }
+
+    // Add the file to the parent directory.
+    auto file = std::shared_ptr<File>(new File(dir, dir->archive, id));
+    this->addChild(file);
+    return file;
+}
+
+void File::destroy()
+{
+    // Lock the file mutex.
+    std::lock_guard file_lock(this->mutex);
+
+    if (this->destroyed)
+        return;
+    this->destroyed = true;
+
+    if (this->archive == nullptr)
+    {
+        logError("Could not destroy file '{}', it is not mounted", this->path);
+        abort();
+    }
+    else if (this->archive->isReadOnly())
+    {
+        logError("Could not destroy file '{}', the archive it is mounted on is read-only", this->path);
+        abort();
+    }
+    else if (this->id == 1)
+    {
+        logError("Could not destroy file '{}', the file is the mount point of an archive", this->path);
+        abort();
+    }
+
+    // Lock the directory mutex and recursively destroy all children.
+    while (this->child)
+    {
+        this->child->destroyRecursive();
+        this->removeChild(this->child);
+    }
+
+    // Remove the file from the parent directory.
+    std::lock_guard dir_lock(this->parent->mutex);
+    this->parent->removeChild(this->shared_from_this());
+    this->parent = nullptr;
+}
+
+void File::destroyRecursive()
+{
+    // Lock the file mutex.
+    std::lock_guard file_lock(this->mutex);
+
+    if (this->destroyed)
+        return;
+
+    // Mark the file as destroyed.
+    this->destroyed = true;
+    this->parent = nullptr;
+
+    // Recursively destroy all children.
+    while (this->child)
+    {
+        this->child->destroyRecursive();
+        this->removeChild(this->child);
+    }
+}
+
+std::unique_ptr<memory::Stream> File::open(OpenMode mode)
+{
+    // Lock the file mutex.
+    std::lock_guard file_lock(this->mutex);
+
+    if (this->archive == nullptr)
+    {
+        logWarning("Could not open file '{}', it is not mounted", this->path);
+        return nullptr;
+    }
+    else if (this->archive->isReadOnly() && mode == OpenMode::Write)
+    {
+        logWarning("Could not open file '{}' for writing, the archive it is mounted on is read-only", this->path);
+        return nullptr;
+    }
+    else if (this->directory)
+    {
+        logWarning("Could not open file '{}', the file is a directory", this->path);
+        return nullptr;
+    }
+
+    // Open the file.
+    return this->archive->open(this->shared_from_this(), mode);
+}
+
+std::string_view File::getName() const
+{
+    return this->name;
+}
+
+std::string_view File::getPath() const
+{
+    return this->path;
+}
+
+bool File::isDirectory() const
+{
+    return this->directory;
+}
+
+std::shared_ptr<Archive> File::getArchive() const
+{
+    return this->archive;
+}
+
+size_t File::getId() const
+{
+    return this->id;
+}
+
+File::Handle File::getParent() const
+{
+    return this->parent;
+}
+
+File::Handle File::getSibling() const
+{
+    return this->sibling;
+}
+
+File::Handle File::getChild() const
+{
+    return this->child;
+}
+
+void File::addChild(File::Handle child)
+{
+    child->sibling = this->child;
+    this->child = child;
+}
+
+void File::removeChild(File::Handle child)
+{
+    if (this->child == child)
+        this->child = child->sibling;
+    else
+    {
+        auto prev = this->child;
+        while (prev->sibling != child)
+            prev = prev->sibling;
+        prev->sibling = child->sibling;
+    }
+}
+
+File::Handle File::findChild(std::string_view name) const
+{
+    for (auto child = this->child; child != nullptr; child = child->sibling)
+        if (child->name == name)
+            return child;
+    return nullptr;
+}
+
+File::~File()
+{
+    if (this->destroyed && this->archive)
+        if (!this->archive->destroy(this->id))
+        {
+            logError("Could not destroy file '{}', internal archive error", this->path);
+            abort();
+        }
+}

--- a/core/src/cubos/data/file_system.cpp
+++ b/core/src/cubos/data/file_system.cpp
@@ -1,0 +1,120 @@
+#include <cubos/data/file_system.hpp>
+#include <cubos/log.hpp>
+
+using namespace cubos;
+using namespace cubos::data;
+
+File::Handle FileSystem::root()
+{
+    static File::Handle root = File::Handle(new File(nullptr, ""));
+    return root;
+}
+
+void FileSystem::mount(std::string_view path, std::shared_ptr<Archive> archive)
+{
+    if (path.empty() || path[0] != '/')
+    {
+        logError("Could not mount archive at path '{}', the path must be absolute");
+        abort();
+    }
+
+    // Remove leading slashes.
+    while (path.starts_with('/'))
+        path.remove_prefix(1);
+
+    FileSystem::root()->mount(path, archive);
+}
+
+void FileSystem::unmount(std::string_view path)
+{
+    if (path.empty() || path[0] != '/')
+    {
+        logError("Could not unmount archive at path '{}', the path must be absolute");
+        return;
+    }
+
+    // Remove leading slashes.
+    while (path.starts_with('/'))
+        path.remove_prefix(1);
+
+    FileSystem::root()->unmount(path);
+}
+
+File::Handle FileSystem::find(std::string_view path)
+{
+    if (path.empty() || path[0] != '/')
+    {
+        logWarning("Could not find file at path '{}', the path must be absolute");
+        return nullptr;
+    }
+
+    // Remove leading slashes.
+    while (path.starts_with('/'))
+        path.remove_prefix(1);
+
+    return FileSystem::root()->find(path);
+}
+
+File::Handle FileSystem::create(std::string_view path, bool directory)
+{
+    if (path.empty() || path[0] != '/')
+    {
+        logWarning("Could not create file at path '{}', the path must be absolute");
+        return nullptr;
+    }
+
+    // Remove leading slashes.
+    while (path.starts_with('/'))
+        path.remove_prefix(1);
+
+    return FileSystem::root()->create(path, directory);
+}
+
+bool FileSystem::destroy(std::string_view path)
+{
+    if (path.empty() || path[0] != '/')
+    {
+        logWarning("Could not destroy file at path '{}', the path must be absolute");
+        return false;
+    }
+
+    // Remove leading slashes.
+    while (path.starts_with('/'))
+        path.remove_prefix(1);
+
+    // Find the file.
+    auto file = FileSystem::root()->find(path);
+    if (file)
+    {
+        file->destroy();
+        return true;
+    }
+    else
+    {
+        logWarning("Could not destroy file at path '{}', the file does not exist");
+        return false;
+    }
+}
+
+std::unique_ptr<memory::Stream> FileSystem::open(std::string_view path, File::OpenMode mode)
+{
+    if (path.empty() || path[0] != '/')
+    {
+        logWarning("Could not open file at path '{}', the path must be absolute");
+        return nullptr;
+    }
+
+    // Remove leading slashes.
+    while (path.starts_with('/'))
+        path.remove_prefix(1);
+
+    // Find the file.
+    auto file = FileSystem::root()->find(path);
+    if (file)
+        return file->open(mode);
+    else
+    {
+        logWarning("Could not open file at path '{}', the file does not exist");
+        return nullptr;
+    }
+}

--- a/core/src/cubos/data/file_system.cpp
+++ b/core/src/cubos/data/file_system.cpp
@@ -85,10 +85,7 @@ bool FileSystem::destroy(std::string_view path)
     // Find the file.
     auto file = FileSystem::root()->find(path);
     if (file)
-    {
-        file->destroy();
-        return true;
-    }
+        return file->destroy();
     else
     {
         logWarning("Could not destroy file at path '{}', the file does not exist");

--- a/core/src/cubos/data/std_archive.cpp
+++ b/core/src/cubos/data/std_archive.cpp
@@ -1,0 +1,247 @@
+#include <cubos/data/std_archive.hpp>
+#include <cubos/data/file_stream.hpp>
+#include <cubos/memory/std_stream.hpp>
+#include <cubos/log.hpp>
+
+using namespace cubos;
+using namespace cubos::data;
+
+STDArchive::STDArchive(const std::filesystem::path& osPath, bool isDirectory, bool readOnly)
+    : osPath(osPath), readOnly(readOnly)
+{
+    // Check if the file/directory exists.
+    if (!std::filesystem::exists(osPath))
+    {
+        if (readOnly)
+        {
+            logError("Couldn't create STDArchive: file/directory '{}' doesn't exist", osPath.c_str());
+            abort();
+        }
+        else
+        {
+            // Create the file/directory.
+            if (isDirectory)
+                std::filesystem::create_directory(osPath);
+            else
+            {
+                // Write an empty file.
+                FILE* file = fopen(osPath.c_str(), "w");
+                if (!file)
+                {
+                    logError("Couldn't create STDArchive: couldn't create root file '{}'", osPath.c_str());
+                    abort();
+                }
+                fclose(file);
+            }
+        }
+    }
+
+    // Check if it's a directory.
+    if (std::filesystem::is_directory(osPath))
+    {
+        if (!isDirectory)
+        {
+            logError("Couldn't create STDArchive: expected a file at '{}', found a directory", osPath.c_str());
+            abort();
+        }
+
+        // Add all children files to the archive.
+        this->files[1] = {osPath, 0, 0, 0, true};
+        this->nextId = 2;
+        this->generate(1);
+    }
+    else
+    {
+        if (isDirectory)
+        {
+            logError("Couldn't create STDArchive: expected a directory at '{}', found a file", osPath.c_str());
+            abort();
+        }
+
+        this->files[1] = {osPath, 0, 0, 0, false};
+    }
+}
+
+void STDArchive::generate(size_t parent)
+{
+    auto& parentInfo = this->files[parent];
+
+    // Iterate over all files in the directory.
+    for (auto& entry : std::filesystem::directory_iterator(parentInfo.osPath))
+    {
+        // Get the path to the file.
+        auto osPath = entry.path();
+
+        // Add the file to the tree.
+        auto directory = std::filesystem::is_directory(osPath);
+        size_t id = this->nextId++;
+        this->files[id] = {osPath, parent, parentInfo.child, 0, directory};
+        parentInfo.child = id;
+
+        // Recursively add all files in the directory.
+        if (directory)
+            this->generate(id);
+    }
+}
+
+size_t STDArchive::create(size_t parent, std::string_view name, bool directory)
+{
+    // Make sure that the archive isn't read-only and the parent is a directory.
+    if (this->readOnly || parent == 0 || !this->isDirectory(parent))
+        return 0;
+
+    // Create the file/directory in the OS file system.
+    auto& parentInfo = this->files.at(parent);
+    auto osPath = parentInfo.osPath / name;
+    if (directory)
+    {
+        if (!std::filesystem::create_directory(osPath))
+            return false;
+    }
+    else
+    {
+        // Write an empty file.
+        FILE* file = fopen(osPath.c_str(), "w");
+        if (!file)
+            return false;
+        fclose(file);
+    }
+
+    // Add the file to the tree.
+    size_t id = this->nextId++;
+    this->files[id] = {osPath, parent, parentInfo.child, 0, directory};
+    parentInfo.child = id;
+    return id;
+}
+
+bool STDArchive::destroy(size_t id)
+{
+    // Make sure the file isn't read only, that the file exist and that it's not the root.
+    if (this->readOnly || this->files.count(id) == 0 || id == 1)
+        return false;
+
+    // Make sure the file isn't a non-empty directory.
+    const auto& info = this->files.at(id);
+    if (info.directory && info.child != 0)
+        return false;
+
+    // Remove the file from the real file system.
+    if (!std::filesystem::remove(info.osPath))
+        return false;
+
+    // Remove the file from the tree.
+    auto& parentInfo = this->files.at(info.parent);
+    if (parentInfo.child == id)
+        parentInfo.child = info.sibling;
+    else
+    {
+        size_t sibling = parentInfo.child;
+        while (sibling != 0)
+        {
+            auto siblingSibling = this->files.at(sibling).sibling;
+            if (siblingSibling == id)
+            {
+                this->files.at(sibling).sibling = info.sibling;
+                break;
+            }
+            sibling = siblingSibling;
+        }
+    }
+    this->files.erase(id);
+    return true;
+}
+
+std::string STDArchive::getName(size_t id) const
+{
+    auto it = this->files.find(id);
+    if (it == this->files.end())
+    {
+        logError("STDArchive: Couldn't get name of file, file doesn't exist");
+        abort();
+    }
+
+    return it->second.osPath.filename().string();
+}
+
+bool STDArchive::isDirectory(size_t id) const
+{
+    auto it = this->files.find(id);
+    if (it == this->files.end())
+    {
+        logError("STDArchive: Couldn't check if file is directory, file doesn't exist");
+        abort();
+    }
+
+    return it->second.directory;
+}
+
+bool STDArchive::isReadOnly() const
+{
+    return this->readOnly;
+}
+
+size_t STDArchive::getParent(size_t id) const
+{
+    auto it = this->files.find(id);
+    if (it == this->files.end())
+    {
+        logError("STDArchive: Couldn't get parent of file, file doesn't exist");
+        abort();
+    }
+
+    return it->second.parent;
+}
+
+size_t STDArchive::getSibling(size_t id) const
+{
+    auto it = this->files.find(id);
+    if (it == this->files.end())
+    {
+        logError("STDArchive: Couldn't get sibling of file, file doesn't exist");
+        abort();
+    }
+
+    return it->second.sibling;
+}
+
+size_t STDArchive::getChild(size_t id) const
+{
+    auto it = this->files.find(id);
+    if (it == this->files.end())
+    {
+        logError("STDArchive: Couldn't get child of file, file doesn't exist");
+        abort();
+    }
+
+    return it->second.child;
+}
+
+std::unique_ptr<memory::Stream> STDArchive::open(File::Handle file, File::OpenMode mode)
+{
+    // Check if the archive is read-only.
+    if (this->readOnly && mode != File::OpenMode::Read)
+    {
+        logError("STDArchive: Couldn't open file for writing, archive is read-only");
+        abort();
+    }
+
+    // Check if the file exists.
+    auto it = this->files.find(file->getId());
+    if (it == this->files.end())
+    {
+        logError("STDArchive: Couldn't open file, file doesn't exist");
+        abort();
+    }
+
+    // Check if the file is a directory.
+    if (it->second.directory)
+    {
+        logError("STDArchive: Couldn't open file, file is a directory");
+        abort();
+    }
+
+    // Open the file.
+    const char* std_mode = mode == File::OpenMode::Write ? "wb" : "rb";
+    return std::make_unique<FileStream<memory::StdStream>>(
+        file, mode, std::move(memory::StdStream(fopen(it->second.osPath.c_str(), std_mode), true)));
+}

--- a/core/src/cubos/memory/std_stream.cpp
+++ b/core/src/cubos/memory/std_stream.cpp
@@ -8,6 +8,14 @@ StdStream::StdStream(FILE* file, bool close)
     this->close = close;
 }
 
+StdStream::StdStream(StdStream&& other)
+{
+    this->file = other.file;
+    this->close = other.close;
+    other.file = nullptr;
+    other.close = false;
+}
+
 StdStream::~StdStream()
 {
     if (this->close)

--- a/core/src/cubos/memory/stream.cpp
+++ b/core/src/cubos/memory/stream.cpp
@@ -21,7 +21,7 @@ Stream& Stream::stdErr = stdErrI;
 
 char Stream::get()
 {
-    char c;
+    char c = '\0';
     this->read(&c, sizeof(c));
     return c;
 }
@@ -456,10 +456,8 @@ void Stream::readUntil(std::string& str, const char* terminator)
     size_t terminatorI = 0;
     char c;
 
-    while (!this->eof() && this->peek() != '\0')
+    for (char c = this->get(); !this->eof() && c != '\0'; c = this->get())
     {
-        c = this->get();
-
         if (c == terminator[terminatorI])
         {
             ++terminatorI;
@@ -484,10 +482,8 @@ size_t Stream::readUntil(char* buffer, size_t size, const char* terminator)
     size_t terminatorI = 0, position = 0;
     char c;
 
-    while (!this->eof() && this->peek() != '\0' && position < size)
+    for (char c = this->get(); !this->eof() && c != '\0' && position < size; c = this->get())
     {
-        c = this->get();
-
         if (c == terminator[terminatorI])
         {
             ++terminatorI;

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CUBOS_TESTS_SOURCE
     "test_yaml_serialization.cpp"
     "test_yaml_deserialization.cpp"
     "test_yaml_serialization_and_deserialization.cpp"
+    "test_std_archive.cpp"
 )
 
 # Add tests target

--- a/core/tests/test_std_archive.cpp
+++ b/core/tests/test_std_archive.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <cubos/data/file_system.hpp>
+#include <cubos/data/std_archive.hpp>
+
+#include <fstream>
+#include <filesystem>
+
+using namespace cubos::data;
+
+TEST(Cubos_Std_Archive_Tests, Read_Directory)
+{
+    using namespace cubos::data;
+
+    // Create a temporary directory.
+    std::filesystem::path tempDir = std::filesystem::temp_directory_path() / "cubos_std_archive_tests";
+    std::filesystem::remove_all(tempDir);
+    std::filesystem::create_directory(tempDir);
+
+    // Create a file in the directory.
+    std::filesystem::path filePath = tempDir / "file.txt";
+    std::ofstream file(filePath);
+    file << "Hello world!";
+    file.close();
+
+    // Create a directory in the directory.
+    std::filesystem::path dirPath = tempDir / "dir";
+    std::filesystem::create_directory(dirPath);
+
+    // Mount the temporary directory as a STDArchive.
+    FileSystem::mount("///tmp//", std::make_shared<STDArchive>(tempDir, true, false));
+
+    // Find the file.
+    File::Handle fileHandle = FileSystem::find("///tmp//file.txt");
+    ASSERT_NE(fileHandle, nullptr);
+    ASSERT_EQ(fileHandle->getPath(), "/tmp/file.txt");
+
+    // Find the directory.
+    File::Handle dirHandle = FileSystem::find("///tmp//dir");
+    ASSERT_NE(dirHandle, nullptr);
+    ASSERT_EQ(dirHandle->getPath(), "/tmp/dir");
+
+    // Create another file in the directory.
+    File::Handle file2Handle = dirHandle->create("file2.txt");
+    ASSERT_NE(file2Handle, nullptr);
+    ASSERT_EQ(file2Handle->getPath(), "/tmp/dir/file2.txt");
+
+    // Write some data to the file.
+    {
+        auto stream = file2Handle->open(File::OpenMode::Write);
+        ASSERT_NE(stream, nullptr);
+        stream->print("Hello file2!");
+    }
+
+    // Read from the file.
+    {
+        auto stream = fileHandle->open(File::OpenMode::Read);
+        ASSERT_NE(stream, nullptr);
+        std::string content;
+        stream->readUntil(content, nullptr);
+        ASSERT_EQ(content, "Hello world!");
+    }
+
+    // Unmount the archive.
+    FileSystem::unmount("///tmp//");
+
+    // Check data in file2.txt
+    {
+        std::ifstream file(dirPath / "file2.txt");
+        std::string content;
+        std::getline(file, content);
+        ASSERT_EQ(content, "Hello file2!");
+    }
+}


### PR DESCRIPTION
Closes #16.

- adds the `File` class, which represents a `File` in the virtual file system.
- adds the generic `Archive` class, which acts as a mount point from the real file system to the virtual one.
- implements the `STDArchive` class, which is an archive used to mount OS directories or files.
- adds the `FileSystem` class, used as a utility to manage the entire virtual file system.
- added a test for `STDArchive`.

Compressed archives will be left for future implementation since they're not a priority right now. Check #81 