### PR TITLE
Implement tag inheritance

### DIFF
--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -121,9 +121,10 @@ namespace cubos::core::ecs
         /// Internal class with settings pertaining to system/tag execution
         struct SystemSettings
         {
+            void copyFrom(const SystemSettings& other);
+
             Dependency before, after;
             // TODO: Add run conditions, threading modes, etc...
-            // TODO: Implement inherithance behavior
             std::vector<std::string> inherits;
         };
 
@@ -132,6 +133,7 @@ namespace cubos::core::ecs
         {
             std::shared_ptr<SystemSettings> settings;
             std::shared_ptr<AnySystemWrapper<void>> system;
+            std::string tag;
         };
 
         /// Internal class used to implement a DFS algorithm for call chain compilation
@@ -152,6 +154,11 @@ namespace cubos::core::ecs
         /// @param nodes Array of DFSNodes.
         /// @return True if a cycle was detected, false if otherwise.
         bool dfsVisit(DFSNode& node, std::vector<DFSNode>& nodes);
+
+        /// Copies settings from inherited tags to this system, recursively
+        /// solving nested inheritance.
+        /// @param settings Settings to handle inheritance for.
+        void handleTagInheritance(std::shared_ptr<SystemSettings>& settings);
 
         /// Variables for holding information before call chain is compiled.
         std::vector<System> pendingSystems;                                 ///< All systems.

--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -178,14 +178,14 @@ namespace cubos::core::ecs
 
         /// Variables for holding information after call chain is compiled.
         std::vector<System*> systems; ///< Compiled order of running systems.
-        bool prepared = false;       ///< Whether the systems are prepared for execution.
+        bool prepared = false;        ///< Whether the systems are prepared for execution.
     };
 
     template <typename F>
     void Dispatcher::addSystem(F func)
     {
         // Wrap the system and put it in the pending queue
-        System* system = new System {nullptr, std::make_shared<SystemWrapper<F>>(func)};
+        System* system = new System{nullptr, std::make_shared<SystemWrapper<F>>(func)};
         pendingSystems.push_back(system);
         currSystem = pendingSystems.back();
     }

--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -51,6 +51,8 @@ namespace cubos::core::ecs
     class Dispatcher
     {
     public:
+        ~Dispatcher();
+
         /// Adds a tag, and sets it as the current tag for further
         /// settings.
         /// @param tag Tag to add.
@@ -175,7 +177,7 @@ namespace cubos::core::ecs
         std::string currTag;                                                ///< Last set tag, for changing settings.
 
         /// Variables for holding information after call chain is compiled.
-        std::vector<System> systems; ///< Compiled order of running systems.
+        std::vector<System*> systems; ///< Compiled order of running systems.
         bool prepared = false;       ///< Whether the systems are prepared for execution.
     };
 

--- a/core/src/cubos/core/ecs/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/dispatcher.cpp
@@ -6,19 +6,15 @@ using namespace cubos::core::ecs;
 
 void Dispatcher::SystemSettings::copyFrom(const SystemSettings* other)
 {
-    std::unique_copy(other->before.tag.begin(), other->before.tag.end(),
-                    std::back_inserter(this->before.tag));
-    std::unique_copy(other->after.tag.begin(), other->after.tag.end(),
-                    std::back_inserter(this->after.tag));
-    std::unique_copy(other->before.system.begin(), other->before.system.end(),
-                    std::back_inserter(this->before.system));
-    std::unique_copy(other->after.system.begin(), other->after.system.end(),
-                    std::back_inserter(this->after.system));
+    std::unique_copy(other->before.tag.begin(), other->before.tag.end(), std::back_inserter(this->before.tag));
+    std::unique_copy(other->after.tag.begin(), other->after.tag.end(), std::back_inserter(this->after.tag));
+    std::unique_copy(other->before.system.begin(), other->before.system.end(), std::back_inserter(this->before.system));
+    std::unique_copy(other->after.system.begin(), other->after.system.end(), std::back_inserter(this->after.system));
 }
 
 Dispatcher::~Dispatcher()
 {
-    for(System* system : systems)
+    for (System* system : systems)
     {
         delete system;
     }
@@ -113,7 +109,7 @@ void Dispatcher::compileChain()
     // Implement system tag settings with custom settings
     for (System* system : pendingSystems)
     {
-        if(!system->tag.empty())
+        if (!system->tag.empty())
         {
             if (!system->settings)
             {

--- a/core/src/cubos/core/ecs/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/dispatcher.cpp
@@ -16,6 +16,14 @@ void Dispatcher::SystemSettings::copyFrom(const SystemSettings* other)
                     std::back_inserter(this->after.system));
 }
 
+Dispatcher::~Dispatcher()
+{
+    for(System* system : systems)
+    {
+        delete system;
+    }
+}
+
 void Dispatcher::addTag(const std::string& tag)
 {
     ENSURE_TAG_SETTINGS(tag);
@@ -190,7 +198,7 @@ bool Dispatcher::dfsVisit(DFSNode& node, std::vector<DFSNode>& nodes)
         }
         // All children nodes were visited; mark this node as complete
         node.m = DFSNode::BLACK;
-        systems.push_back(*systemInfo);
+        systems.push_back(systemInfo);
         return false;
     }
     }
