### PR TITLE
Implement window plugin

### DIFF
--- a/core/src/cubos/core/ecs/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/dispatcher.cpp
@@ -69,6 +69,11 @@ void Dispatcher::putStage(std::string stage, std::string referenceStage, Directi
     if (it != this->stagesOrder.end())
     {
         this->stagesOrder.erase(it);
+        // Erase invalidates next iterators, so refIt may need to be updated.
+        if(refIt > it)
+        {
+            refIt = std::find(this->stagesOrder.begin(), this->stagesOrder.end(), referenceStage);
+        }
     }
 
     if (referenceStage.empty() || direction == Direction::Before)

--- a/core/src/cubos/core/ecs/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/dispatcher.cpp
@@ -70,7 +70,7 @@ void Dispatcher::putStage(std::string stage, std::string referenceStage, Directi
     {
         this->stagesOrder.erase(it);
         // Erase invalidates next iterators, so refIt may need to be updated.
-        if(refIt > it)
+        if (refIt > it)
         {
             refIt = std::find(this->stagesOrder.begin(), this->stagesOrder.end(), referenceStage);
         }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -26,9 +26,11 @@ set(CUBOS_ENGINE_SOURCE
     "src/cubos/engine/data/meta.cpp"
     "src/cubos/engine/data/asset_manager.cpp"
     "src/cubos/engine/data/loader.cpp"
-    "src/cubos/engine/data/grid.cpp" 
-    "src/cubos/engine/data/palette.cpp" 
-    "src/cubos/engine/data/scene.cpp" 
+    "src/cubos/engine/data/grid.cpp"
+    "src/cubos/engine/data/palette.cpp"
+    "src/cubos/engine/data/scene.cpp"
+
+    "src/cubos/engine/plugins/window.cpp"
 )
 
 set(CUBOS_ENGINE_INCLUDE
@@ -57,6 +59,8 @@ set(CUBOS_ENGINE_INCLUDE
     "include/cubos/engine/data/palette.hpp"
     "include/cubos/engine/data/grid.hpp"
     "include/cubos/engine/data/scene.hpp"
+
+    "include/cubos/engine/plugins/window.hpp"
 )
 
 # Create cubos engine

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -57,6 +57,20 @@ namespace cubos::engine
         /// @param stage The stage in which the system should be executed.
         template <typename F> Cubos& addStartupSystem(F func, std::string stage);
 
+        /// Sets a given stage to happen after another stage.
+        /// The current stage must exist, but the reference stage may not, in which case it
+        /// will be created.
+        /// @param current The current stage, which will be placed right after the reference stage.
+        /// @param reference The reference stage.
+        Cubos& putStageAfter(const std::string& stage, const std::string& referenceStage);
+
+        /// Sets a given stage to happen before another stage.
+        /// The current stage must exist, but the reference stage may not, in which case it
+        /// will be created.
+        /// @param current The current stage, which will be placed right before the reference stage.
+        /// @param reference The reference stage.
+        Cubos& putStageBefore(const std::string& stage, const std::string& referenceStage);
+
         /// Runs the engine.
         void run();
 
@@ -64,6 +78,8 @@ namespace cubos::engine
         core::ecs::Dispatcher mainDispatcher, startupDispatcher;
         core::ecs::World world;
         std::set<void (*)(Cubos&)> plugins;
+
+        bool isStartupStage;
     };
 
     // Implementation.
@@ -83,12 +99,14 @@ namespace cubos::engine
     template <typename F> Cubos& Cubos::addSystem(F func, std::string stage)
     {
         mainDispatcher.addSystem(func, stage);
+        isStartupStage = false;
         return *this;
     }
 
     template <typename F> Cubos& Cubos::addStartupSystem(F func, std::string stage)
     {
         startupDispatcher.addSystem(func, stage);
+        isStartupStage = true;
         return *this;
     }
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/plugins/window.hpp
+++ b/engine/include/cubos/engine/plugins/window.hpp
@@ -9,7 +9,17 @@ using namespace cubos::engine;
 
 namespace cubos::engine::plugins
 {
+    /// Plugin to create and handle the lifecycle of a window. This is required
+    /// for showing any visual output to the user.
+    ///
+    /// Startup Stages:
+    /// - openWindow: Opens the window.
+    ///
+    /// Stages:
+    /// - poll: Polls the window for events and handles quit requests.
+    /// - swapBuffers: Swaps the window's back buffers.
+    /// @param cubos CUBOS. main class
     void windowPlugin(Cubos& cubos);
-};
+}; // namespace cubos::engine::plugins
 
 #endif // CUBOS_ENGINE_PLUGINS_WINDOW_HPP

--- a/engine/include/cubos/engine/plugins/window.hpp
+++ b/engine/include/cubos/engine/plugins/window.hpp
@@ -1,0 +1,15 @@
+#ifndef CUBOS_ENGINE_PLUGINS_WINDOW_HPP
+#define CUBOS_ENGINE_PLUGINS_WINDOW_HPP
+
+#include <cubos/core/io/window.hpp>
+
+#include <cubos/engine/cubos.hpp>
+
+using namespace cubos::engine;
+
+namespace cubos::engine::plugins
+{
+    void windowPlugin(Cubos& cubos);
+};
+
+#endif // CUBOS_ENGINE_PLUGINS_WINDOW_HPP

--- a/engine/samples/assets/scenes/main.cubos
+++ b/engine/samples/assets/scenes/main.cubos
@@ -5,11 +5,7 @@
   },
   "entities": {
     "main": {
-      "Num": 0,
-      "Grid": {
-        "handle": "car.grd",
-        "size": 1
-      }
+      "Num": 0
     },
     "sub1.root": {
       "Parent": "main"

--- a/engine/samples/scene.cpp
+++ b/engine/samples/scene.cpp
@@ -1,5 +1,3 @@
-#include <components/cubos/grid.hpp>
-
 #include <cubos/core/log.hpp>
 #include <cubos/core/data/file_system.hpp>
 #include <cubos/core/data/std_archive.hpp>

--- a/engine/samples/scene.cpp
+++ b/engine/samples/scene.cpp
@@ -1,3 +1,5 @@
+#include <components/cubos/grid.hpp>
+
 #include <cubos/core/log.hpp>
 #include <cubos/core/data/file_system.hpp>
 #include <cubos/core/data/std_archive.hpp>
@@ -11,6 +13,8 @@
 #include <cubos/engine/cubos.hpp>
 #include <cubos/engine/data/asset_manager.hpp>
 #include <cubos/engine/data/scene.hpp>
+
+#include <cubos/engine/plugins/window.hpp>
 
 using namespace cubos;
 using namespace engine;
@@ -104,5 +108,6 @@ int main(int argc, char** argv)
         .addStartupSystem(setup, "Setup")
         .addStartupSystem(printStuff, "End")
 
+        .addPlugin(cubos::engine::plugins::windowPlugin)
         .run();
 }

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -20,6 +20,32 @@ Cubos& Cubos::addPlugin(void (*func)(Cubos&))
     return *this;
 }
 
+Cubos& Cubos::putStageAfter(const std::string& stage, const std::string& referenceStage)
+{
+    if(isStartupStage)
+    {
+        startupDispatcher.putStageAfter(stage, referenceStage);
+    }
+    else
+    {
+        mainDispatcher.putStageAfter(stage, referenceStage);
+    }
+    return *this;
+}
+
+Cubos& Cubos::putStageBefore(const std::string& stage, const std::string& referenceStage)
+{
+    if(isStartupStage)
+    {
+        startupDispatcher.putStageBefore(stage, referenceStage);
+    }
+    else
+    {
+        mainDispatcher.putStageBefore(stage, referenceStage);
+    }
+    return *this;
+}
+
 Cubos::Cubos()
 {
     addResource<ShouldQuit>(true);

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -22,7 +22,7 @@ Cubos& Cubos::addPlugin(void (*func)(Cubos&))
 
 Cubos& Cubos::putStageAfter(const std::string& stage, const std::string& referenceStage)
 {
-    if(isStartupStage)
+    if (isStartupStage)
     {
         startupDispatcher.putStageAfter(stage, referenceStage);
     }
@@ -35,7 +35,7 @@ Cubos& Cubos::putStageAfter(const std::string& stage, const std::string& referen
 
 Cubos& Cubos::putStageBefore(const std::string& stage, const std::string& referenceStage)
 {
-    if(isStartupStage)
+    if (isStartupStage)
     {
         startupDispatcher.putStageBefore(stage, referenceStage);
     }

--- a/engine/src/cubos/engine/plugins/window.cpp
+++ b/engine/src/cubos/engine/plugins/window.cpp
@@ -1,0 +1,42 @@
+#include <cubos/engine/plugins/window.hpp>
+#include <cubos/core/settings.hpp>
+
+static void startup(cubos::core::io::Window& window, ShouldQuit& quit, cubos::core::Settings& settings)
+{
+    quit.value = false;
+    window = cubos::core::io::openWindow(
+        settings.getString("window.title", "Cubos"),
+        {
+            settings.getInteger("window.width", 800),
+            settings.getInteger("window.height", 600)
+        }
+    );
+}
+
+static void pollSystem(const cubos::core::io::Window& window, ShouldQuit& quit)
+{
+    window->pollEvents();
+    if(window->shouldClose())
+    {
+        quit.value = true;
+    }
+}
+
+static void swapBuffersSystem(const cubos::core::io::Window& window)
+{
+    window->swapBuffers();
+}
+
+void cubos::engine::plugins::windowPlugin(Cubos& cubos)
+{
+    cubos
+        .addResource<cubos::core::io::Window>()
+
+        .addStartupSystem(startup, "OpenWindow")
+
+        .addSystem(pollSystem, "Poll")
+        .putStageAfter("Main", "Poll")
+
+        .addSystem(swapBuffersSystem, "SwapBuffers")
+        .putStageBefore("Main", "SwapBuffers");
+}

--- a/engine/src/cubos/engine/plugins/window.cpp
+++ b/engine/src/cubos/engine/plugins/window.cpp
@@ -1,22 +1,18 @@
 #include <cubos/engine/plugins/window.hpp>
 #include <cubos/core/settings.hpp>
 
-static void startup(cubos::core::io::Window& window, ShouldQuit& quit, cubos::core::Settings& settings)
+static void startup(cubos::core::io::Window& window, ShouldQuit& quit, const cubos::core::Settings& settings)
 {
     quit.value = false;
     window = cubos::core::io::openWindow(
         settings.getString("window.title", "Cubos"),
-        {
-            settings.getInteger("window.width", 800),
-            settings.getInteger("window.height", 600)
-        }
-    );
+        {settings.getInteger("window.width", 800), settings.getInteger("window.height", 600)});
 }
 
 static void pollSystem(const cubos::core::io::Window& window, ShouldQuit& quit)
 {
     window->pollEvents();
-    if(window->shouldClose())
+    if (window->shouldClose())
     {
         quit.value = true;
     }
@@ -35,8 +31,5 @@ void cubos::engine::plugins::windowPlugin(Cubos& cubos)
         .addStartupSystem(startup, "OpenWindow")
 
         .addSystem(pollSystem, "Poll")
-        .putStageAfter("Main", "Poll")
-
-        .addSystem(swapBuffersSystem, "SwapBuffers")
-        .putStageBefore("Main", "SwapBuffers");
+        .addSystem(swapBuffersSystem, "SwapBuffers");
 }

--- a/tools/src/convert.cpp
+++ b/tools/src/convert.cpp
@@ -380,7 +380,7 @@ static bool convert(const Options& options)
 int runConvert(int argc, char** argv)
 {
     // Parse command line arguments.
-    Options options;
+    Options options = {};
     if (!parseArguments(argc, argv, options))
     {
         printHelp();

--- a/tools/src/embed.cpp
+++ b/tools/src/embed.cpp
@@ -353,7 +353,7 @@ static bool generate(const Options& options)
 int runEmbed(int argc, char** argv)
 {
     // Parse command line arguments.
-    Options options;
+    Options options = {};
     if (!parseArguments(argc, argv, options))
     {
         printHelp();

--- a/tools/src/generate.cpp
+++ b/tools/src/generate.cpp
@@ -817,7 +817,7 @@ static bool generate(const Options& options)
 int runGenerate(int argc, char** argv)
 {
     // Parse command line arguments.
-    Options options;
+    Options options = {};
     if (!parseArguments(argc, argv, options))
     {
         printHelp();


### PR DESCRIPTION
This implement our first core plugin, `windowPlugin`, which users should add if they want to show output to a window. With this, window generation, polling and swapping buffers is handled internally by the engine.

A few bugs had to be fixed too:
- The dispatcher had a bug when a given element was erased from the stages; this may invalidate the `refIt` iterator, causing a crash.
- Some `Options` objects were not initialized on `cubinhos`, causing crashes.

(Rebasing this was becoming ugly, so I had to make a temporary `cubos_class_window_copy` branch. Please only delete this after this is merged, just in case TM)