### PR TITLE
Fix ImGui samples

### DIFF
--- a/engine/src/cubos/engine/plugins/imgui.cpp
+++ b/engine/src/cubos/engine/plugins/imgui.cpp
@@ -2,19 +2,28 @@
 #include <cubos/engine/plugins/window.hpp>
 #include <cubos/core/ui/imgui.hpp>
 
-static void initializeImGui(const cubos::core::io::Window& window)
+using namespace cubos::core;
+
+static void initializeImGui(const io::Window& window)
 {
-    cubos::core::ui::initialize(window);
+    ui::initialize(window);
 }
 
-static void beginImGuiFrame()
+static void beginImGuiFrame(ecs::EventReader<io::WindowEvent> events)
 {
-    cubos::core::ui::beginFrame();
+    // Pass window events to ImGui.
+    // TODO: handleEvent returns a bool indicating if the event was handled or not.
+    //       This will be used to stop propagating the event to other systems when
+    //       the mouse is over an ImGui window.
+    //       Not sure how we will propagate that information to other systems yet.
+    for (auto event : events)
+        ui::handleEvent(event);
+    ui::beginFrame();
 }
 
 static void endImGuiFrame()
 {
-    cubos::core::ui::endFrame();
+    ui::endFrame();
 }
 
 void cubos::engine::plugins::imguiPlugin(Cubos& cubos)

--- a/engine/src/cubos/engine/plugins/window.cpp
+++ b/engine/src/cubos/engine/plugins/window.cpp
@@ -1,20 +1,20 @@
 #include <cubos/engine/plugins/window.hpp>
 #include <cubos/core/settings.hpp>
 
-static void startup(cubos::core::io::Window& window, ShouldQuit& quit, const cubos::core::Settings& settings)
+using namespace cubos::core;
+
+static void startup(io::Window& window, ShouldQuit& quit, const Settings& settings)
 {
     quit.value = false;
-    window = cubos::core::io::openWindow(
-        settings.getString("window.title", "Cubos"),
-        {settings.getInteger("window.width", 800), settings.getInteger("window.height", 600)});
+    window = io::openWindow(settings.getString("window.title", "Cubos"),
+                            {settings.getInteger("window.width", 800), settings.getInteger("window.height", 600)});
 }
 
-static void pollSystem(const cubos::core::io::Window& window, ShouldQuit& quit)
+static void pollSystem(const io::Window& window, ShouldQuit& quit, ecs::EventWriter<io::WindowEvent> events)
 {
+    // Send window events to other systems.
     while (auto event = window->pollEvent())
-    {
-        // TODO: when event pipes get merged, this should be changed to use them.
-    }
+        events.push(event.value());
 
     if (window->shouldClose())
     {
@@ -22,14 +22,15 @@ static void pollSystem(const cubos::core::io::Window& window, ShouldQuit& quit)
     }
 }
 
-static void swapBuffersSystem(const cubos::core::io::Window& window)
+static void swapBuffersSystem(const io::Window& window)
 {
     window->swapBuffers();
 }
 
 void cubos::engine::plugins::windowPlugin(Cubos& cubos)
 {
-    cubos.addResource<cubos::core::io::Window>();
+    cubos.addResource<io::Window>();
+    cubos.addEvent<io::WindowEvent>();
 
     cubos.startupSystem(startup).tagged("OpenWindow");
 


### PR DESCRIPTION
Closes #285.

After merging #297, the ImGui samples have stopped working. This happened because #202 had not been finished yet and we couldn't communicate the events from the window plugin to the ImGui plugin.