@@ -204,13 +212,13 @@ void Dispatcher::callSystems(World& world, CommandBuffer& cmds)
     if (!this->prepared)
     {
         for (auto& system : systems)
-            system.system->prepare(world);
+            system->system->prepare(world);
         this->prepared = true;
     }
 
-    for (auto it = systems.begin(); it != systems.end(); it++)
+    for (auto& system : systems)
     {
-        it->system->call(world, cmds);
+        system->system->call(world, cmds);
         // TODO: Check synchronization concerns when this gets multithreaded
         cmds.commit();
     }

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -30,7 +30,6 @@ namespace cubos::engine
     {
     public:
         TagBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags);
-        ~TagBuilder() = delete;
 
         /// Sets the current tag to be executed before another tag.
         /// @param tag The tag to be executed before.
@@ -50,7 +49,6 @@ namespace cubos::engine
     {
     public:
         SystemBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags);
-        ~SystemBuilder() = delete;
 
         /// Sets the current system's tag.
         /// @param tag The tag to be set.
@@ -118,19 +116,19 @@ namespace cubos::engine
         /// Sets the current tag for the main dispatcher. If the tag doesn't exist, it will be created.
         /// @param tag The tag to set.
         /// @return Tag builder used to configure the tag.
-        TagBuilder& tag(const std::string& tag);
+        TagBuilder tag(const std::string& tag);
 
         /// Sets the current tag for the startup dispatcher. If the tag doesn't exist, it will be created.
         /// @param tag The tag to set.
         /// @return Tag builder used to configure the tag.
-        TagBuilder& startupTag(const std::string& tag);
+        TagBuilder startupTag(const std::string& tag);
 
         /// Adds a new system to the engine, which will be executed at every iteration of the main loop.
         /// @tparam F The type of the system function.
         /// @param func The system function.
         /// @return System builder used to configure the system.
         template <typename F>
-        SystemBuilder& system(F func);
+        SystemBuilder system(F func);
 
         /// Adds a new startup system to the engine.
         /// Startup systems are executed only once, before the main loop starts.
@@ -138,7 +136,7 @@ namespace cubos::engine
         /// @param func The system function.
         /// @return System builder used to configure the system.
         template <typename F>
-        SystemBuilder& startupSystem(F func);
+        SystemBuilder startupSystem(F func);
 
         /// Runs the engine.
         void run();
@@ -189,21 +187,21 @@ namespace cubos::engine
     }
 
     template <typename F>
-    SystemBuilder& Cubos::system(F func)
+    SystemBuilder Cubos::system(F func)
     {
         mainDispatcher.addSystem(func);
-        SystemBuilder* builder = new SystemBuilder(mainDispatcher, startupTags);
+        SystemBuilder builder(mainDispatcher, startupTags);
 
-        return *builder;
+        return builder;
     }
 
     template <typename F>
