### PR TITLE
Various Fixes in RenderDevice

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/io/sources/double_axis.cpp"
 
     "src/cubos/gl/debug.cpp"
-    
+    "src/cubos/gl/render_device.cpp"
     "src/cubos/gl/ogl_render_device.hpp"
     "src/cubos/gl/ogl_render_device.cpp"
     "src/cubos/gl/material.cpp"

--- a/core/include/cubos/gl/render_device.hpp
+++ b/core/include/cubos/gl/render_device.hpp
@@ -515,6 +515,14 @@ namespace cubos::gl
         /// @return Constant buffer handle, or nullptr if the creation failed.
         virtual ConstantBuffer createConstantBuffer(size_t size, const void* data, Usage usage) = 0;
 
+        /// Creates a new constant buffer.
+        /// @param size Size in bytes.
+        /// @param data Initial data, can be nullptr.
+        /// @param usage The usage which the buffer will have.
+        /// @param storage The intended storage type for the buffer.
+        /// @return Constant buffer handle, or nullptr if the creation failed.
+        virtual ConstantBuffer createConstantBuffer(size_t size, const void* data, Usage usage, BufferStorageType storage) = 0;
+
         /// Creates a new index buffer.
         /// @param size Size in bytes.
         /// @param data Initial data, can be nullptr.

--- a/core/include/cubos/gl/render_device.hpp
+++ b/core/include/cubos/gl/render_device.hpp
@@ -2,6 +2,7 @@
 #define CUBOS_GL_RENDER_DEVICE_HPP
 
 #include <memory>
+#include <variant>
 #include <glm/glm.hpp>
 
 #define CUBOS_GL_MAX_FRAMEBUFFER_RENDER_TARGET_COUNT 8
@@ -240,26 +241,40 @@ namespace cubos::gl
         NegativeZ = 5,
     };
 
