### PR TITLE
Fix macOS CI compilation

### DIFF
--- a/.github/workflows/build-engine-macos.yml
+++ b/.github/workflows/build-engine-macos.yml
@@ -21,7 +21,7 @@ jobs:
         
     - name: Install dependencies
       run: |
-        brew install glfw
+        brew install glfw llvm@14
 
     - name: Configure CMake
       run: CC=$(brew --prefix llvm@14)/bin/clang CXX=$(brew --prefix llvm@14)/bin/clang++ cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DGLFW_USE_SUBMODULE=OFF -DBUILD_CORE_SAMPLES=ON -DBUILD_CORE_TESTS=ON


### PR DESCRIPTION
macOS image [was updated](https://github.com/actions/runner-images/releases/tag/macOS-12%2F20230117.3) and the default version is now 15, so we install v14 with brew before.