### PR TITLE
[WIP] Format function signatures and templates on different lines 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,5 +6,5 @@ IndentWidth: 4
 AccessModifierOffset: -4
 DerivePointerAlignment: false
 PointerAlignment: Left
-
+AlwaysBreakTemplateDeclarations: Yes
 ...

--- a/core/include/cubos/core/data/deserializer.hpp
+++ b/core/include/cubos/core/data/deserializer.hpp
@@ -285,7 +285,8 @@ namespace cubos::core::data
         d.readString(value);
     }
 
-    template <typename T> void deserialize(Deserializer& d, glm::tvec2<T>& value)
+    template <typename T>
+    void deserialize(Deserializer& d, glm::tvec2<T>& value)
     {
         d.beginObject();
         d.read(value.x);
@@ -293,26 +294,18 @@ namespace cubos::core::data
         d.endObject();
     }
 
-    template <typename T> void deserialize(Deserializer& d, glm::tvec3<T>& value)
-    {
-        d.beginObject();
-        d.read(value.x);
-        d.read(value.y);
-        d.read(value.z);
-        d.endObject();
-    }
-
-    template <typename T> void deserialize(Deserializer& d, glm::tvec4<T>& value)
+    template <typename T>
+    void deserialize(Deserializer& d, glm::tvec3<T>& value)
     {
         d.beginObject();
         d.read(value.x);
         d.read(value.y);
         d.read(value.z);
-        d.read(value.w);
         d.endObject();
     }
 
-    template <typename T> void deserialize(Deserializer& d, glm::tquat<T>& value)
+    template <typename T>
+    void deserialize(Deserializer& d, glm::tvec4<T>& value)
     {
         d.beginObject();
         d.read(value.x);
@@ -322,7 +315,19 @@ namespace cubos::core::data
         d.endObject();
     }
 
-    template <typename T> void deserialize(Deserializer& d, glm::tmat4x4<T>& mat)
+    template <typename T>
+    void deserialize(Deserializer& d, glm::tquat<T>& value)
+    {
+        d.beginObject();
+        d.read(value.x);
+        d.read(value.y);
+        d.read(value.z);
+        d.read(value.w);
+        d.endObject();
+    }
+
+    template <typename T>
+    void deserialize(Deserializer& d, glm::tmat4x4<T>& mat)
     {
         d.beginObject();
         d.read(mat[0]);
@@ -343,7 +348,8 @@ namespace cubos::core::data
         d.endArray();
     }
 