+    enum class BufferStorageType
+    {
+        Small,
+        Large,
+    };
+
     /// Framebuffer description.
     struct FramebufferDesc
     {
-        struct
+        struct CubeMapTarget
+        {
+            CubeMap handle; ///< Cube map handle.
+            CubeFace face;  ///< Cube map face which will be used as target.
+        };                  ///< If the target is a cube map, this handle is used.
+
+        struct Texture2DTarget
+        {
+            Texture2D handle; ///< Texture handle.
+        };                    ///< If the target isn't a cube map, this handle is used.
+
+        struct FramebufferTarget
         {
             bool isCubeMap = false; ///< Is this target a cube map face?
             uint32_t mipLevel = 0;  ///< Mip level of the texture which will be set as a render target.
 
-            union {
-                struct
-                {
-                    CubeMap handle; ///< Cube map handle.
-                    CubeFace face;  ///< Cube map face which will be used as target.
-                } cubeMap;          ///< If the target is a cube map, this handle is used.
+            std::variant<CubeMapTarget, Texture2DTarget> target;
 
-                struct
-                {
-                    Texture2D handle; ///< Texture handle.
-                } texture;            ///< If the target isn't a cube map, this handle is used.
-            };
+            [[nodiscard]] const CubeMapTarget& getCubeMapTarget() const;
+
+            [[nodiscard]] const Texture2DTarget& getTexture2DTarget() const;
+
+            void setCubeMapTarget(const CubeMap& handle, CubeFace face);
+
+            void setTexture2DTarget(const Texture2D& handle);
         } targets[CUBOS_GL_MAX_FRAMEBUFFER_RENDER_TARGET_COUNT]; ///< Render targets.
 
         uint32_t targetCount = 1; ///< Number of render targets.
@@ -352,45 +367,46 @@ namespace cubos::gl
     /// 1D texture description.
     struct Texture1DDesc
     {
-        const void* data[CUBOS_GL_MAX_MIP_LEVEL_COUNT]; ///< Optional initial texture data.
-        size_t mipLevelCount = 1;                       ///< Number of mip levels.
-        size_t width;                                   ///< Texture width.
-        Usage usage;                                    ///< Texture usage mode.
-        TextureFormat format;                           ///< Texture format.
+        const void* data[CUBOS_GL_MAX_MIP_LEVEL_COUNT] = {}; ///< Optional initial texture data.
+        size_t mipLevelCount = 1;                            ///< Number of mip levels.
+        size_t width;                                        ///< Texture width.
+        Usage usage;                                         ///< Texture usage mode.
+        TextureFormat format;                                ///< Texture format.
     };
 
     /// 2D texture description.
     struct Texture2DDesc
     {
-        const void* data[CUBOS_GL_MAX_MIP_LEVEL_COUNT]; ///< Optional initial texture data.
-        size_t mipLevelCount = 1;                       ///< Number of mip levels.
-        size_t width;                                   ///< Texture width.
-        size_t height;                                  ///< Texture height.
-        Usage usage;                                    ///< Texture usage mode.
-        TextureFormat format;                           ///< Texture format.
+        const void* data[CUBOS_GL_MAX_MIP_LEVEL_COUNT] = {}; ///< Optional initial texture data.
+        size_t mipLevelCount = 1;                            ///< Number of mip levels.
+        size_t width;                                        ///< Texture width.
+        size_t height;                                       ///< Texture height.
+        Usage usage;                                         ///< Texture usage mode.
+        TextureFormat format;                                ///< Texture format.
     };
 
     /// 3D texture description.
     struct Texture3DDesc
     {
-        const void* data[CUBOS_GL_MAX_MIP_LEVEL_COUNT]; ///< Optional initial texture data.
-        size_t mipLevelCount = 1;                       ///< Number of mip levels.
-        size_t width;                                   ///< Texture width.
-        size_t height;                                  ///< Texture height.
-        size_t depth;                                   ///< Texture depth.
-        Usage usage;                                    ///< Texture usage mode.
-        TextureFormat format;                           ///< Texture format.
+        const void* data[CUBOS_GL_MAX_MIP_LEVEL_COUNT] = {}; ///< Optional initial texture data.
+        size_t mipLevelCount = 1;                            ///< Number of mip levels.
+        size_t width;                                        ///< Texture width.
+        size_t height;                                       ///< Texture height.
+        size_t depth;                                        ///< Texture depth.
+        Usage usage;                                         ///< Texture usage mode.
+        TextureFormat format;                                ///< Texture format.
     };
 
     /// Cube map description.
     struct CubeMapDesc
     {
-        const void* data[6][CUBOS_GL_MAX_MIP_LEVEL_COUNT]; ///< Optional initial cube map data, indexed using CubeFace.
-        size_t mipLevelCount = 1;                          ///< Number of mip levels.
-        size_t width;                                      ///< Cube map face width.
-        size_t height;                                     ///< Cube map face height.
-        Usage usage;                                       ///< Texture usage mode.
-        TextureFormat format;                              ///< Texture format.
+        const void* data[6][CUBOS_GL_MAX_MIP_LEVEL_COUNT] = {
+            {}, {}, {}, {}, {}, {}}; ///< Optional initial cube map data, indexed using CubeFace.
+        size_t mipLevelCount = 1;    ///< Number of mip levels.
+        size_t width;                ///< Cube map face width.
+        size_t height;               ///< Cube map face height.
+        Usage usage;                 ///< Texture usage mode.
+        TextureFormat format;        ///< Texture format.
     };
 
     /// Constant buffer element.
@@ -539,6 +555,9 @@ namespace cubos::gl
 
         /// Clears the color buffer bit on the current framebuffer to a specific color.
         virtual void clearColor(float r, float g, float b, float a) = 0;
+
+        /// Clears the color buffer of a specific target on the current framebuffer to a specific color.
+        virtual void clearTargetColor(size_t target, float r, float g, float b, float a) = 0;
 
         /// Clears the depth buffer bit on the current framebuffer to a specific value.
         virtual void clearDepth(float depth) = 0;
@@ -725,6 +744,8 @@ namespace cubos::gl
 
             /// Unmaps the constant buffer, updating it with data written to the mapped region.
             virtual void unmap() = 0;
+            /// Get hint as to what underlying storage type is being used for the buffer.
+            virtual BufferStorageType getStorageTypeHint() = 0;
 
         protected:
             ConstantBuffer() = default;

--- a/core/src/cubos/gl/ogl_render_device.cpp
+++ b/core/src/cubos/gl/ogl_render_device.cpp
@@ -158,23 +158,23 @@ static bool textureFormatToGL(TextureFormat texFormat, GLenum& internalFormat, G
         break;
     case TextureFormat::Depth16:
         internalFormat = GL_DEPTH_COMPONENT16;
-        format = GL_DEPTH_COMPONENT16;
+        format = GL_DEPTH_COMPONENT;
         type = GL_FLOAT;
         break;
     case TextureFormat::Depth32:
         internalFormat = GL_DEPTH_COMPONENT32F;
-        format = GL_DEPTH_COMPONENT32F;
+        format = GL_DEPTH_COMPONENT;
         type = GL_FLOAT;
         break;
     case TextureFormat::Depth24Stencil8:
         internalFormat = GL_DEPTH24_STENCIL8;
-        format = GL_DEPTH24_STENCIL8;
-        type = GL_FLOAT;
+        format = GL_DEPTH_STENCIL;
+        type = GL_UNSIGNED_INT_24_8;
         break;
     case TextureFormat::Depth32Stencil8:
         internalFormat = GL_DEPTH32F_STENCIL8;
-        format = GL_DEPTH32F_STENCIL8;
-        type = GL_FLOAT;
+        format = GL_DEPTH_STENCIL;
+        type = GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
         break;
 
     default:
@@ -635,7 +635,7 @@ public:
 class OGLConstantBuffer : public impl::ConstantBuffer
 {
 public:
-    OGLConstantBuffer(GLuint id) : id(id)
+    OGLConstantBuffer(GLuint id, GLenum bufferType) : id(id), bufferType(bufferType)
     {
     }
 
@@ -646,16 +646,31 @@ public:
 
     virtual void* map() override
     {
-        glBindBuffer(GL_UNIFORM_BUFFER, this->id);
-        return glMapBuffer(GL_UNIFORM_BUFFER, GL_WRITE_ONLY);
+        glBindBuffer(bufferType, this->id);
+        return glMapBuffer(bufferType, GL_WRITE_ONLY);
     }
 
     virtual void unmap() override
     {
-        glUnmapBuffer(GL_UNIFORM_BUFFER);
+        glUnmapBuffer(bufferType);
+    }
+
+    virtual BufferStorageType getStorageTypeHint() override
+    {
+        switch (bufferType)
+        {
+        case GL_UNIFORM_BUFFER:
+            return BufferStorageType::Small;
+        case GL_SHADER_STORAGE_BUFFER:
+            return BufferStorageType::Large;
+        default:
+            logError("OGLContantBuffer::getStorageTypeHint() failed: Invalid bufferType value.");
+            abort();
+        }
     }
 
     GLuint id;
+    GLenum bufferType;
 };
 
 class OGLIndexBuffer : public impl::IndexBuffer
@@ -808,7 +823,8 @@ public:
     virtual void bind(ConstantBuffer cb) override
     {
         if (cb)
-            glBindBufferBase(GL_UNIFORM_BUFFER, this->loc, std::static_pointer_cast<OGLConstantBuffer>(cb)->id);
+            glBindBufferBase(std::static_pointer_cast<OGLConstantBuffer>(cb)->bufferType, this->loc,
+                             std::static_pointer_cast<OGLConstantBuffer>(cb)->id);
         else
             glBindBufferBase(GL_UNIFORM_BUFFER, this->loc, 0);
     }
@@ -888,6 +904,7 @@ public:
     OGLShaderPipeline(ShaderStage vs, ShaderStage ps, GLuint program) : vs(vs), ps(ps), program(program)
     {
         this->uboCount = 0;
+        this->ssboCount = 0;
     }
 
     virtual ~OGLShaderPipeline() override
@@ -931,6 +948,27 @@ public:
             return &bps.back();
         }
 
+        // Search for shader storage block binding
+        index = glGetProgramResourceIndex(this->program, GL_SHADER_STORAGE_BLOCK, name);
+        if (index != GL_INVALID_INDEX)
+        {
+            auto loc = this->ssboCount;
+            glShaderStorageBlockBinding(this->program, index, loc);
+
+            GLenum glErr = glGetError();
+            if (glErr != 0)
+            {
+                logError(
+                    "OGLShaderPipeline::getBindingPoint() failed: glShaderStorageBlockBinding caused OpenGL error {}",
+                    glErr);
+                return nullptr;
+            }
+
+            this->ssboCount += 1;
+            bps.emplace_back(name, loc);
+            return &bps.back();
+        }
+
         return nullptr;
     }
 