-    SystemBuilder& Cubos::startupSystem(F func)
+    SystemBuilder Cubos::startupSystem(F func)
     {
         startupDispatcher.addSystem(func);
-        SystemBuilder* builder = new SystemBuilder(startupDispatcher, mainTags);
+        SystemBuilder builder(startupDispatcher, mainTags);
 
-        return *builder;
+        return builder;
     }
 } // namespace cubos::engine
 

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -29,7 +29,7 @@ namespace cubos::engine
     class TagBuilder
     {
     public:
-        TagBuilder(core::ecs::Dispatcher& dispatcher);
+        TagBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags);
         ~TagBuilder() = delete;
 
         /// Sets the current tag to be executed before another tag.
@@ -42,13 +42,14 @@ namespace cubos::engine
 
     private:
         core::ecs::Dispatcher& dispatcher;
+        std::vector<std::string>& tags;
     };
 
     /// Used to chain configurations related to systems
     class SystemBuilder
     {
     public:
-        SystemBuilder(core::ecs::Dispatcher& dispatcher);
+        SystemBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags);
         ~SystemBuilder() = delete;
 
         /// Sets the current system's tag.
@@ -75,6 +76,7 @@ namespace cubos::engine
 
     private:
         core::ecs::Dispatcher& dispatcher;
+        std::vector<std::string>& tags;
     };
 
     /// Represents the engine itself, and exposes the interface with which the game developer interacts with.
@@ -145,6 +147,7 @@ namespace cubos::engine
         core::ecs::Dispatcher mainDispatcher, startupDispatcher;
         core::ecs::World world;
         std::set<void (*)(Cubos&)> plugins;
+        std::vector<std::string> mainTags, startupTags;
     };
 
     // Implementation.
@@ -189,7 +192,7 @@ namespace cubos::engine
     SystemBuilder& Cubos::system(F func)
     {
         mainDispatcher.addSystem(func);
-        SystemBuilder* builder = new SystemBuilder(mainDispatcher);
+        SystemBuilder* builder = new SystemBuilder(mainDispatcher, startupTags);
 
         return *builder;
     }
@@ -198,7 +201,7 @@ namespace cubos::engine
     SystemBuilder& Cubos::startupSystem(F func)
     {
         startupDispatcher.addSystem(func);
-        SystemBuilder* builder = new SystemBuilder(startupDispatcher);
+        SystemBuilder* builder = new SystemBuilder(startupDispatcher, mainTags);
 
         return *builder;
     }

--- a/engine/samples/systems/main.cpp
+++ b/engine/samples/systems/main.cpp
@@ -26,6 +26,16 @@ void systemC()
     CUBOS_INFO("[By System] C");
 }
 
+void systemInherit1()
+{
+    CUBOS_INFO("[By System] Inheritance 1");
+}
+
+void systemInherit2()
+{
+    CUBOS_INFO("[By System] Inheritance 2");
+}
+
 int main(int argc, char** argv)
 {
     cubos::engine::Cubos cubos;
@@ -43,6 +53,10 @@ int main(int argc, char** argv)
     // Now add a lambda between both systems to test
     auto lambda = []() { CUBOS_INFO("--- INTERMISSION ---"); };
     cubos.startupSystem(lambda).afterSystem(tagC);
+
+    // System inheritance
+    //cubos.startupSystem(systemInherit1);
+    //cubos.startupSystem(systemInherit2).tagged("B").afterSystem(systemInherit1);
 
     cubos.run();
 }

--- a/engine/samples/systems/main.cpp
+++ b/engine/samples/systems/main.cpp
@@ -49,7 +49,6 @@ int main(int argc, char** argv)
     cubos.startupSystem(tagC).tagged("C");
     cubos.startupSystem(tagA).tagged("A");
 
-
     // Order using systems
     cubos.startupSystem(systemC);
     cubos.startupSystem(systemA).beforeSystem(systemC).afterTag("C");

