### PR TITLE
Add debug serializer with fmt integration

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CUBOS_CORE_SOURCE
 
     "src/cubos/core/data/serializer.cpp"
     "src/cubos/core/data/deserializer.cpp"
+    "src/cubos/core/data/debug_serializer.cpp"
     "src/cubos/core/data/yaml_serializer.cpp"
     "src/cubos/core/data/yaml_deserializer.cpp"
     "src/cubos/core/data/binary_serializer.cpp"
@@ -81,6 +82,7 @@ set(CUBOS_CORE_INCLUDE
 
     "include/cubos/core/data/serializer.hpp"
     "include/cubos/core/data/deserializer.hpp"
+    "include/cubos/core/data/debug_serializer.hpp"
     "include/cubos/core/data/yaml_serializer.hpp"
     "include/cubos/core/data/yaml_deserializer.hpp"
     "include/cubos/core/data/binary_serializer.hpp"
@@ -179,16 +181,17 @@ else ()
     find_package(googletest REQUIRED)
 endif ()
 
-if (SPDLOG_USE_SUBMODULE)
-    add_subdirectory(lib/spdlog)
-else ()
-    find_package(spdlog REQUIRED)
-endif ()
-
 if (FMT_USE_SUBMODULE)
     add_subdirectory(lib/fmt)
 else ()
     find_package(fmt REQUIRED)
+endif ()
+
+if (SPDLOG_USE_SUBMODULE)
+    add_subdirectory(lib/spdlog)
+else ()
+    set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
+    find_package(spdlog REQUIRED)
 endif ()
 
 add_library(imgui STATIC

--- a/core/include/cubos/core/data/debug_serializer.hpp
+++ b/core/include/cubos/core/data/debug_serializer.hpp
@@ -1,0 +1,69 @@
+#ifndef CUBOS_CORE_DATA_DEBUG_SERIALIZER_HPP
+#define CUBOS_CORE_DATA_DEBUG_SERIALIZER_HPP
+
+#include <cubos/core/data/serializer.hpp>
+
+#include <stack>
+
+namespace cubos::core::data
+{
+    /// Implementation of the abstract Serializer class for debugging purposes.
+    /// This class is used internally by the logging functions.
+    class DebugSerializer : public Serializer
+    {
+    public:
+        /// @param stream The stream to serialize to.
+        /// @param pretty Whether to pretty-print the output.
+        /// @param typeNames Whether to print the type names.
+        DebugSerializer(memory::Stream& stream, bool pretty = false, bool typeNames = false);
+        virtual ~DebugSerializer() override = default;
+
+        // Implement interface methods.
+
+        virtual void writeI8(int8_t value, const char* name) override;
+        virtual void writeI16(int16_t value, const char* name) override;
+        virtual void writeI32(int32_t value, const char* name) override;
+        virtual void writeI64(int64_t value, const char* name) override;
+        virtual void writeU8(uint8_t value, const char* name) override;
+        virtual void writeU16(uint16_t value, const char* name) override;
+        virtual void writeU32(uint32_t value, const char* name) override;
+        virtual void writeU64(uint64_t value, const char* name) override;
+        virtual void writeF32(float value, const char* name) override;
+        virtual void writeF64(double value, const char* name) override;
+        virtual void writeBool(bool value, const char* name) override;
+        virtual void writeString(const char* value, const char* name) override;
+        virtual void beginObject(const char* name) override;
+        virtual void endObject() override;
+        virtual void beginArray(size_t length, const char* name) override;
+        virtual void endArray() override;
+        virtual void beginDictionary(size_t length, const char* name) override;
+        virtual void endDictionary() override;
+
+    private:
+        /// The possible state modes of serialization.
+        enum class Mode
+        {
+            Object,
+            Array,
+            Dictionary
+        };
+
+        /// Data of a serialization state.
+        struct State
+        {
+            Mode mode;    ///< The mode of the state.
+            bool isKey;   ///< Whether the next write is a key or a value (if we are in a dictionary).
+            bool isFirst; ///< Whether this is the first write in the state.
+        };
+
+        /// Prints spaces to indent the output.
+        void printIndent();
+
+        std::stack<State> state; ///< The current state of the serializer.
+        int indent;              ///< The current indentation level.
+        bool pretty;             ///< Whether to pretty-print the output.
+        bool typeNames;          ///< Whether to print the type names.
+    };
+} // namespace cubos::core::data
+
+#endif // CUBOS_CORE_DATA_DEBUG_SERIALIZER_HPP

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -119,6 +119,7 @@ namespace cubos::core
 template <typename T>
 requires(cubos::core::data::TriviallySerializable<T> && !std::is_pointer_v<T> && !std::is_array_v<T> &&
          !std::integral<T> && !std::floating_point<T> && !std::is_same_v<T, std::string>) struct fmt::formatter<T>
+    : formatter<string_view>
 {
     bool pretty = false; ///< Whether to pretty print the data.
     bool types = false;  ///< Whether to print the type name.
@@ -149,7 +150,7 @@ requires(cubos::core::data::TriviallySerializable<T> && !std::is_pointer_v<T> &&
         stream.put('\0');
         // Skip the '?: ' prefix.
         auto result = std::string(static_cast<const char*>(stream.getBuffer()) + 3);
-        return format_to(ctx.out(), "{}", result);
+        return formatter<string_view>::format(string_view(result), ctx);
     }
 };
 

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -1,6 +1,9 @@
 #ifndef CUBOS_CORE_LOG_HPP
 #define CUBOS_CORE_LOG_HPP
 
+#include <cubos/core/memory/buffer_stream.hpp>
+#include <cubos/core/data/debug_serializer.hpp>
+
 #include <spdlog/spdlog.h>
 
 namespace cubos::core
@@ -110,5 +113,43 @@ namespace cubos::core
         spdlog::critical(fmt, std::forward<Args>(args)...);
     }
 } // namespace cubos::core