@@ -940,6 +978,7 @@ public:
 
 private:
     int uboCount;
+    int ssboCount;
 };
 
 OGLRenderDevice::OGLRenderDevice()
@@ -966,8 +1005,8 @@ Framebuffer OGLRenderDevice::createFramebuffer(const FramebufferDesc& desc)
     }
 
     for (int i = 0; i < desc.targetCount; ++i)
-        if (desc.targets[i].isCubeMap && desc.targets[i].cubeMap.handle == nullptr ||
-            !desc.targets[i].isCubeMap && desc.targets[i].texture.handle == nullptr)
+        if (desc.targets[i].isCubeMap && desc.targets[i].getCubeMapTarget().handle == nullptr ||
+            !desc.targets[i].isCubeMap && desc.targets[i].getTexture2DTarget().handle == nullptr)
         {
             logError("OGLRenderDevice::createFramebuffer() failed: target {} is nullptr", i);
             return nullptr;
@@ -978,28 +1017,35 @@ Framebuffer OGLRenderDevice::createFramebuffer(const FramebufferDesc& desc)
     glGenFramebuffers(1, &id);
     glBindFramebuffer(GL_FRAMEBUFFER, id);
 
+    std::vector<GLenum> drawBuffers;
+
     // Attach targets
     for (int i = 0; i < desc.targetCount; ++i)
+    {
         if (desc.targets[i].isCubeMap)
         {
             GLenum face;
-            cubeFaceToGL(desc.targets[i].cubeMap.face, face);
-            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + 1, face,
-                                   std::static_pointer_cast<OGLTexture2D>(desc.targets[i].texture.handle)->id, 0);
+            cubeFaceToGL(desc.targets[i].getCubeMapTarget().face, face);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, face,
+                                   std::static_pointer_cast<OGLCubeMap>(desc.targets[i].getCubeMapTarget().handle)->id,
+                                   0);
         }
         else
         {
-            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + 1, GL_TEXTURE_2D,
-                                   std::static_pointer_cast<OGLTexture2D>(desc.targets[i].texture.handle)->id, 0);
+            glFramebufferTexture2D(
+                GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D,
+                std::static_pointer_cast<OGLTexture2D>(desc.targets[i].getTexture2DTarget().handle)->id, 0);
         }