-    template <> inline void deserialize(Deserializer& d, std::vector<bool>& vec)
+    template <>
+    inline void deserialize(Deserializer& d, std::vector<bool>& vec)
     {
         size_t length = d.beginArray();
         vec.resize(length);

--- a/core/include/cubos/core/data/file_stream.hpp
+++ b/core/include/cubos/core/data/file_stream.hpp
@@ -11,7 +11,8 @@ namespace cubos::core::data
     /// Acts as a wrapper around a specific file stream, while maintaining a reference to the file so that it
     /// can be destroyed automatically when the stream is destroyed.
     /// @tparam T The type of internal stream in the stream.
-    template <typename T> class FileStream final : public memory::Stream
+    template <typename T>
+    class FileStream final : public memory::Stream
     {
     public:
         /// @param file The file which the stream is reading/writing from/to.
@@ -41,7 +42,8 @@ namespace cubos::core::data
     {
     }
 
-    template <typename T> inline size_t FileStream<T>::read(void* buffer, size_t size)
+    template <typename T>
+    inline size_t FileStream<T>::read(void* buffer, size_t size)
     {
         if (this->mode != File::OpenMode::Read)
         {
@@ -52,7 +54,8 @@ namespace cubos::core::data
         return stream.read(buffer, size);
     }
 
-    template <typename T> inline size_t FileStream<T>::write(const void* buffer, size_t size)
+    template <typename T>
+    inline size_t FileStream<T>::write(const void* buffer, size_t size)
     {
         if (this->mode != File::OpenMode::Write)
         {
@@ -63,22 +66,26 @@ namespace cubos::core::data
         return stream.write(buffer, size);
     }
 
-    template <typename T> inline size_t FileStream<T>::tell() const
+    template <typename T>
+    inline size_t FileStream<T>::tell() const
     {
         return stream.tell();
     }
 
-    template <typename T> inline void FileStream<T>::seek(int64_t offset, memory::SeekOrigin origin)
+    template <typename T>
+    inline void FileStream<T>::seek(int64_t offset, memory::SeekOrigin origin)
     {
         stream.seek(offset, origin);
     }
 
-    template <typename T> inline bool FileStream<T>::eof() const
+    template <typename T>
+    inline bool FileStream<T>::eof() const
     {
         return stream.eof();
     }
 
-    template <typename T> inline char FileStream<T>::peek() const
+    template <typename T>
+    inline char FileStream<T>::peek() const
     {
         return stream.peek();
     }

--- a/core/include/cubos/core/data/serialization_map.hpp
+++ b/core/include/cubos/core/data/serialization_map.hpp
@@ -9,7 +9,8 @@ namespace cubos::core::data
     /// Class used to map between references and their serialized identifiers.
     /// @tparam R Reference type.
     /// @tparam I Serialized identifier type.
-    template <typename R, typename I> class SerializationMap final
+    template <typename R, typename I>
+    class SerializationMap final
     {
     public:
         SerializationMap();
@@ -65,7 +66,8 @@ namespace cubos::core::data
 
     // Implementation
 
-    template <typename R, typename I> SerializationMap<R, I>::SerializationMap() : usingFunctions(false)
+    template <typename R, typename I>
+    SerializationMap<R, I>::SerializationMap() : usingFunctions(false)
     {
     }
 
@@ -76,14 +78,16 @@ namespace cubos::core::data
     {
     }
 
-    template <typename R, typename I> void SerializationMap<R, I>::add(const R& reference, const I& id)
+    template <typename R, typename I>
+    void SerializationMap<R, I>::add(const R& reference, const I& id)
     {
         assert(!this->usingFunctions);
         this->refToId.insert({reference, id});
         this->idToRef.insert({id, reference});
     }
 
-    template <typename R, typename I> bool SerializationMap<R, I>::hasRef(const R& reference) const
+    template <typename R, typename I>
+    bool SerializationMap<R, I>::hasRef(const R& reference) const
     {
         if (this->usingFunctions)
         {
@@ -96,7 +100,8 @@ namespace cubos::core::data
         }
     }
 
-    template <typename R, typename I> bool SerializationMap<R, I>::hasId(const I& id) const
+    template <typename R, typename I>
+    bool SerializationMap<R, I>::hasId(const I& id) const
     {
         if (this->usingFunctions)
         {
@@ -109,7 +114,8 @@ namespace cubos::core::data
         }
     }
 
-    template <typename R, typename I> R SerializationMap<R, I>::getRef(const I& id) const
+    template <typename R, typename I>
+    R SerializationMap<R, I>::getRef(const I& id) const
     {
         if (this->usingFunctions)
         {
@@ -123,7 +129,8 @@ namespace cubos::core::data
         }
     }
 
-    template <typename R, typename I> I SerializationMap<R, I>::getId(const R& reference) const
+    template <typename R, typename I>
+    I SerializationMap<R, I>::getId(const R& reference) const
     {
         if (this->usingFunctions)
         {
@@ -137,14 +144,16 @@ namespace cubos::core::data
         }
     }
 
-    template <typename R, typename I> void SerializationMap<R, I>::clear()
+    template <typename R, typename I>
+    void SerializationMap<R, I>::clear()
     {
         this->usingFunctions = false;
         this->refToId.clear();
         this->idToRef.clear();
     }
 
-    template <typename R, typename I> size_t SerializationMap<R, I>::size() const
+    template <typename R, typename I>
+    size_t SerializationMap<R, I>::size() const
     {
         return this->refToId.size();
     }

--- a/core/include/cubos/core/data/serializer.hpp
+++ b/core/include/cubos/core/data/serializer.hpp
@@ -188,7 +188,8 @@ namespace cubos::core::data
         /// @param obj The object to serialize.
         /// @param ctx The context required to serialize.
         /// @param name The name of the object (optional).
-        template <typename T, typename TCtx> void write(const T& obj, TCtx&& ctx, const char* name);
+        template <typename T, typename TCtx>
+        void write(const T& obj, TCtx&& ctx, const char* name);
 
         /// Indicates that a object is currently being serialized.
         /// @param name The name of the object (optional).
@@ -312,7 +313,8 @@ namespace cubos::core::data
         s.writeString(v.c_str(), name);
     }
 
-    template <typename T> void serialize(Serializer& s, const glm::tvec2<T>& vec, const char* name)
+    template <typename T>
+    void serialize(Serializer& s, const glm::tvec2<T>& vec, const char* name)
     {
         s.beginObject(name);
         s.write(vec.x, "x");
@@ -320,7 +322,8 @@ namespace cubos::core::data
         s.endObject();
     }
 
-    template <typename T> void serialize(Serializer& s, const glm::tvec3<T>& vec, const char* name)
+    template <typename T>
+    void serialize(Serializer& s, const glm::tvec3<T>& vec, const char* name)
     {
         s.beginObject(name);
         s.write(vec.x, "x");
@@ -329,7 +332,8 @@ namespace cubos::core::data
         s.endObject();
     }
 
-    template <typename T> void serialize(Serializer& s, const glm::tvec4<T>& vec, const char* name)
+    template <typename T>
+    void serialize(Serializer& s, const glm::tvec4<T>& vec, const char* name)
     {
         s.beginObject(name);
         s.write(vec.x, "x");
@@ -339,7 +343,8 @@ namespace cubos::core::data
         s.endObject();
     }
 
-    template <typename T> void serialize(Serializer& s, const glm::tquat<T>& quat, const char* name)
+    template <typename T>
+    void serialize(Serializer& s, const glm::tquat<T>& quat, const char* name)
     {
         s.beginObject(name);
         s.write(quat.w, "w");
@@ -349,7 +354,8 @@ namespace cubos::core::data
         s.endObject();
     }
 
-    template <typename T> void serialize(Serializer& s, const glm::tmat4x4<T>& mat, const char* name)
+    template <typename T>
+    void serialize(Serializer& s, const glm::tmat4x4<T>& mat, const char* name)
     {
         s.beginObject(name);
         s.write(mat[0], "0");

--- a/core/include/cubos/core/ecs/blueprint.hpp
+++ b/core/include/cubos/core/ecs/blueprint.hpp
@@ -30,7 +30,8 @@ namespace cubos::core::ecs
         /// @tparam ComponentTypes The types of the components.
         /// @param entity The entity to add the components to.
         /// @param components The components to add.
-        template <typename... ComponentTypes> void add(Entity entity, const ComponentTypes&... components);
+        template <typename... ComponentTypes>
+        void add(Entity entity, const ComponentTypes&... components);
 
         /// Deserializes a component and adds it to an entity.
         /// @param entity The entity to add the component to.
@@ -90,7 +91,8 @@ namespace cubos::core::ecs
 
         /// Implementation of the IBuffer interface for a single component type.
         /// @tparam ComponentType The type of the component.
-        template <typename ComponentType> struct Buffer : IBuffer
+        template <typename ComponentType>
+        struct Buffer : IBuffer
         {
             // Interface methods implementation.
 
@@ -125,7 +127,8 @@ namespace cubos::core::ecs
         return entity;
     }
 
-    template <typename... ComponentTypes> void Blueprint::add(Entity entity, const ComponentTypes&... components)
+    template <typename... ComponentTypes>
+    void Blueprint::add(Entity entity, const ComponentTypes&... components)
     {
         assert(entity.generation == 0 && this->map.hasRef(entity));
 
@@ -201,7 +204,8 @@ namespace cubos::core::ecs
         buffer->mutex.unlock();
     }
 
-    template <typename ComponentType> Blueprint::IBuffer* Blueprint::Buffer<ComponentType>::create()
+    template <typename ComponentType>
+    Blueprint::IBuffer* Blueprint::Buffer<ComponentType>::create()
     {
         return new Buffer<ComponentType>();
     }

--- a/core/include/cubos/core/ecs/commands.hpp
+++ b/core/include/cubos/core/ecs/commands.hpp
@@ -26,12 +26,14 @@ namespace cubos::core::ecs
         /// Gets a reference to a component of the entity.
         /// @tparam ComponentType The type of the component.
         /// @returns A reference to the component.
-        template <typename ComponentType> ComponentType& get();
+        template <typename ComponentType>
+        ComponentType& get();
 
         /// Adds component to the entity.
         /// @tparam ComponentTypes The types of the components.
         /// @param components The components to add.
-        template <typename... ComponentTypes> EntityBuilder& add(ComponentTypes&&... components);
+        template <typename... ComponentTypes>
+        EntityBuilder& add(ComponentTypes&&... components);
 
     private:
         friend Commands;
@@ -60,7 +62,8 @@ namespace cubos::core::ecs
         /// Aborts if the name is not found.
         /// @tparam ComponentType The type of the component.
         /// @returns A reference to the component.
-        template <typename ComponentType> ComponentType& get(const std::string& name);
+        template <typename ComponentType>
+        ComponentType& get(const std::string& name);
 
         /// Adds component to the blueprint.
         /// Aborts if the name is not found.
@@ -94,18 +97,21 @@ namespace cubos::core::ecs
         /// @tparam ComponentTypes The types of the components to be added.
         /// @param entity The entity to which the components will be added.
         /// @param components The components to add.
-        template <typename... ComponentTypes> void add(Entity entity, ComponentTypes&&... components);
+        template <typename... ComponentTypes>
+        void add(Entity entity, ComponentTypes&&... components);
 
         /// Removes components from an entity.
         /// @tparam ComponentTypes The types of the components to be removed.
         /// @param entity The entity from which the components will be removed.
-        template <typename... ComponentTypes> void remove(Entity entity);
+        template <typename... ComponentTypes>
+        void remove(Entity entity);
 
         /// Creates a new entity with the given components.
         /// @tparam ComponentTypes The types of the components to be added.
         /// @param components The components to add.
         /// @returns The new entity.
-        template <typename... ComponentTypes> EntityBuilder create(ComponentTypes&&... components);
+        template <typename... ComponentTypes>
+        EntityBuilder create(ComponentTypes&&... components);
 
         /// Destroys an entity.
         /// @param entity The entity to destroy.
@@ -139,7 +145,8 @@ namespace cubos::core::ecs
 
         /// Implementation of the IBuffer interface for a specific component type.
         /// @tparam ComponentType The type of the component.
-        template <typename ComponentType> struct Buffer : IBuffer
+        template <typename ComponentType>
+        struct Buffer : IBuffer
         {
             // Interface methods implementation.
 
@@ -171,7 +178,8 @@ namespace cubos::core::ecs
 
     // Implementation.
 
-    template <typename ComponentType> ComponentType& EntityBuilder::get()
+    template <typename ComponentType>
+    ComponentType& EntityBuilder::get()
     {
         auto it = this->commands.buffers.find(typeid(ComponentType));
         if (it != this->commands.buffers.end())
@@ -188,13 +196,15 @@ namespace cubos::core::ecs
         abort();
     }
 
-    template <typename... ComponentTypes> EntityBuilder& EntityBuilder::add(ComponentTypes&&... components)
+    template <typename... ComponentTypes>
+    EntityBuilder& EntityBuilder::add(ComponentTypes&&... components)
     {
         this->commands.add(this->eEntity, std::move(components)...);
         return *this;
     }
 
-    template <typename ComponentType> ComponentType& BlueprintBuilder::get(const std::string& name)
+    template <typename ComponentType>
+    ComponentType& BlueprintBuilder::get(const std::string& name)
     {
         auto it = this->commands.buffers.find(typeid(ComponentType));
         if (it != this->commands.buffers.end())
@@ -218,7 +228,8 @@ namespace cubos::core::ecs
         return *this;
     }
 
-    template <typename... ComponentTypes> void Commands::add(Entity entity, ComponentTypes&&... components)
+    template <typename... ComponentTypes>
+    void Commands::add(Entity entity, ComponentTypes&&... components)
     {
         std::lock_guard<std::mutex> lock(this->mutex);
         Entity::Mask& mask = this->added[entity];
@@ -240,7 +251,8 @@ namespace cubos::core::ecs
             ...);
     }
 
-    template <typename... ComponentTypes> void Commands::remove(Entity entity)
+    template <typename... ComponentTypes>
+    void Commands::remove(Entity entity)
     {
         std::lock_guard<std::mutex> lock(this->mutex);
         Entity::Mask& mask = this->removed[entity];
@@ -254,7 +266,8 @@ namespace cubos::core::ecs
             ...);
     }
 
-    template <typename... ComponentTypes> EntityBuilder Commands::create(ComponentTypes&&... components)
+    template <typename... ComponentTypes>
+    EntityBuilder Commands::create(ComponentTypes&&... components)
     {
         std::lock_guard<std::mutex> lock(this->mutex);
 
@@ -281,7 +294,8 @@ namespace cubos::core::ecs
         return EntityBuilder(entity, *this);
     }
 
-    template <typename ComponentType> void Commands::Buffer<ComponentType>::clear()
+    template <typename ComponentType>
+    void Commands::Buffer<ComponentType>::clear()
     {
         this->components.clear();
     }

--- a/core/include/cubos/core/ecs/component_manager.hpp
+++ b/core/include/cubos/core/ecs/component_manager.hpp
@@ -15,7 +15,8 @@ namespace cubos::core::ecs
 {
     /// Generic type used to identify the storage type of a component.
     /// Must be specialized for each component type.
-    template <typename T> struct ComponentStorage
+    template <typename T>
+    struct ComponentStorage
     {
         // This should never be instantiated.
         static_assert(!std::is_same_v<T, T>, "ComponentStorage must be specialized for each component type.");
@@ -38,7 +39,8 @@ namespace cubos::core::ecs
     /// If the component type is not registered, aborts the program.
     /// @tparam T Component type.
     /// @returns The registered name of the component type.
-    template <typename T> const std::string& getComponentName();
+    template <typename T>
+    const std::string& getComponentName();
 
     /// Gets the registered name of a component type.
     /// If the component type is not registered, aborts the program.
@@ -47,7 +49,8 @@ namespace cubos::core::ecs
     const std::string& getComponentName(std::type_index type);
 
     /// Utility struct used to reference component storages for reading.
-    template <typename T> class ReadStorage
+    template <typename T>
+    class ReadStorage
     {
     public:
         ReadStorage(ReadStorage&&);
@@ -65,7 +68,8 @@ namespace cubos::core::ecs
     };
 
     /// Utility struct used to reference component storages for writing.
-    template <typename T> class WriteStorage
+    template <typename T>
+    class WriteStorage
     {
     public:
         WriteStorage(WriteStorage&&);
@@ -90,7 +94,8 @@ namespace cubos::core::ecs
         /// Registers a new component type with the component manager.
         /// Must be called before any component of this type is used in any way.
         /// @tparam T The type of the component.
-        template <typename T> void registerComponent();
+        template <typename T>
+        void registerComponent();
 
         /// Gets the ID of the component type.
         /// @param type The type of the component.
@@ -100,7 +105,8 @@ namespace cubos::core::ecs
         /// Gets the ID of the component type.
         /// @tparam T The type of the component.
         /// @returns The ID of the component type.
-        template <typename T> size_t getID() const;
+        template <typename T>
+        size_t getID() const;
 
         /// Gets the type of the component.
         /// @param id The ID of the component type.
@@ -110,23 +116,27 @@ namespace cubos::core::ecs
         /// Gets the storage of the component type.
         /// @tparam T The type of the component.
         /// @returns The storage guard of the component type.
-        template <typename T> ReadStorage<T> read() const;
+        template <typename T>
+        ReadStorage<T> read() const;
 
         /// Gets the storage of the component type.
         /// @tparam T The type of the component.
         /// @returns The storage guard of the component type.
-        template <typename T> WriteStorage<T> write() const;
+        template <typename T>
+        WriteStorage<T> write() const;
 
         /// Adds a component to an entity.
         /// @tparam T The type of the component.
         /// @param id The ID of the entity.
         /// @param value The initial value of the component.
-        template <typename T> void add(uint32_t id, T value);
+        template <typename T>
+        void add(uint32_t id, T value);
 
         /// Removes a component from an entity.
         /// @tparam T The type of the component.
         /// @param id The ID of the entity.
-        template <typename T> void remove(uint32_t id);
+        template <typename T>
+        void remove(uint32_t id);
 
         /// Removes a component from an entity.
         /// @param id The ID of the entity.
@@ -173,7 +183,8 @@ namespace cubos::core::ecs
 
     // Implementation.
 
-    template <typename T> const std::string& getComponentName()
+    template <typename T>
+    const std::string& getComponentName()
     {
         return getComponentName(typeid(T));
     }
@@ -184,7 +195,8 @@ namespace cubos::core::ecs
         // Do nothing.
     }
 
-    template <typename T> const typename ComponentStorage<T>::Type& ReadStorage<T>::get() const
+    template <typename T>
+    const typename ComponentStorage<T>::Type& ReadStorage<T>::get() const
     {
         return this->storage;
     }
@@ -203,7 +215,8 @@ namespace cubos::core::ecs
         // Do nothing.
     }
 
-    template <typename T> typename ComponentStorage<T>::Type& WriteStorage<T>::get() const
+    template <typename T>
+    typename ComponentStorage<T>::Type& WriteStorage<T>::get() const
     {
         return this->storage;
     }
@@ -216,7 +229,8 @@ namespace cubos::core::ecs
         // Do nothing.
     }
 
-    template <typename T> void ComponentManager::registerComponent()
+    template <typename T>
+    void ComponentManager::registerComponent()
     {
         static_assert(std::is_same<T, typename ComponentStorage<T>::Type::Type>(),
                       "A component can't use a storage for a different component type!");
@@ -228,33 +242,38 @@ namespace cubos::core::ecs
         }
     }
 
-    template <typename T> size_t ComponentManager::getID() const
+    template <typename T>
+    size_t ComponentManager::getID() const
     {
         return this->getIDFromIndex(typeid(T));
     }
 
-    template <typename T> ReadStorage<T> ComponentManager::read() const
+    template <typename T>
+    ReadStorage<T> ComponentManager::read() const
     {
         const size_t id = this->getID<T>();
         return ReadStorage<T>(*static_cast<const typename ComponentStorage<T>::Type*>(this->entries[id - 1].storage),
                               std::shared_lock<std::shared_mutex>(*this->entries[id - 1].mutex));
     }
 
-    template <typename T> WriteStorage<T> ComponentManager::write() const
+    template <typename T>
+    WriteStorage<T> ComponentManager::write() const
     {
         const size_t id = this->getID<T>();
         return WriteStorage<T>(*static_cast<typename ComponentStorage<T>::Type*>(this->entries[id - 1].storage),
                                std::unique_lock<std::shared_mutex>(*this->entries[id - 1].mutex));
     }
 
-    template <typename T> void ComponentManager::add(uint32_t entityId, T value)
+    template <typename T>
+    void ComponentManager::add(uint32_t entityId, T value)
     {
         const size_t id = this->getID<T>();
         auto storage = static_cast<typename ComponentStorage<T>::Type*>(this->entries[id - 1].storage);
         storage->insert(entityId, std::move(value));
     }
 
-    template <typename T> void ComponentManager::remove(uint32_t entityId)
+    template <typename T>
+    void ComponentManager::remove(uint32_t entityId)
     {
         const size_t id = this->getID<T>();
         auto storage = static_cast<typename ComponentStorage<T>::Type*>(this->entries[id - 1].storage);

--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -26,7 +26,8 @@ namespace cubos::core::ecs
         /// Adds a system into a stage.
         /// @param system System to add.
         /// @param stage Stage to add the system in.
-        template <typename F> void addSystem(F system, std::string stage);
+        template <typename F>
+        void addSystem(F system, std::string stage);
 
         /// Calls all systems in order of the stages they are in.
         /// @param world World to call the systems in.
@@ -60,7 +61,8 @@ namespace cubos::core::ecs
         Direction defaultDirection; ///< The direction new stages are put in relation to the default stage.
     };
 
-    template <typename F> void Dispatcher::addSystem(F system, std::string stage)
+    template <typename F>
+    void Dispatcher::addSystem(F system, std::string stage)
     {
         // Register stage if it doesn't exist.
         if (this->stagesByName.find(stage) == this->stagesByName.end())

--- a/core/include/cubos/core/ecs/entity_manager.hpp
+++ b/core/include/cubos/core/ecs/entity_manager.hpp
@@ -39,7 +39,8 @@ namespace cubos::core::ecs
 {
     namespace impl
     {
-        template <typename T> class QueryFetcher;
+        template <typename T>
+        class QueryFetcher;
     }
 
     /// Handle used to identify an Entity.
@@ -155,7 +156,8 @@ namespace std
 {
     /// Add hash function for Entity, so that it can be used as a key in an unordered_map.
     /// @cond
-    template <> struct hash<cubos::core::ecs::Entity>
+    template <>
+    struct hash<cubos::core::ecs::Entity>
     {
         inline std::size_t operator()(const cubos::core::ecs::Entity& k) const
         {

--- a/core/include/cubos/core/ecs/map_storage.hpp
+++ b/core/include/cubos/core/ecs/map_storage.hpp
@@ -9,7 +9,8 @@ namespace cubos::core::ecs
     /// @brief MapStorage is a Storage implementation that uses a STL unordered_map, this is best
     /// for components that aren't used that often so the data is stored in a more compact way.
     /// @tparam T The type to be stored in the storage.
-    template <typename T> class MapStorage : public Storage<T>
+    template <typename T>
+    class MapStorage : public Storage<T>
     {
     public:
         T* insert(uint32_t index, T value) override;
@@ -21,23 +22,27 @@ namespace cubos::core::ecs
         std::unordered_map<uint32_t, T> data;
     };
 
-    template <typename T> T* MapStorage<T>::insert(uint32_t index, T value)
+    template <typename T>
+    T* MapStorage<T>::insert(uint32_t index, T value)
     {
         data[index] = value;
         return &data[index];
     }
 
-    template <typename T> T* MapStorage<T>::get(uint32_t index)
+    template <typename T>
+    T* MapStorage<T>::get(uint32_t index)
     {
         return &data.at(index);
     }
 
-    template <typename T> const T* MapStorage<T>::get(uint32_t index) const
+    template <typename T>
+    const T* MapStorage<T>::get(uint32_t index) const
     {
         return &data.at(index);
     }
 
-    template <typename T> void MapStorage<T>::erase(uint32_t index)
+    template <typename T>
+    void MapStorage<T>::erase(uint32_t index)
     {
         data.erase(index);
     }

--- a/core/include/cubos/core/ecs/null_storage.hpp
+++ b/core/include/cubos/core/ecs/null_storage.hpp
@@ -9,7 +9,8 @@ namespace cubos::core::ecs
     /// @brief NullStorage is a Storage implementation that doesn't keep any data, made for components
     /// that don't hold any data and just work as tags.
     /// @tparam T The type to be stored in the storage.
-    template <typename T> class NullStorage : public Storage<T>
+    template <typename T>
+    class NullStorage : public Storage<T>
     {
     public:
         T* insert(uint32_t index, T value) override;
@@ -21,22 +22,26 @@ namespace cubos::core::ecs
         T data;
     };
 
-    template <typename T> T* NullStorage<T>::insert(uint32_t index, T value)
+    template <typename T>
+    T* NullStorage<T>::insert(uint32_t index, T value)
     {
         return &data;
     }
 
-    template <typename T> T* NullStorage<T>::get(uint32_t index)
+    template <typename T>
+    T* NullStorage<T>::get(uint32_t index)
     {
         return &data;
     }
 
-    template <typename T> const T* NullStorage<T>::get(uint32_t index) const
+    template <typename T>
+    const T* NullStorage<T>::get(uint32_t index) const
     {
         return &data;
     }
 
-    template <typename T> void NullStorage<T>::erase(uint32_t index)
+    template <typename T>
+    void NullStorage<T>::erase(uint32_t index)
     {
     }
 

--- a/core/include/cubos/core/ecs/query.hpp
+++ b/core/include/cubos/core/ecs/query.hpp
@@ -21,7 +21,8 @@ namespace cubos::core::ecs
     namespace impl
     {
         /// Fetches the requested type from a world.
-        template <typename T> struct QueryFetcher
+        template <typename T>
+        struct QueryFetcher
         {
             // This should never be instantiated.
             static_assert(!std::is_same_v<T, T>,
@@ -29,7 +30,8 @@ namespace cubos::core::ecs
         };
 
         /// @tparam Component The type of the component to fetch.
-        template <typename Component> struct QueryFetcher<Component&>
+        template <typename Component>
+        struct QueryFetcher<Component&>
         {
             using Type = WriteStorage<Component>;
 
@@ -51,7 +53,8 @@ namespace cubos::core::ecs
         };
 
         /// @tparam Component The type of the component to fetch.
-        template <typename Component> struct QueryFetcher<const Component&>
+        template <typename Component>
+        struct QueryFetcher<const Component&>
         {
             using Type = ReadStorage<Component>;
 
@@ -73,7 +76,8 @@ namespace cubos::core::ecs
         };
 
         /// @tparam Component The type of the component to fetch.
-        template <typename Component> struct QueryFetcher<Component*>
+        template <typename Component>
+        struct QueryFetcher<Component*>
         {
             using Type = WriteStorage<Component>;
 
@@ -95,7 +99,8 @@ namespace cubos::core::ecs
         };
 
         /// @tparam Component The type of the component to fetch.
-        template <typename Component> struct QueryFetcher<const Component*>
+        template <typename Component>
+        struct QueryFetcher<const Component*>
         {
             using Type = ReadStorage<Component>;
 
@@ -128,7 +133,8 @@ namespace cubos::core::ecs
     /// is not needed, a const reference/pointer should be used.
     ///
     /// @tparam ComponentTypes The types of the component references to be queried.
-    template <typename... ComponentTypes> class Query
+    template <typename... ComponentTypes>
+    class Query
     {
     public:
         using Fetched = std::tuple<typename impl::QueryFetcher<ComponentTypes>::Type...>;
@@ -240,24 +246,28 @@ namespace cubos::core::ecs
         }
     }
 
-    template <typename... ComponentTypes> typename Query<ComponentTypes...>::Iterator Query<ComponentTypes...>::begin()
+    template <typename... ComponentTypes>
+    typename Query<ComponentTypes...>::Iterator Query<ComponentTypes...>::begin()
     {
         return Iterator(this->world, this->fetched, this->world.entityManager.withMask(this->mask));
     }
 
-    template <typename... ComponentTypes> typename Query<ComponentTypes...>::Iterator Query<ComponentTypes...>::end()
+    template <typename... ComponentTypes>
+    typename Query<ComponentTypes...>::Iterator Query<ComponentTypes...>::end()
     {
         return Iterator(this->world, this->fetched, this->world.entityManager.end());
     }
 
-    template <typename... ComponentTypes> QueryInfo Query<ComponentTypes...>::info()
+    template <typename... ComponentTypes>
+    QueryInfo Query<ComponentTypes...>::info()
     {
         QueryInfo info;
         ([&]() { impl::QueryFetcher<ComponentTypes>::add(info); }(), ...);
         return info;
     }
 
-    template <typename Component> void impl::QueryFetcher<Component&>::add(QueryInfo& info)
+    template <typename Component>
+    void impl::QueryFetcher<Component&>::add(QueryInfo& info)
     {
         info.written.insert(typeid(Component));
     }
@@ -274,7 +284,8 @@ namespace cubos::core::ecs
         return *lock.get().get(entity.index);
     }
 
-    template <typename Component> void impl::QueryFetcher<const Component&>::add(QueryInfo& info)
+    template <typename Component>
+    void impl::QueryFetcher<const Component&>::add(QueryInfo& info)
     {
         info.read.insert(typeid(Component));
     }
@@ -291,7 +302,8 @@ namespace cubos::core::ecs
         return *lock.get().get(entity.index);
     }
 
-    template <typename Component> void impl::QueryFetcher<Component*>::add(QueryInfo& info)
+    template <typename Component>
+    void impl::QueryFetcher<Component*>::add(QueryInfo& info)
     {
         info.written.insert(typeid(Component));
     }
@@ -315,7 +327,8 @@ namespace cubos::core::ecs
         }
     }
 
-    template <typename Component> void impl::QueryFetcher<const Component*>::add(QueryInfo& info)
+    template <typename Component>
+    void impl::QueryFetcher<const Component*>::add(QueryInfo& info)
     {
         info.read.insert(typeid(Component));
     }

--- a/core/include/cubos/core/ecs/registry.hpp
+++ b/core/include/cubos/core/ecs/registry.hpp
@@ -28,7 +28,8 @@ namespace cubos::core::ecs
         /// Registers a new component type.
         /// @tparam T The component type to register.
         /// @param name The name of the component.
-        template <typename ComponentType> static void add(const std::string& name);
+        template <typename ComponentType>
+        static void add(const std::string& name);
 
         /// Gets the name of a component type.
         /// @param index The type index of the component.
@@ -55,7 +56,8 @@ namespace cubos::core::ecs
 
     // Implementation.
 
-    template <typename ComponentType> void Registry::add(const std::string& name)
+    template <typename ComponentType>
+    void Registry::add(const std::string& name)
     {
         auto& creators = Registry::creators();
         auto& names = Registry::names();

--- a/core/include/cubos/core/ecs/resource_manager.hpp
+++ b/core/include/cubos/core/ecs/resource_manager.hpp
@@ -10,7 +10,8 @@
 namespace cubos::core::ecs
 {
     /// Utility struct used to reference resources for reading.
-    template <typename T> class ReadResource
+    template <typename T>
+    class ReadResource
     {
     public:
         ReadResource(ReadResource&&);
@@ -28,7 +29,8 @@ namespace cubos::core::ecs
     };
 
     /// Utility struct used to reference resources for writing.
-    template <typename T> class WriteResource
+    template <typename T>
+    class WriteResource
     {
     public:
         WriteResource(WriteResource&&);
@@ -58,17 +60,20 @@ namespace cubos::core::ecs
         /// @tparam T The type of the resource.
         /// @tparam TArgs The types of the arguments of the constructor of the resource.
         /// @param args The arguments of the constructor of the resource.
-        template <typename T, typename... TArgs> void add(TArgs... args);
+        template <typename T, typename... TArgs>
+        void add(TArgs... args);
 
         /// Reads a resource from the resource manager, locking it for reading.
         /// @tparam T The type of the resource.
         /// @returns A lock referring to the resource.
-        template <typename T> ReadResource<T> read() const;
+        template <typename T>
+        ReadResource<T> read() const;
 
         /// Writes a resource to the resource manager, locking it for writing.
         /// @tparam T The type of the resource.
         /// @returns A lock referring to the resource.
-        template <typename T> WriteResource<T> write() const;
+        template <typename T>
+        WriteResource<T> write() const;
 
     private:
         /// Data specific to a resource.
@@ -100,7 +105,8 @@ namespace cubos::core::ecs
         // Do nothing.
     }
 
-    template <typename T> const T& ReadResource<T>::get() const
+    template <typename T>
+    const T& ReadResource<T>::get() const
     {
         return this->resource;
     }
@@ -118,7 +124,8 @@ namespace cubos::core::ecs
         // Do nothing.
     }
 
-    template <typename T> T& WriteResource<T>::get() const
+    template <typename T>
+    T& WriteResource<T>::get() const
     {
         return this->resource;
     }
@@ -137,7 +144,8 @@ namespace cubos::core::ecs
         // Do nothing.
     }
 
-    template <typename T, typename... TArgs> void ResourceManager::add(TArgs... args)
+    template <typename T, typename... TArgs>
+    void ResourceManager::add(TArgs... args)
     {
         auto it = resources.find(typeid(T));
         if (it != resources.end())
@@ -149,7 +157,8 @@ namespace cubos::core::ecs
         this->resources.try_emplace(typeid(T), new T(args...), [](void* data) { delete static_cast<T*>(data); });
     }
 
-    template <typename T> ReadResource<T> ResourceManager::read() const
+    template <typename T>
+    ReadResource<T> ResourceManager::read() const
     {
         auto it = resources.find(typeid(T));
         if (it == resources.end())
@@ -162,7 +171,8 @@ namespace cubos::core::ecs
         return ReadResource<T>(*static_cast<const T*>(resource.data), std::shared_lock(resource.mutex));
     }
 
-    template <typename T> WriteResource<T> ResourceManager::write() const
+    template <typename T>
+    WriteResource<T> ResourceManager::write() const
     {
         auto it = resources.find(typeid(T));
         if (it == resources.end())

--- a/core/include/cubos/core/ecs/storage.hpp
+++ b/core/include/cubos/core/ecs/storage.hpp
@@ -47,7 +47,8 @@ namespace cubos::core::ecs
     /// @brief Storage is an abstract container for a certain type with common operations, such as,
     /// insert, get and erase.
     /// @tparam T The type to be stored in the storage.
-    template <typename T> class Storage : public IStorage
+    template <typename T>
+    class Storage : public IStorage
     {
     public:
         using Type = T;
@@ -98,7 +99,8 @@ namespace cubos::core::ecs
         return false;
     }
 
-    template <typename T> std::type_index Storage<T>::type() const
+    template <typename T>
+    std::type_index Storage<T>::type() const
     {
         return std::type_index(typeid(T));
     }

--- a/core/include/cubos/core/ecs/vec_storage.hpp
+++ b/core/include/cubos/core/ecs/vec_storage.hpp
@@ -9,7 +9,8 @@ namespace cubos::core::ecs
     /// @brief VecStorage is a Storage implementation that uses a STL vector, this is best
     /// for components that are used very often, in order to be the most efficient memory wise.
     /// @tparam T The type to be stored in the storage.
-    template <typename T> class VecStorage : public Storage<T>
+    template <typename T>
+    class VecStorage : public Storage<T>
     {
     public:
         T* insert(uint32_t index, T value) override;
@@ -21,7 +22,8 @@ namespace cubos::core::ecs
         std::vector<T> data;
     };
 
-    template <typename T> T* VecStorage<T>::insert(uint32_t index, T value)
+    template <typename T>
+    T* VecStorage<T>::insert(uint32_t index, T value)
     {
         if (data.size() <= index)
         {
@@ -36,17 +38,20 @@ namespace cubos::core::ecs
         return &data[index];
     }
 
-    template <typename T> T* VecStorage<T>::get(uint32_t index)
+    template <typename T>
+    T* VecStorage<T>::get(uint32_t index)
     {
         return &data[index];
     }
 
-    template <typename T> const T* VecStorage<T>::get(uint32_t index) const
+    template <typename T>
+    const T* VecStorage<T>::get(uint32_t index) const
     {
         return &data[index];
     }
 
-    template <typename T> void VecStorage<T>::erase(uint32_t index)
+    template <typename T>
+    void VecStorage<T>::erase(uint32_t index)
     {
         data[index].~T();
         new (&data[index]) T;

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -14,7 +14,8 @@ namespace cubos::core::ecs
 {
     namespace impl
     {
-        template <typename T> class QueryFetcher;
+        template <typename T>
+        class QueryFetcher;
     }
 
     /// @brief World is used as a container for all of the entity and component data.
@@ -31,27 +32,32 @@ namespace cubos::core::ecs
         /// @tparam T The type of the resource.
         /// @tparam TArgs The types of the arguments of the constructor of the resource.
         /// @param args The arguments of the constructor of the resource.
-        template <typename T, typename... TArgs> void registerResource(TArgs... args);
+        template <typename T, typename... TArgs>
+        void registerResource(TArgs... args);
 
         /// @brief Registers a component type.
         /// @tparam T Component type.
         /// @param storage Storage for the component type.
-        template <typename T> void registerComponent();
+        template <typename T>
+        void registerComponent();
 
         /// Reads a resource, locking it for reading.
         /// @tparam T The type of the resource.
         /// @returns A lock referring to the resource.
-        template <typename T> ReadResource<T> read() const;
+        template <typename T>
+        ReadResource<T> read() const;
 
         /// Writes a resource, locking it for writing.
         /// @tparam T The type of the resource.
         /// @returns A lock referring to the resource.
-        template <typename T> WriteResource<T> write() const;
+        template <typename T>
+        WriteResource<T> write() const;
 
         /// @brief Creates a new entity.
         /// @tparam ComponentTypes The types of the components to be added when the entity is created.
         /// @param components The initial values for the components.
-        template <typename... ComponentTypes> Entity create(ComponentTypes&&... components);
+        template <typename... ComponentTypes>
+        Entity create(ComponentTypes&&... components);
 
         /// @brief Removes an entity.
         /// @param entity Entity ID.
@@ -60,17 +66,20 @@ namespace cubos::core::ecs
         /// @brief Adds components to an entity.
         /// @tparam ComponentTypes The types of the components to be added.
         /// @param components The initial values for the components.
-        template <typename... ComponentTypes> void add(Entity entity, ComponentTypes&&... components);
+        template <typename... ComponentTypes>
+        void add(Entity entity, ComponentTypes&&... components);
 
         /// @brief Removes components from an entity.
         /// @tparam ComponentTypes Component types to be removed.
         /// @param entity Entity ID.
-        template <typename... ComponentTypes> void remove(Entity entity);
+        template <typename... ComponentTypes>
+        void remove(Entity entity);
 
         /// @brief Checks if an entity has a component.
         /// @tparam T Component type.
         /// @param entity Entity ID.
-        template <typename T> bool has(Entity entity) const;
+        template <typename T>
+        bool has(Entity entity) const;
 
         /// @brief Creates a package from the components of an entity.
         /// @param entity Entity ID.
@@ -87,8 +96,10 @@ namespace cubos::core::ecs
 
     private:
         friend class Debug;
-        template <typename... ComponentTypes> friend class Query;
-        template <typename T> friend class impl::QueryFetcher;
+        template <typename... ComponentTypes>
+        friend class Query;
+        template <typename T>
+        friend class impl::QueryFetcher;
         friend class Commands;
 
         ResourceManager resourceManager;
@@ -98,29 +109,34 @@ namespace cubos::core::ecs
 
     // Implementation.
 
-    template <typename T, typename... TArgs> void World::registerResource(TArgs... args)
+    template <typename T, typename... TArgs>
+    void World::registerResource(TArgs... args)
     {
         CUBOS_TRACE("Registered resource '{}'", typeid(T).name());
         this->resourceManager.add<T>(args...);
     }
 
-    template <typename T> void World::registerComponent()
+    template <typename T>
+    void World::registerComponent()
     {
         CUBOS_TRACE("Registered component '{}'", getComponentName<T>());
         this->componentManager.registerComponent<T>();
     }
 
-    template <typename T> ReadResource<T> World::read() const
+    template <typename T>
+    ReadResource<T> World::read() const
     {
         return this->resourceManager.read<T>();
     }
 
-    template <typename T> WriteResource<T> World::write() const
+    template <typename T>
+    WriteResource<T> World::write() const
     {
         return this->resourceManager.write<T>();
     }
 
-    template <typename... ComponentTypes> Entity World::create(ComponentTypes&&... components)
+    template <typename... ComponentTypes>
+    Entity World::create(ComponentTypes&&... components)
     {
         size_t ids[] = {
             (this->componentManager
@@ -143,7 +159,8 @@ namespace cubos::core::ecs
         return entity;
     }
 
-    template <typename... ComponentTypes> void World::add(Entity entity, ComponentTypes&&... components)
+    template <typename... ComponentTypes>
+    void World::add(Entity entity, ComponentTypes&&... components)
     {
         if (!this->entityManager.isValid(entity))
         {
@@ -169,7 +186,8 @@ namespace cubos::core::ecs
 #endif
     }
 
-    template <typename... ComponentTypes> void World::remove(Entity entity)
+    template <typename... ComponentTypes>
+    void World::remove(Entity entity)
     {
         if (!this->entityManager.isValid(entity))
         {
@@ -195,7 +213,8 @@ namespace cubos::core::ecs
 #endif
     }
 
-    template <typename T> bool World::has(Entity entity) const
+    template <typename T>
+    bool World::has(Entity entity) const
     {
         if (!this->entityManager.isValid(entity))
         {

--- a/core/include/cubos/core/event.hpp
+++ b/core/include/cubos/core/event.hpp
@@ -17,7 +17,8 @@ namespace cubos::core
     ///     event.fire("Hello!"); // Prints "Hello!"
     ///
     /// @tparam TArgs The argument types of the callback functions.
-    template <typename... TArgs> class Event
+    template <typename... TArgs>
+    class Event
     {
     public:
         using Callback = std::function<void(TArgs...)>; ///< Callback type.
@@ -41,13 +42,15 @@ namespace cubos::core
         /// @param obj The instance associated with the method callback that should be called when the event is fired.
         /// @param callback The method callback when the event is fired.
         /// @see unregisterCallback.
-        template <class TObj> void registerCallback(TObj* obj, void (TObj::*callback)(TArgs...));
+        template <class TObj>
+        void registerCallback(TObj* obj, void (TObj::*callback)(TArgs...));
 
         /// Unregisters a callback.
         /// @param obj The instance associated with the method callback that should be unregistered.
         /// @param callback The method callback that should be unregistred.
         /// @see registerCallback.
-        template <class TObj> void unregisterCallback(TObj* obj, void (TObj::*callback)(TArgs...));
+        template <class TObj>
+        void unregisterCallback(TObj* obj, void (TObj::*callback)(TArgs...));
 
         /// Fires the event, calling all the callbacks with the passed arguments.
         /// @param args Event arguments.
@@ -62,7 +65,8 @@ namespace cubos::core
             void* obj;
         };
 
-        template <typename TObj> struct ObjectMethodCallback : public MethodCallback
+        template <typename TObj>
+        struct ObjectMethodCallback : public MethodCallback
         {
 
             ObjectMethodCallback(TObj* obj, void (TObj::*callback)(TArgs...));
@@ -77,7 +81,8 @@ namespace cubos::core
         std::vector<MethodCallback*> methodCallbacks;
     };
 
-    template <typename... TArgs> Event<TArgs...>::~Event()
+    template <typename... TArgs>
+    Event<TArgs...>::~Event()
     {
         for (auto& m : this->methodCallbacks)
             delete m;
@@ -91,13 +96,15 @@ namespace cubos::core
         return this->callbacks.size() - 1;
     }
 
-    template <typename... TArgs> void Event<TArgs...>::unregisterCallback(Event<TArgs...>::ID id)
+    template <typename... TArgs>
+    void Event<TArgs...>::unregisterCallback(Event<TArgs...>::ID id)
     {
         auto lock = std::lock_guard<std::mutex>(this->mutex);
         this->callbacks[id] = nullptr;
     }
 
-    template <typename... TArgs> void Event<TArgs...>::fire(TArgs... args) const
+    template <typename... TArgs>
+    void Event<TArgs...>::fire(TArgs... args) const
     {
         auto lock = std::lock_guard<std::mutex>(this->mutex);
         for (auto& callback : this->callbacks)

--- a/core/include/cubos/core/io/context.hpp
+++ b/core/include/cubos/core/io/context.hpp
@@ -26,13 +26,15 @@ namespace cubos::core::io
         /// Get the value stores inside the Context.
         /// Assumes the value stored is of type T.
         /// @return returns the value if stored value is of type T. Otherwise, crashes.
-        template <class T> T getValue();
+        template <class T>
+        T getValue();
 
     private:
         std::variant<float, glm::vec2> value;
     };
 
-    template <class T> T Context::getValue()
+    template <class T>
+    T Context::getValue()
     {
         return std::get<T>(this->value);
     }

--- a/core/include/cubos/core/io/input_manager.hpp
+++ b/core/include/cubos/core/io/input_manager.hpp
@@ -67,7 +67,8 @@ namespace cubos::core::io
         /// @param obj the object owning the method
         /// @param callback the method that will be called when the key is down
         /// @param key the key to trigger the callback
-        template <class T> static void registerKeyDownCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key);
+        template <class T>
+        static void registerKeyDownCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key);
 
         /// Unregisters a key down method callback
         /// @param obj the object owning the method
@@ -92,13 +93,15 @@ namespace cubos::core::io
         /// @param obj the object owning the method
         /// @param callback the method that will be called when the key is released
         /// @param key the key to trigger the callback
-        template <class T> static void registerKeyUpCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key);
+        template <class T>
+        static void registerKeyUpCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key);
 
         /// Unregisters a key up method callback
         /// @param obj the object owning the method
         /// @param callback the method that will be unregistered
         /// @param key the key to unregister the callback
-        template <class T> static void unregisterKeyUpCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key);
+        template <class T>
+        static void unregisterKeyUpCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key);
 
         /// Registers a mouse button down function callback
         /// @param callback the function to call when the mouse button is down
@@ -217,7 +220,8 @@ namespace cubos::core::io
         InputManager::keyDownCallbacks[key]->unregisterCallback<T>(obj, callback);
     }
 
-    template <class T> void InputManager::registerKeyUpCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key)
+    template <class T>
+    void InputManager::registerKeyUpCallback(T* obj, void (T::*callback)(), cubos::core::io::Key key)
     {
         if (!InputManager::keyUpCallbacks.contains(key))
         {

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -72,7 +72,8 @@ requires(cubos::core::data::TriviallySerializable<T> && !std::is_pointer_v<T> &&
         return it;
     }
 
-    template <typename FormatContext> auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out())
+    template <typename FormatContext>
+    auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out())
     {
         auto stream = cubos::core::memory::BufferStream(32);
         cubos::core::data::DebugSerializer serializer(stream, this->pretty, this->types);

--- a/core/include/cubos/core/memory/endianness.hpp
+++ b/core/include/cubos/core/memory/endianness.hpp
@@ -7,7 +7,8 @@ namespace cubos::core::memory
     /// @tparam T The type of the value.
     /// @param value The value to swap.
     /// @return The swapped value.
-    template <typename T> T swapBytes(T value);
+    template <typename T>
+    T swapBytes(T value);
 
     /// Checks if the current platform is little endian.
     /// @return True if the current platform is little endian, false otherwise.
@@ -17,29 +18,34 @@ namespace cubos::core::memory
     /// @tparam T The type of the value.
     /// @param value The value to convert.
     /// @return The converted value.
-    template <typename T> T fromLittleEndian(T value);
+    template <typename T>
+    T fromLittleEndian(T value);
 
     /// Converts a value from local endianness to little endianness.
     /// @tparam T The type of the value.
     /// @param value The value to convert.
     /// @return The converted value.
-    template <typename T> T toLittleEndian(T value);
+    template <typename T>
+    T toLittleEndian(T value);
 
     /// Converts a value from big endianness to local endianness.
     /// @tparam T The type of the value.
     /// @param value The value to convert.
     /// @return The converted value.
-    template <typename T> T fromBigEndian(T value);
+    template <typename T>
+    T fromBigEndian(T value);
 
     /// Converts a value from local endianness to big endianness.
     /// @tparam T The type of the value.
     /// @param value The value to convert.
     /// @return The converted value.
-    template <typename T> T toBigEndian(T value);
+    template <typename T>
+    T toBigEndian(T value);
 
     // Implementation.
 
-    template <typename T> inline T swapBytes(T value)
+    template <typename T>
+    inline T swapBytes(T value)
     {
         union {
             T value;
@@ -58,22 +64,26 @@ namespace cubos::core::memory
         return *reinterpret_cast<char*>(&i) == 1;
     }
 
-    template <typename T> inline T fromLittleEndian(T value)
+    template <typename T>
+    inline T fromLittleEndian(T value)
     {
         return isLittleEndian() ? value : swapBytes(value);
     }
 
-    template <typename T> inline T toLittleEndian(T value)
+    template <typename T>
+    inline T toLittleEndian(T value)
     {
         return isLittleEndian() ? value : swapBytes(value);
     }
 
-    template <typename T> inline T fromBigEndian(T value)
+    template <typename T>
+    inline T fromBigEndian(T value)
     {
         return isLittleEndian() ? swapBytes(value) : value;
     }
 
-    template <typename T> inline T toBigEndian(T value)
+    template <typename T>
+    inline T toBigEndian(T value)
     {
         return isLittleEndian() ? swapBytes(value) : value;
     }

--- a/core/include/cubos/core/memory/stream.hpp
+++ b/core/include/cubos/core/memory/stream.hpp
@@ -123,7 +123,8 @@ namespace cubos::core::memory
         /// @tparam TArgs The types of the remaining arguments.
         /// @param arg First argument to print.
         /// @param args The arguments to print.
-        template <typename T, typename... TArgs> void printf(const char* fmt, T arg, TArgs... args);
+        template <typename T, typename... TArgs>
+        void printf(const char* fmt, T arg, TArgs... args);
 
         /// Formatted print recursion tail function.
         /// @param fmt The remainder format string.
@@ -208,7 +209,8 @@ namespace cubos::core::memory
         this->print(static_cast<uint64_t>(value), base);
     }
 
-    template <typename T, typename... TArgs> void Stream::printf(const char* fmt, T arg, TArgs... args)
+    template <typename T, typename... TArgs>
+    void Stream::printf(const char* fmt, T arg, TArgs... args)
     {
         for (;; ++fmt)
         {

--- a/core/src/cubos/core/data/binary_deserializer.cpp
+++ b/core/src/cubos/core/data/binary_deserializer.cpp
@@ -5,7 +5,8 @@
 using namespace cubos::core;
 using namespace cubos::core::data;
 
-template <typename T> static inline T fromEndianness(T val, bool fromLittleEndian)
+template <typename T>
+static inline T fromEndianness(T val, bool fromLittleEndian)
 {
     if (fromLittleEndian)
         return memory::fromLittleEndian(val);

--- a/core/src/cubos/core/data/binary_serializer.cpp
+++ b/core/src/cubos/core/data/binary_serializer.cpp
@@ -4,7 +4,8 @@
 using namespace cubos::core;
 using namespace cubos::core::data;
 
-template <typename T> static inline T toEndianness(T val, bool toLittleEndian)
+template <typename T>
+static inline T toEndianness(T val, bool toLittleEndian)
 {
     if (toLittleEndian)
         return memory::toLittleEndian(val);

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -42,19 +42,22 @@ namespace cubos::engine
         /// @tparam TArgs The types of the arguments passed to the resource's constructor.
         /// @param args The arguments passed to the resource's constructor.
         /// @return Reference to this object, for chaining.
-        template <typename R, typename... TArgs> Cubos& addResource(TArgs... args);
+        template <typename R, typename... TArgs>
+        Cubos& addResource(TArgs... args);
 
         /// Adds a new component type to the engine.
         /// @tparam C The type of the component.
         /// @return Reference to this object, for chaining.
-        template <typename C> Cubos& addComponent();
+        template <typename C>
+        Cubos& addComponent();
 
         /// Adds a new system to the engine, which will be executed every iteration of the main loop.
         /// If the stage doesn't already exist, it is created in the previously specified default position.
         /// @tparam F The type of the system function.
         /// @param func The system function.
         /// @param stage The stage in which the system should be executed.
-        template <typename F> Cubos& addSystem(F func, std::string stage);
+        template <typename F>
+        Cubos& addSystem(F func, std::string stage);
 
         /// Adds a new startup system to the engine.
         /// Startup systems are executed before the main loop starts.
@@ -62,7 +65,8 @@ namespace cubos::engine
         /// @tparam F The type of the system function.
         /// @param func The system function.
         /// @param stage The stage in which the system should be executed.
-        template <typename F> Cubos& addStartupSystem(F func, std::string stage);
+        template <typename F>
+        Cubos& addStartupSystem(F func, std::string stage);
 
         /// Sets a given stage to happen after another stage.
         /// The current stage must exist, but the reference stage may not, in which case it
@@ -91,26 +95,30 @@ namespace cubos::engine
 
     // Implementation.
 
-    template <typename R, typename... TArgs> Cubos& Cubos::addResource(TArgs... args)
+    template <typename R, typename... TArgs>
+    Cubos& Cubos::addResource(TArgs... args)
     {
         world.registerResource<R>(args...);
         return *this;
     }
 
-    template <typename C> Cubos& Cubos::addComponent()
+    template <typename C>
+    Cubos& Cubos::addComponent()
     {
         world.registerComponent<C>();
         return *this;
     }
 
-    template <typename F> Cubos& Cubos::addSystem(F func, std::string stage)
+    template <typename F>
+    Cubos& Cubos::addSystem(F func, std::string stage)
     {
         mainDispatcher.addSystem(func, stage);
         isStartupStage = false;
         return *this;
     }
 
-    template <typename F> Cubos& Cubos::addStartupSystem(F func, std::string stage)
+    template <typename F>
+    Cubos& Cubos::addStartupSystem(F func, std::string stage)
     {
         startupDispatcher.addSystem(func, stage);
         isStartupStage = true;

--- a/engine/include/cubos/engine/data/asset_manager.hpp
+++ b/engine/include/cubos/engine/data/asset_manager.hpp
@@ -64,7 +64,7 @@ namespace cubos::engine::data
         template <typename T>
         requires IsAsset<T> Asset<T> store(const std::string& id, Usage usage, T&& data);
 
-    private :
+    private:
         /// Stores runtime information about an asset.
         struct Info
         {

--- a/engine/include/cubos/engine/gl/pps/manager.hpp
+++ b/engine/include/cubos/engine/gl/pps/manager.hpp
@@ -46,7 +46,8 @@ namespace cubos::engine::gl::pps
         /// Adds a pass to the manager.
         /// @tparam T The type of the pass to add.
         /// @return The ID of the pass.
-        template <typename T> size_t addPass();
+        template <typename T>
+        size_t addPass();
 
         /// Removes a pass from the manager.
         /// @param id The ID of the pass.
@@ -73,7 +74,8 @@ namespace cubos::engine::gl::pps
 
     // Implementation.
 
-    template <typename T> size_t Manager::addPass()
+    template <typename T>
+    size_t Manager::addPass()
     {
         size_t id = this->nextId++;
         this->passes[id] = new T(this->renderDevice, this->size);


### PR DESCRIPTION
Added `AlwaysBreakTemplateDeclarations` to `.clang-format`
This setting allows to format template definitions on a separate line from function signatures, see #259.

The **whole source code needs to be updated**, not sure if we do that on a separate commit or we finish #219 and then the job is done via the action ... (?)