+
+// Implement custom formatting for all trivially serializable types.
+
+template <typename T>
+requires(cubos::core::data::TriviallySerializable<T> && !std::is_pointer_v<T> && !std::is_array_v<T> &&
+         !std::integral<T> && !std::floating_point<T> && !std::is_same_v<T, std::string>) struct fmt::formatter<T>
+{
+    bool pretty = false; ///< Whether to pretty print the data.
+    bool types = false;  ///< Whether to print the type name.
+
+    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin())
+    {
+        auto it = ctx.begin(), end = ctx.end();
+        while (it != end)
+        {
+            if (*it == 'p')
+                this->pretty = true;
+            else if (*it == 't')
+                this->types = true;
+            else if (*it != '}')
+                throw format_error("invalid format");
+            else
+                break;
+            ++it;
+        }
+        return it;
+    }
+
+    template <typename FormatContext> auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out())
+    {
+        auto stream = cubos::core::memory::BufferStream(32);
+        cubos::core::data::DebugSerializer serializer(stream, this->pretty, this->types);
+        serializer.write(val, nullptr);
+        stream.put('\0');
+        // Skip the '?: ' prefix.
+        return format_to(ctx.out(), "{}", static_cast<const char*>(stream.getBuffer()) + 3);
+    }
+};
 
 #endif // CUBOS_CORE_LOG_HPP

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -148,7 +148,8 @@ requires(cubos::core::data::TriviallySerializable<T> && !std::is_pointer_v<T> &&
         serializer.write(val, nullptr);
         stream.put('\0');
         // Skip the '?: ' prefix.
-        return format_to(ctx.out(), "{}", static_cast<const char*>(stream.getBuffer()) + 3);
+        auto result = std::string(static_cast<const char*>(stream.getBuffer()) + 3);
+        return format_to(ctx.out(), "{}", result);
     }
 };
 

--- a/core/include/cubos/core/memory/buffer_stream.hpp
+++ b/core/include/cubos/core/memory/buffer_stream.hpp
@@ -37,7 +37,7 @@ namespace cubos::core::memory
         virtual void seek(int64_t offset, SeekOrigin origin) override;
         virtual bool eof() const override;
         virtual char peek() const override;
-        
+
     private:
         void* buffer;    ///< Pointer to the buffer being written to/read from.
         size_t size;     ///< Size of the buffer.

--- a/core/include/cubos/core/memory/buffer_stream.hpp
+++ b/core/include/cubos/core/memory/buffer_stream.hpp
@@ -26,13 +26,18 @@ namespace cubos::core::memory
         virtual ~BufferStream() override;
         BufferStream(BufferStream&&);
 