+        drawBuffers.push_back(GL_COLOR_ATTACHMENT0 + i);
+    }
 
     // Attach depth stencil texture
     if (desc.depthStencil)
     {
         auto ds = std::static_pointer_cast<OGLTexture2D>(desc.depthStencil);
-        if (ds->format == GL_DEPTH_COMPONENT16 || ds->format == GL_DEPTH_COMPONENT32F)
+        if (ds->format == GL_DEPTH_COMPONENT)
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, ds->id, 0);
-        else if (ds->format == GL_DEPTH24_STENCIL8 || ds->format == GL_DEPTH32F_STENCIL8)
+        else if (ds->format == GL_DEPTH_STENCIL)
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, ds->id, 0);
         else
         {
@@ -1008,6 +1054,9 @@ Framebuffer OGLRenderDevice::createFramebuffer(const FramebufferDesc& desc)
             return nullptr;
         }
     }
+
+    // Define draw buffers
+    glDrawBuffers(drawBuffers.size(), &drawBuffers[0]);
 
     // Check errors
     GLenum glErr = glGetError();
@@ -1407,11 +1456,20 @@ ConstantBuffer OGLRenderDevice::createConstantBuffer(size_t size, const void* da
     else
         abort(); // Invalid enum value
 
+    // Choose SSBO or UBO depending on given buffer size
+    GLint maxUniformBufferSize;
+    glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &maxUniformBufferSize);
+    GLenum bufferType;
+    if (size > maxUniformBufferSize)
+        bufferType = GL_SHADER_STORAGE_BUFFER;
+    else
+        bufferType = GL_UNIFORM_BUFFER;
+
     // Initialize buffer
     GLuint id;
     glGenBuffers(1, &id);