--- a/engine/samples/systems/main.cpp
+++ b/engine/samples/systems/main.cpp
@@ -40,23 +40,31 @@ int main(int argc, char** argv)
 {
     cubos::engine::Cubos cubos;
 
+    cubos.startupTag("B").beforeTag("C");
+    cubos.startupTag("C").afterTag("A");
+    cubos.startupTag("A");
+
     // Order using tags
-    cubos.startupSystem(tagB).tagged("B").beforeTag("C");
-    cubos.startupSystem(tagC).tagged("C").afterTag("A");
+    cubos.startupSystem(tagB).tagged("B");
+    cubos.startupSystem(tagC).tagged("C");
     cubos.startupSystem(tagA).tagged("A");
+
 
     // Order using systems
     cubos.startupSystem(systemC);
-    cubos.startupSystem(systemA).beforeSystem(systemC).afterSystem(tagC);
+    cubos.startupSystem(systemA).beforeSystem(systemC).afterTag("C");
     cubos.startupSystem(systemB).afterSystem(systemA);
 
-    // Now add a lambda between both systems to test
+    // Lambda between systems and tags
     auto lambda = []() { CUBOS_INFO("--- INTERMISSION ---"); };
-    cubos.startupSystem(lambda).afterSystem(tagC);
+    cubos.startupSystem(lambda).afterTag("C").beforeSystem(systemA);
 
     // System inheritance
-    //cubos.startupSystem(systemInherit1);
-    //cubos.startupSystem(systemInherit2).tagged("B").afterSystem(systemInherit1);
+    cubos.startupSystem(systemInherit1).tagged("A");
+    cubos.startupSystem(systemInherit2).afterTag("B").beforeSystem(systemInherit1);
+
+    // Closed loop. This will prevent chain compilation!
+    // cubos.startupTag("A").afterTag("C");
 
     cubos.run();
 }

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -14,7 +14,8 @@ Arguments::Arguments(const std::vector<std::string>& value) : value(value)
 {
 }
 
-TagBuilder::TagBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags) : dispatcher(dispatcher), tags(tags)
+TagBuilder::TagBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags)
+    : dispatcher(dispatcher), tags(tags)
 {
 }
 
@@ -32,15 +33,17 @@ TagBuilder& TagBuilder::afterTag(const std::string& tag)
     return *this;
 }
 
-SystemBuilder::SystemBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags) : dispatcher(dispatcher), tags(tags)
+SystemBuilder::SystemBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags)
+    : dispatcher(dispatcher), tags(tags)
 {
 }
 
 SystemBuilder& SystemBuilder::tagged(const std::string& tag)
 {
-    if(std::find(tags.begin(), tags.end(), tag) != tags.end())
+    if (std::find(tags.begin(), tags.end(), tag) != tags.end())
     {
-        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ", tag);
+        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ",
+                   tag);
     }
     dispatcher.systemSetTag(tag);
     return *this;
@@ -48,9 +51,10 @@ SystemBuilder& SystemBuilder::tagged(const std::string& tag)
 
 SystemBuilder& SystemBuilder::beforeTag(const std::string& tag)
 {
-    if(std::find(tags.begin(), tags.end(), tag) != tags.end())
+    if (std::find(tags.begin(), tags.end(), tag) != tags.end())
     {
-        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ", tag);
+        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ",
+                   tag);
     }
     dispatcher.systemSetBeforeTag(tag);
     return *this;
@@ -58,9 +62,10 @@ SystemBuilder& SystemBuilder::beforeTag(const std::string& tag)
 
 SystemBuilder& SystemBuilder::afterTag(const std::string& tag)
 {
-    if(std::find(tags.begin(), tags.end(), tag) != tags.end())
+    if (std::find(tags.begin(), tags.end(), tag) != tags.end())
     {
-        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ", tag);
+        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ",
+                   tag);
     }
     dispatcher.systemSetAfterTag(tag);
     return *this;

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -14,40 +14,54 @@ Arguments::Arguments(const std::vector<std::string>& value) : value(value)
 {
 }
 