+        /// Gets the buffer of this stream.
+        const void* getBuffer() const;
+
+        // Method implementations.
+
         virtual size_t read(void* data, size_t size) override;
         virtual size_t write(const void* data, size_t size) override;
         virtual size_t tell() const override;
         virtual void seek(int64_t offset, SeekOrigin origin) override;
         virtual bool eof() const override;
         virtual char peek() const override;
-
+        
     private:
         void* buffer;    ///< Pointer to the buffer being written to/read from.
         size_t size;     ///< Size of the buffer.

--- a/core/include/cubos/core/memory/buffer_stream.hpp
+++ b/core/include/cubos/core/memory/buffer_stream.hpp
@@ -17,6 +17,13 @@ namespace cubos::core::memory
         /// @param size The size of the buffer.
         BufferStream(const void* buffer, size_t size);
 
+        /// Initializes a buffer stream with a new buffer, initially of the given size.
+        /// When initialized this way, the buffer stream will own the buffer and will delete it when it is destroyed.
+        /// It will expand the buffer when needed.
+        /// @param size The size of the buffer.
+        BufferStream(size_t size);
+
+        virtual ~BufferStream() override;
         BufferStream(BufferStream&&);
 
         virtual size_t read(void* data, size_t size) override;
@@ -32,6 +39,7 @@ namespace cubos::core::memory
         size_t position; ///< Current position in the buffer.
         bool readOnly;   ///< Whether the buffer is read-only.
         bool reachedEof; ///< Whether the end of the buffer has been reached.
+        bool owned;      ///< Whether the buffer is owned by this stream.
     };
 } // namespace cubos::core::memory
 

--- a/core/include/cubos/core/memory/stream.hpp
+++ b/core/include/cubos/core/memory/stream.hpp
@@ -125,6 +125,10 @@ namespace cubos::core::memory
         /// @param args The arguments to print.
         template <typename T, typename... TArgs> void printf(const char* fmt, T arg, TArgs... args);
 
+        /// Formatted print recursion tail function.
+        /// @param fmt The remainder format string.
+        void printf(const char* fmt);
+
         /// Parses a 8 bit signed integer from the stream.
         /// @param value Parsed value.
         /// @param base The base to use.
@@ -188,11 +192,6 @@ namespace cubos::core::memory
         /// Ignores a number of bytes from the stream.
         /// @param size The number of bytes to ignore.
         void ignore(size_t size);
-
-    private:
-        /// Formatted print recursion tail function.
-        /// @param fmt The remainder format string.
-        void printf(const char* fmt);
     };
 
     // Implementation