-    glBindBuffer(GL_UNIFORM_BUFFER, id);
-    glBufferData(GL_UNIFORM_BUFFER, size, data, glUsage);
+    glBindBuffer(bufferType, id);
+    glBufferData(bufferType, size, data, glUsage);
 
     // Check errors
     GLenum glErr = glGetError();
@@ -1422,7 +1480,7 @@ ConstantBuffer OGLRenderDevice::createConstantBuffer(size_t size, const void* da
         return nullptr;
     }
 
-    return std::make_shared<OGLConstantBuffer>(id);
+    return std::make_shared<OGLConstantBuffer>(id, bufferType);
 }
 
 IndexBuffer OGLRenderDevice::createIndexBuffer(size_t size, const void* data, IndexFormat format, Usage usage)
@@ -1716,6 +1774,12 @@ void OGLRenderDevice::clearColor(float r, float g, float b, float a)
 {
     glClearColor(r, g, b, a);
     glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void OGLRenderDevice::clearTargetColor(size_t target, float r, float g, float b, float a)
+{
+    float color[] = {r, g, b, a};
+    glClearBufferfv(GL_COLOR, target, color);
 }
 
 void OGLRenderDevice::clearDepth(float depth)

--- a/core/src/cubos/gl/ogl_render_device.cpp
+++ b/core/src/cubos/gl/ogl_render_device.cpp
@@ -1028,13 +1028,14 @@ Framebuffer OGLRenderDevice::createFramebuffer(const FramebufferDesc& desc)
             cubeFaceToGL(desc.targets[i].getCubeMapTarget().face, face);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, face,
                                    std::static_pointer_cast<OGLCubeMap>(desc.targets[i].getCubeMapTarget().handle)->id,
-                                   0);
+                                   desc.targets[i].mipLevel);
         }
         else
         {
             glFramebufferTexture2D(
                 GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D,
-                std::static_pointer_cast<OGLTexture2D>(desc.targets[i].getTexture2DTarget().handle)->id, 0);
+                std::static_pointer_cast<OGLTexture2D>(desc.targets[i].getTexture2DTarget().handle)->id,
+                desc.targets[i].mipLevel);
         }
         drawBuffers.push_back(GL_COLOR_ATTACHMENT0 + i);
     }