-TagBuilder::TagBuilder(core::ecs::Dispatcher& dispatcher) : dispatcher(dispatcher)
+TagBuilder::TagBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags) : dispatcher(dispatcher), tags(tags)
 {
 }
 
 TagBuilder& TagBuilder::beforeTag(const std::string& tag)
 {
+    tags.push_back(tag);
     dispatcher.tagSetBeforeTag(tag);
     return *this;
 }
 
 TagBuilder& TagBuilder::afterTag(const std::string& tag)
 {
+    tags.push_back(tag);
     dispatcher.tagSetAfterTag(tag);
     return *this;
 }
 
-SystemBuilder::SystemBuilder(core::ecs::Dispatcher& dispatcher) : dispatcher(dispatcher)
+SystemBuilder::SystemBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags) : dispatcher(dispatcher), tags(tags)
 {
 }
 
 SystemBuilder& SystemBuilder::tagged(const std::string& tag)
 {
+    if(std::find(tags.begin(), tags.end(), tag) != tags.end())
+    {
+        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ", tag);
+    }
     dispatcher.systemSetTag(tag);
     return *this;
 }
 
 SystemBuilder& SystemBuilder::beforeTag(const std::string& tag)
 {
+    if(std::find(tags.begin(), tags.end(), tag) != tags.end())
+    {
+        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ", tag);
+    }
     dispatcher.systemSetBeforeTag(tag);
     return *this;
 }
 
 SystemBuilder& SystemBuilder::afterTag(const std::string& tag)
 {
+    if(std::find(tags.begin(), tags.end(), tag) != tags.end())
+    {
+        CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ", tag);
+    }
     dispatcher.systemSetAfterTag(tag);
     return *this;
 }
@@ -69,7 +83,7 @@ Cubos& Cubos::addPlugin(void (*func)(Cubos&))
 TagBuilder& Cubos::tag(const std::string& tag)
 {
     mainDispatcher.addTag(tag);
-    TagBuilder* builder = new TagBuilder(mainDispatcher);
+    TagBuilder* builder = new TagBuilder(mainDispatcher, mainTags);
 
     return *builder;
 }
@@ -77,7 +91,7 @@ TagBuilder& Cubos::tag(const std::string& tag)
 TagBuilder& Cubos::startupTag(const std::string& tag)
 {
     startupDispatcher.addTag(tag);
-    TagBuilder* builder = new TagBuilder(startupDispatcher);
+    TagBuilder* builder = new TagBuilder(startupDispatcher, startupTags);
 
     return *builder;
 }
@@ -102,6 +116,8 @@ Cubos::Cubos(int argc, char** argv)
 void Cubos::run()
 {
     plugins.clear();
+    mainTags.clear();
+    startupTags.clear();
 
     // Compile execution chain
     startupDispatcher.compileChain();

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -80,20 +80,20 @@ Cubos& Cubos::addPlugin(void (*func)(Cubos&))
     return *this;
 }
 
-TagBuilder& Cubos::tag(const std::string& tag)
+TagBuilder Cubos::tag(const std::string& tag)
 {
     mainDispatcher.addTag(tag);
-    TagBuilder* builder = new TagBuilder(mainDispatcher, mainTags);
+    TagBuilder builder(mainDispatcher, mainTags);
 
-    return *builder;
+    return builder;
 }
 
-TagBuilder& Cubos::startupTag(const std::string& tag)
+TagBuilder Cubos::startupTag(const std::string& tag)
 {
     startupDispatcher.addTag(tag);
-    TagBuilder* builder = new TagBuilder(startupDispatcher, startupTags);
+    TagBuilder builder(startupDispatcher, startupTags);
 
-    return *builder;
+    return builder;
 }
 
 Cubos::Cubos()


### PR DESCRIPTION
Closes #292 

Implement proper tag inheritance, which was left to do after the initial dispatcher rework.

Other than that, I found some bugs on the dispatcher along the way that were fixed. I also introduced a warning when users use tags from opposite system types:
```cpp
cubos.tag("A"); // Main tag
cubos.startupSystem(a).tagged("A"); // Startup system, tag mismatch
```