--- a/core/samples/CMakeLists.txt
+++ b/core/samples/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 # Set sample source files
 set(CORE_SAMPLES_SOURCES
+    "logging.cpp"
     "render_device.cpp"
     "render_device_compute.cpp"
     "debug_renderer.cpp"

--- a/core/samples/logging.cpp
+++ b/core/samples/logging.cpp
@@ -1,0 +1,24 @@
+#include <cubos/core/log.hpp>
+#include <cubos/core/memory/buffer_stream.hpp>
+#include <cubos/core/data/debug_serializer.hpp>
+
+using namespace cubos::core;
+
+int main(void)
+{
+    initializeLogger();
+
+    logTrace("Trace message");
+    logDebug("Debug message");
+    logInfo("Info message");
+    logWarning("Warning message");
+    logError("Error message");
+    logCritical("Critical message");
+
+    logInfo("Trivially serializable type: {}", glm::vec3(0.0f, 1.0f, 2.0f));
+    logInfo("Again, but with type information: {:t}", glm::vec3(0.0f, 1.0f, 2.0f));
+    logInfo("Since unordered maps are serializable, we can do this: {}",
+            std::unordered_map<int, const char*>{{1, "one"}, {2, "two"}});
+
+    return 0;
+}

--- a/core/src/cubos/core/data/debug_serializer.cpp
+++ b/core/src/cubos/core/data/debug_serializer.cpp
@@ -1,0 +1,180 @@
+#include <cubos/core/data/debug_serializer.hpp>
+
+using namespace cubos::core;
+using namespace cubos::core::data;
+
+DebugSerializer::DebugSerializer(memory::Stream& stream, bool pretty, bool typeNames) : Serializer(stream)
+{
+    this->indent = 0;
+    this->pretty = pretty;
+    this->typeNames = typeNames;
+    this->state.push(State{Mode::Object, false, true});
+}
+
+void DebugSerializer::printIndent()
+{
+    for (int i = 0; i < this->indent * 2; ++i)
+    {
+        this->stream.put(' ');
+    }
+}
+
+// Prints a generic value.
+#define GENERIC_WRITE(...)                                                                                             \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        /* Print the separator. */                                                                                     \
+        auto& state = this->state.top();                                                                               \
+        if (state.isFirst)                                                                                             \
+        {                                                                                                              \
+            state.isFirst = false;                                                                                     \
+            if (this->pretty)                                                                                          \
+            {                                                                                                          \
+                this->stream.put('\n');                                                                                \
+                this->printIndent();                                                                                   \
+            }                                                                                                          \
+        }                                                                                                              \
+        else if (state.mode == Mode::Dictionary && !state.isKey)                                                       \
+            this->stream.print(": ");                                                                                  \
+        else if (this->pretty)                                                                                         \
+        {                                                                                                              \
+            this->stream.print(",\n");                                                                                 \
+            this->printIndent();                                                                                       \
+        }                                                                                                              \
+        else                                                                                                           \
+            this->stream.print(", ");                                                                                  \
+                                                                                                                       \
+        /* Print the name of the value, if its an object. */                                                           \
+        if (state.mode == Mode::Object)                                                                                \
+            this->stream.printf("{}: ", name == nullptr ? "?" : name);                                                 \
+                                                                                                                       \
+        /* Print the value, with its type name, if enabled. */                                                         \
+        this->stream.printf(__VA_ARGS__);                                                                              \
+                                                                                                                       \
+        /* If it's a dictionary, flip the isKey flag. */                                                               \
+        if (state.mode == Mode::Dictionary)                                                                            \
+            state.isKey = !state.isKey;                                                                                \
+    } while (false)
+
+void DebugSerializer::writeI8(int8_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "i8" : "");
+}
+
+void DebugSerializer::writeI16(int16_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "i16" : "");
+}
+
+void DebugSerializer::writeI32(int32_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "i32" : "");
+}
+
+void DebugSerializer::writeI64(int64_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "i64" : "");
+}
+
+void DebugSerializer::writeU8(uint8_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "u8" : "");
+}
+
+void DebugSerializer::writeU16(uint16_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "u16" : "");
+}
+
+void DebugSerializer::writeU32(uint32_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "u32" : "");
+}
+
+void DebugSerializer::writeU64(uint64_t value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "u64" : "");
+}
+
+void DebugSerializer::writeF32(float value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "f32" : "");
+}
+
+void DebugSerializer::writeF64(double value, const char* name)
+{
+    GENERIC_WRITE("{}{}", value, this->typeNames ? "f64" : "");
+}
+
+void DebugSerializer::writeBool(bool value, const char* name)
+{
+    GENERIC_WRITE(value ? "true" : "false");
+}
+
+void DebugSerializer::writeString(const char* value, const char* name)
+{
+    GENERIC_WRITE("\"{}\"", value);
+}
+
+void DebugSerializer::beginObject(const char* name)
+{
+    GENERIC_WRITE("(");
+    this->state.push({Mode::Object, false, true});
+    this->indent++;
+}
+
+void DebugSerializer::endObject()
+{
+    this->indent--;
+    this->state.pop();
+    if (this->pretty)
+    {
+        this->stream.put('\n');
+        this->printIndent();
+    }
+    this->stream.put(')');
+}
+
+void DebugSerializer::beginArray(size_t length, const char* name)
+{
+    if (this->typeNames)
+        GENERIC_WRITE("{}x[", length);
+    else
+        GENERIC_WRITE("[");
+    this->state.push({Mode::Array, false, true});
+    this->indent++;
+}
+
+void DebugSerializer::endArray()
+{
+    this->indent--;
+    this->state.pop();
+    if (this->pretty)
+    {
+        this->stream.put('\n');
+        this->printIndent();
+    }
+    this->stream.put(']');
+}
+
+void DebugSerializer::beginDictionary(size_t length, const char* name)
+{
+    if (this->typeNames)
+        GENERIC_WRITE("{}x{", length);
+    else
+        GENERIC_WRITE("{");
+    this->state.push({Mode::Dictionary, true, true});
+    this->indent++;
+}
+
+void DebugSerializer::endDictionary()
+{
+    this->indent--;
+    this->state.pop();
+    if (this->pretty)
+    {
+        this->stream.put('\n');
+        this->printIndent();
+    }
+    this->stream.put('}');
+}