--- a/core/src/cubos/gl/ogl_render_device.cpp
+++ b/core/src/cubos/gl/ogl_render_device.cpp
@@ -1443,6 +1443,20 @@ CubeMap OGLRenderDevice::createCubeMap(const CubeMapDesc& desc)
 
 ConstantBuffer OGLRenderDevice::createConstantBuffer(size_t size, const void* data, Usage usage)
 {
+    // Choose SSBO or UBO depending on given buffer size
+    GLint maxUniformBufferSize;
+    glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &maxUniformBufferSize);
+    BufferStorageType storage;
+    if (size > maxUniformBufferSize)
+        storage = BufferStorageType::Large;
+    else
+        storage = BufferStorageType::Small;
+    return createConstantBuffer(size, data, usage, storage);
+}
+
+ConstantBuffer OGLRenderDevice::createConstantBuffer(size_t size, const void* data, Usage usage,
+                                                     BufferStorageType storage)
+{
     // Validate arguments
     if (usage == Usage::Static && data == nullptr)
         abort();
@@ -1457,14 +1471,11 @@ ConstantBuffer OGLRenderDevice::createConstantBuffer(size_t size, const void* da
     else
         abort(); // Invalid enum value
 
-    // Choose SSBO or UBO depending on given buffer size
-    GLint maxUniformBufferSize;
-    glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &maxUniformBufferSize);
     GLenum bufferType;
-    if (size > maxUniformBufferSize)
-        bufferType = GL_SHADER_STORAGE_BUFFER;
-    else
+    if (storage == BufferStorageType::Small)
         bufferType = GL_UNIFORM_BUFFER;
+    else
+        bufferType = GL_SHADER_STORAGE_BUFFER;
 
     // Initialize buffer
     GLuint id;

--- a/core/src/cubos/gl/ogl_render_device.hpp
+++ b/core/src/cubos/gl/ogl_render_device.hpp
@@ -35,6 +35,7 @@ namespace cubos::gl
         virtual ShaderPipeline createShaderPipeline(ShaderStage vs, ShaderStage ps) override;
         virtual void setShaderPipeline(ShaderPipeline pipeline) override;
         virtual void clearColor(float r, float g, float b, float a) override;
+        virtual void clearTargetColor(size_t target, float r, float g, float b, float a) override;
         virtual void clearDepth(float depth) override;
         virtual void clearStencil(int stencil) override;
         virtual void drawTriangles(size_t offset, size_t count) override;

--- a/core/src/cubos/gl/ogl_render_device.hpp
+++ b/core/src/cubos/gl/ogl_render_device.hpp
@@ -26,6 +26,8 @@ namespace cubos::gl
         virtual Texture3D createTexture3D(const Texture3DDesc& desc) override;
         virtual CubeMap createCubeMap(const CubeMapDesc& desc) override;
         virtual ConstantBuffer createConstantBuffer(size_t size, const void* data, Usage usage) override;
+        virtual ConstantBuffer createConstantBuffer(size_t size, const void* data, Usage usage,
+                                                    BufferStorageType storage) override;
         virtual IndexBuffer createIndexBuffer(size_t size, const void* data, IndexFormat format, Usage usage) override;
         virtual void setIndexBuffer(IndexBuffer ib) override;
         virtual VertexBuffer createVertexBuffer(size_t size, const void* data, Usage usage) override;

--- a/core/src/cubos/gl/render_device.cpp
+++ b/core/src/cubos/gl/render_device.cpp
@@ -1,0 +1,24 @@
+#include <cubos/gl/render_device.hpp>
+
+using namespace cubos::gl;
+
+const FramebufferDesc::CubeMapTarget& FramebufferDesc::FramebufferTarget::getCubeMapTarget() const
+{
+    return std::get<CubeMapTarget>(target);
+}
+
+const FramebufferDesc::Texture2DTarget& FramebufferDesc::FramebufferTarget::getTexture2DTarget() const
+{
+    return std::get<Texture2DTarget>(target);
+}
+
+void FramebufferDesc::FramebufferTarget::setCubeMapTarget(const CubeMap& handle, CubeFace face)
+{
+    isCubeMap = true;
+    target = CubeMapTarget{handle, face};
+}
+void FramebufferDesc::FramebufferTarget::setTexture2DTarget(const Texture2D& handle)
+{
+    isCubeMap = false;
+    target = Texture2DTarget{handle};
+}


### PR DESCRIPTION
- Wrong GLenum equivalents fixed
- Use std::variant instead of union in framebuffer targets
- Use set*Target methods in framebuffer targets instead of setting values directly.