--- a/core/src/cubos/core/memory/buffer_stream.cpp
+++ b/core/src/cubos/core/memory/buffer_stream.cpp
@@ -11,6 +11,7 @@ BufferStream::BufferStream(void* buffer, size_t size, bool readOnly)
     this->position = 0;
     this->readOnly = readOnly;
     this->reachedEof = false;
+    this->owned = false;
 }
 
 BufferStream::BufferStream(const void* buffer, size_t size)
@@ -22,6 +23,30 @@ BufferStream::BufferStream(const void* buffer, size_t size)
     this->position = 0;
     this->readOnly = true;
     this->reachedEof = false;
+    this->owned = false;
+}
+
+BufferStream::BufferStream(size_t size)
+{
+    if (size == 0)
+    {
+        abort();
+    }
+
+    this->buffer = new char[size];
+    this->size = size;
+    this->position = 0;
+    this->readOnly = false;
+    this->reachedEof = false;
+    this->owned = true;
+}
+
+BufferStream::~BufferStream()
+{
+    if (this->owned)
+    {
+        delete[] static_cast<char*>(this->buffer);
+    }
 }
 
 BufferStream::BufferStream(BufferStream&& other)
@@ -31,11 +56,13 @@ BufferStream::BufferStream(BufferStream&& other)
     this->position = other.position;
     this->readOnly = other.readOnly;
     this->reachedEof = other.reachedEof;
+    this->owned = other.owned;
     other.buffer = nullptr;
     other.size = 0;
     other.position = 0;
     other.readOnly = true;
     other.reachedEof = true;
+    other.owned = false;
 }
 
 size_t BufferStream::read(void* data, size_t size)
@@ -59,8 +86,26 @@ size_t BufferStream::write(const void* data, size_t size)
     size_t bytesRemaining = this->size - this->position;
     if (size > bytesRemaining)
     {
-        size = bytesRemaining;
-        this->reachedEof = true;
+        if (this->owned)
+        {
+            // Expand the buffer.
+            size_t newSize = this->size * 2;
+            while (newSize < this->position + size)
+            {
+                newSize *= 2;
+            }
+
+            char* newBuffer = new char[newSize];
+            memcpy(newBuffer, static_cast<char*>(this->buffer), this->size);
+            delete[] static_cast<char*>(this->buffer);
+            this->buffer = newBuffer;
+            this->size = newSize;
+        }
+        else
+        {
+            size = bytesRemaining;
+            this->reachedEof = true;
+        }
     }
     memcpy(static_cast<char*>(this->buffer) + this->position, data, size);
     this->position += size;

--- a/core/src/cubos/core/memory/buffer_stream.cpp
+++ b/core/src/cubos/core/memory/buffer_stream.cpp
@@ -65,6 +65,11 @@ BufferStream::BufferStream(BufferStream&& other)
     other.owned = false;
 }
 
+const void* BufferStream::getBuffer() const
+{
+    return this->buffer;
+}
+
 size_t BufferStream::read(void* data, size_t size)
 {
     size_t bytesRemaining = this->size - this->position;

--- a/core/src/cubos/core/memory/stream.cpp
+++ b/core/src/cubos/core/memory/stream.cpp
@@ -85,7 +85,7 @@ void Stream::print(uint64_t value, size_t base)
 
 void Stream::print(float value, size_t decimalPlaces)
 {
-    this->print(static_cast<double>(value, decimalPlaces));
+    this->print(static_cast<double>(value), decimalPlaces);
 }
 
 void Stream::print(double value, size_t decimalPlaces)
@@ -96,6 +96,19 @@ void Stream::print(double value, size_t decimalPlaces)
     {
         this->put('-');
         value = -value;
+    }
+    else if (value == 0.0)
+    {
+        this->put('0');
+        if (decimalPlaces > 0)
+        {
+            this->put('.');
+            for (size_t i = 0; i < decimalPlaces; ++i)
+            {
+                this->put('0');
+            }
+        }
+        return;
     }
 
     // Validate input


### PR DESCRIPTION
Closes #173
Closes #140

- Add new DebugSerializer 
- Integrated this serializer with fmt so that it is used automatically when logging.
- Added a new logging sample to exemplify this usage.
- Made spdlog use the external fmt we were already using.