### PR TITLE
Allow multiple system tags and cleanup existing plugin code

### DIFF
--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -143,7 +143,7 @@ namespace cubos::core::ecs
         {
             std::shared_ptr<SystemSettings> settings;
             std::shared_ptr<AnySystemWrapper<void>> system;
-            std::vector<std::string> tags;
+            std::unordered_set<std::string> tags;
         };
 
         /// Internal class used to implement a DFS algorithm for call chain compilation

--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -80,7 +80,7 @@ namespace cubos::core::ecs
 
         /// Sets the tag for the current system.
         /// @param tag The tag to run under.
-        void systemSetTag(const std::string& tag);
+        void systemAddTag(const std::string& tag);
 
         /// Sets the current system to run after the tag.
         /// If the specified tag doesn't exist, it is internally created.
@@ -143,7 +143,7 @@ namespace cubos::core::ecs
         {
             std::shared_ptr<SystemSettings> settings;
             std::shared_ptr<AnySystemWrapper<void>> system;
-            std::string tag;
+            std::vector<std::string> tags;
         };
 
         /// Internal class used to implement a DFS algorithm for call chain compilation

--- a/core/samples/ecs.cpp
+++ b/core/samples/ecs.cpp
@@ -165,24 +165,24 @@ int main()
     auto cmds = ecs::CommandBuffer(world);
     dispatcher.addTag("Main");
     dispatcher.addSystem(mySystem);
-    dispatcher.systemSetTag("Main");
+    dispatcher.systemAddTag("Main");
 
     dispatcher.addTag("Transform");
     dispatcher.tagSetAfterTag("Main");
     dispatcher.addSystem(printPositions);
-    dispatcher.systemSetTag("Transform");
+    dispatcher.systemAddTag("Transform");
 
     dispatcher.addTag("New");
     dispatcher.tagSetAfterTag("Main");
     dispatcher.addSystem(printPlayerPosition);
-    dispatcher.systemSetTag("New");
+    dispatcher.systemAddTag("New");
 
     dispatcher.addTag("PreProcess");
     dispatcher.tagSetBeforeTag("Main");
     dispatcher.tagSetBeforeTag("Transform");
     dispatcher.addSystem(
         [](const DeltaTime& dt, MyResource& res) { std::cout << "lambda: " << dt.dt << " " << res.val << std::endl; });
-    dispatcher.systemSetTag("PreProcess");
+    dispatcher.systemAddTag("PreProcess");
 
     dispatcher.compileChain();
     // call systems on dispatcher

--- a/core/src/cubos/core/ecs/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/dispatcher.cpp
@@ -58,11 +58,11 @@ void Dispatcher::tagSetBeforeTag(const std::string& tag)
     tagSettings[tag]->after.tag.push_back(currTag);
 }
 
-void Dispatcher::systemSetTag(const std::string& tag)
+void Dispatcher::systemAddTag(const std::string& tag)
 {
     ENSURE_CURR_SYSTEM();
     ENSURE_TAG_SETTINGS(tag);
-    currSystem->tag = tag;
+    currSystem->tags.push_back(tag);
 }
 
 void Dispatcher::systemSetAfterTag(const std::string& tag)
@@ -109,13 +109,13 @@ void Dispatcher::compileChain()
     // Implement system tag settings with custom settings
     for (System* system : pendingSystems)
     {
-        if (!system->tag.empty())
+        for (auto& tag : system->tags)
         {
             if (!system->settings)
             {
                 system->settings = std::make_shared<SystemSettings>();
             }
-            system->settings->copyFrom(tagSettings[system->tag].get());
+            system->settings->copyFrom(tagSettings[tag].get());
         }
     }
 
@@ -167,7 +167,7 @@ bool Dispatcher::dfsVisit(DFSNode& node, std::vector<DFSNode>& nodes)
             {
                 for (auto it = nodes.begin(); it != nodes.end(); it++)
                 {
-                    if (it->s->tag == tag)
+                    if (std::find(it->s->tags.begin(), it->s->tags.end(), tag) != it->s->tags.end())
                     {
                         if (dfsVisit(*it, nodes))
                         {

--- a/core/src/cubos/core/ecs/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/dispatcher.cpp
@@ -62,7 +62,7 @@ void Dispatcher::systemAddTag(const std::string& tag)
 {
     ENSURE_CURR_SYSTEM();
     ENSURE_TAG_SETTINGS(tag);
-    currSystem->tags.push_back(tag);
+    currSystem->tags.insert(tag);
 }
 
 void Dispatcher::systemSetAfterTag(const std::string& tag)

--- a/engine/include/cubos/engine/plugins/env_settings.hpp
+++ b/engine/include/cubos/engine/plugins/env_settings.hpp
@@ -7,10 +7,16 @@ using namespace cubos::engine;
 
 namespace cubos::engine::plugins
 {
-    /// Plugin to handle environment settings, provided via command line.
-    /// Arguments resource needs to have been added, otherwise this will crash.
-    /// For this to happen, the command line arguments argc and argv
-    /// from the main function should be provided to Cubos' constructor.
+    /// Plugin to load environment settings, provided via command line.
+    /// Any duplicated setting will be overwritten.
+    ///
+    /// @details This plugin needs the Arguments resource to be defined. The resouce is defined
+    /// when the command line arguments (argc and argv) are provided to the Cubos constructor.
+    ///
+    /// Startup tags:
+    /// - `cubos.settings`: the settings are loaded with this tag.
+    /// - `cubos.settings.base`: the settings are loaded after this tag.
+    ///
     /// @param cubos CUBOS. main class
     void envSettingsPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins

--- a/engine/include/cubos/engine/plugins/env_settings.hpp
+++ b/engine/include/cubos/engine/plugins/env_settings.hpp
@@ -13,7 +13,7 @@ namespace cubos::engine::plugins
     ///
     /// Startup tags:
     /// - `cubos.settings`: the settings are loaded with this tag.
-    /// - `cubos.settings.base`: the settings are loaded after this tag.
+    /// - `cubos.settings.env`: the settings are loaded with this tag.
     ///
     /// @param cubos CUBOS. main class
     void envSettingsPlugin(Cubos& cubos);

--- a/engine/include/cubos/engine/plugins/env_settings.hpp
+++ b/engine/include/cubos/engine/plugins/env_settings.hpp
@@ -3,8 +3,6 @@
 
 #include <cubos/engine/cubos.hpp>
 
-using namespace cubos::engine;
-
 namespace cubos::engine::plugins
 {
     /// Plugin to load environment settings, provided via command line.

--- a/engine/include/cubos/engine/plugins/file_settings.hpp
+++ b/engine/include/cubos/engine/plugins/file_settings.hpp
@@ -5,10 +5,17 @@
 
 namespace cubos::engine::plugins
 {
-    /// Plugin which loads
+    /// Plugin to load settings, provided via a file.
+    /// Any duplicated setting will be overwritten.
     ///
-    /// Startup Stages:
-    /// - readSettings: fills the settings with the options loaded from a file.
+    /// @details The settings file must be a JSON file, located at the path specified by the
+    /// `settings.path` setting. If the setting is not defined, its assumed to be located at
+    /// `./settings.json`. If the file does not exist, the plugin will abort.
+    ///
+    /// Startup tags:
+    /// - `cubos.settings`: the settings are loaded with this tag.
+    /// - `cubos.settings.file`: the settings are loaded with this tag.
+    ///
     /// @param cubos CUBOS. main class
     void fileSettingsPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins

--- a/engine/include/cubos/engine/plugins/file_settings.hpp
+++ b/engine/include/cubos/engine/plugins/file_settings.hpp
@@ -1,11 +1,11 @@
-#ifndef CUBOS_ENGINE_PLUGINS_FILESETTINGS_HPP
-#define CUBOS_ENGINE_PLUGINS_FILESETTINGS_HPP
+#ifndef CUBOS_ENGINE_PLUGINS_FILE_SETTINGS_HPP
+#define CUBOS_ENGINE_PLUGINS_FILE_SETTINGS_HPP
 
 #include <cubos/engine/cubos.hpp>
 
 namespace cubos::engine::plugins
 {
-    /// Plugin to load settings from a file.
+    /// Plugin which loads
     ///
     /// Startup Stages:
     /// - readSettings: fills the settings with the options loaded from a file.
@@ -13,4 +13,4 @@ namespace cubos::engine::plugins
     void fileSettingsPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins
 
-#endif // CUBOS_ENGINE_PLUGINS_FILESETTINGS_HPP
+#endif // CUBOS_ENGINE_PLUGINS_FILE_SETTINGS_HPP

--- a/engine/include/cubos/engine/plugins/imgui.hpp
+++ b/engine/include/cubos/engine/plugins/imgui.hpp
@@ -5,17 +5,24 @@
 
 namespace cubos::engine::plugins
 {
-    /// Plugin that adds ImGui functionalities and allows ImGui windows to be rendered.
+    /// Plugin to initialize and configure ImGui for CUBOS. Tag your ImGui systems with
+    /// `cubos.imgui`.
     ///
-    /// Startup Stages:
-    /// - InitImGui: Initializes the UI window (after OpenWindow stage).
+    /// @details This plugin adds three systems: one to initialize ImGui, one to start a new
+    /// ImGui frame, and one to end and render the ImGui frame. Between the two ImGui frame
+    /// systems, you can add your own ImGui system, with the tag 'cubos.imgui'.
     ///
-    /// Stages:
-    /// - BeginImGuiFrame: Starts a new ImGui frame (after Poll stage).
-    /// - EndImGuiFrame: Ends the ImGui frame (before SwapBuffers stage).
+    /// Dependencies:
+    /// - `windowPlugin`
     ///
-    /// If you want to render your own ImGui component system, the system should run
-    /// between BeginImGuiFrame and EndImGuiFrame.
+    /// Startup tags:
+    /// - `cubos.imgui.init`: initializes the ImGui, after `cubos.window.init`.
+    ///
+    /// Tags:
+    /// - `cubos.imgui.begin`: starts a new ImGui frame (after `cubos.window.poll`).
+    /// - `cubos.imgui.end`: ends the ImGui frame (before `cubos.window.render`).
+    /// - `cubos.imgui`: runs your own ImGui system (between the previous two tags).
+    ///
     /// @param cubos CUBOS. main class
     void imguiPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins

--- a/engine/include/cubos/engine/plugins/renderer.hpp
+++ b/engine/include/cubos/engine/plugins/renderer.hpp
@@ -3,28 +3,46 @@
 
 #include <cubos/engine/cubos.hpp>
 
-#include <glm/glm.hpp>
-#include <cubos/core/gl/render_device.hpp>
 #include <cubos/core/ecs/entity_manager.hpp>
 
 namespace cubos::engine::plugins
 {
-    /// Plugin to create and use a renderer.
-    ///
-    /// Startup Tags:
-    /// - setRenderer: Sets up the renderer.
-    ///
-    /// Tags:
-    /// - CreateDrawList: Creates list of entities to be drawn in a frame.
-    /// - Draw: Draws component's to the renderer's frame.
-    /// @param cubos CUBOS. main class
-    void rendererPlugin(Cubos& cubos);
-
-    /// Resource to contain the current active camera
+    /// Resource to identify the entity which represents the active camera.
     struct ActiveCamera
     {
-        cubos::core::ecs::Entity entity;
+        core::ecs::Entity entity;
     };
+
+    /// Plugin to create and handle the lifecycle of a renderer. It renders all entities with a
+    /// `Grid` and `LocalToWorld` components.
+    ///
+    /// @details This plugin adds three systems: one to initialize the renderer, one to collect the
+    /// frame information and one to draw the frame.
+    ///
+    /// Dependencies:
+    /// - `windowPlugin`
+    /// - `transformPlugin`
+    ///
+    /// Resources:
+    /// - `Renderer`: handle to the renderer.
+    /// - `Frame`: holds the current frame information.
+    /// - `ActiveCamera`: the entity which represents the active camera.
+    ///
+    /// Components:
+    /// - `Grid`: a grid to be rendered. Must be used with `LocalToWorld`.
+    /// - `Camera`: holds camera information. The entity pointed to by `ActiveCamera` must have
+    ///   this component.
+    ///
+    /// Startup tags:
+    /// - `cubos.renderer.init`: initializes the renderer, after `cubos.window.init`.
+    ///
+    /// Tags:
+    /// - `cubos.renderer.frame`: collects the frame information, after `cubos.transform.update`.
+    /// - `cubos.renderer.draw`: renders the frame to the window, after `cubos.renderer.frame`
+    ///   and before `cubos.window.render`.
+    ///
+    /// @param cubos CUBOS. main class
+    void rendererPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins
 
 #endif // CUBOS_ENGINE_PLUGINS_RENDERER_HPP

--- a/engine/include/cubos/engine/plugins/tools/entity_selector.hpp
+++ b/engine/include/cubos/engine/plugins/tools/entity_selector.hpp
@@ -13,7 +13,15 @@ namespace cubos::engine::plugins::tools
         cubos::core::ecs::Entity selection;
     };
 
-    /// Plugin that allows having a singular entity be selected for inspection
+    /// Plugin that provides a resource used to identify the currently selected entity in the
+    /// editor or other tools.
+    ///
+    /// @details This plugin only provides the resource. It is used just to avoid duplicating
+    /// the resource definition in multiple plugins.
+    ///
+    /// Resources:
+    /// - `EntitySelector`: the currently selected entity.
+    ///
     /// @param cubos CUBOS. main class
     void entitySelectorPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins::tools

--- a/engine/include/cubos/engine/plugins/tools/settings_inspector.hpp
+++ b/engine/include/cubos/engine/plugins/tools/settings_inspector.hpp
@@ -7,7 +7,13 @@ using namespace cubos::engine;
 
 namespace cubos::engine::plugins::tools
 {
-    /// Plugin that allows inspecting the current settings
+    /// Plugin that allows inspecting the current settings through a ImGui window.
+    ///
+    /// @details This plugin adds one system, which adds a ImGui window with the current settings.
+    ///
+    /// Dependencies:
+    /// - `imguiPlugin`
+    //
     /// @param cubos CUBOS. main class
     void settingsInspectorPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins::tools

--- a/engine/include/cubos/engine/plugins/transform.hpp
+++ b/engine/include/cubos/engine/plugins/transform.hpp
@@ -3,14 +3,25 @@
 
 #include <cubos/engine/cubos.hpp>
 
-using namespace cubos::engine;
-
 namespace cubos::engine::plugins
 {
-    /// Plugin to create and use transforms.
+    /// Plugin which adds components to represent the transform of an entity.
     ///
-    /// Stages:
-    /// - Transform: Sets the glm matrix for the transforms.
+    /// @details This plugin adds one system, which updates the `LocalToWorld` component of all
+    /// entities with a `LocalTransform` component, taking information from the `Position`,
+    /// `Rotation` and `Scale` components. These three components are optional, and any subset of
+    /// them can be used.
+    ///
+    /// Components:
+    /// - `LocalToWorld`: holds the local to world transform matrix.
+    /// - `Position`: holds the position of the entity.
+    /// - `Rotation`: holds the rotation of the entity.
+    /// - `Scale`: holds the scale of the entity.
+    ///
+    /// Tags:
+    /// - `cubos.transform.update`: updates the `LocalToWorld` components with the information from
+    ///   the `Position`, `Rotation` and `Scale` components.
+    ///
     /// @param cubos CUBOS. main class
     void transformPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins

--- a/engine/include/cubos/engine/plugins/window.hpp
+++ b/engine/include/cubos/engine/plugins/window.hpp
@@ -9,15 +9,29 @@ using namespace cubos::engine;
 
 namespace cubos::engine::plugins
 {
-    /// Plugin to create and handle the lifecycle of a window. This is required
-    /// for showing any visual output to the user.
+    /// Plugin to create and handle the lifecycle of a window. This is required for showing any
+    /// visual output to the user.
     ///
-    /// Startup Stages:
-    /// - openWindow: Opens the window.
+    /// @details This plugin adds three systems: one to open the window, one to poll the window
+    /// for events, and one to swap the window's back buffers. Polled events are written to the
+    /// event pipe as `core::io::WindowEvent`s.
     ///
-    /// Stages:
-    /// - poll: Polls the window for events and handles quit requests.
-    /// - swapBuffers: Swaps the window's back buffers.
+    /// Sets `ShouldQuit` to `true` if the window is closed. The window is created with the
+    /// settings `window.width`, `window.height` and `window.title`.
+    ///
+    /// Events:
+    /// - `core::io::WindowEvent`: events polled from the window.
+    ///
+    /// Resources:
+    /// - `core::io::Window`: the window's handle.
+    ///
+    /// Startup tags:
+    /// - `cubos.window.init`: initializes and opens the window, runs after `cubos.settings`.
+    ///
+    /// Tags:
+    /// - `cubos.window.poll`: polls the window for events.
+    /// - `cubos.window.render`: swaps the window's back buffers.
+    ///
     /// @param cubos CUBOS. main class
     void windowPlugin(Cubos& cubos);
 }; // namespace cubos::engine::plugins

--- a/engine/samples/scene/main.cpp
+++ b/engine/samples/scene/main.cpp
@@ -125,30 +125,22 @@ int main(int argc, char** argv)
     Cubos cubos(argc, argv);
 
     cubos.addPlugin(plugins::envSettingsPlugin);
-    cubos.addPlugin(plugins::windowPlugin);
     cubos.addPlugin(plugins::fileSettingsPlugin);
-
-    cubos.addPlugin(plugins::envSettingsPlugin);
     cubos.addPlugin(plugins::rendererPlugin);
-
-    cubos.addResource<data::AssetManager>().addComponent<Num>().addComponent<Parent>();
-
-    cubos.startupTag("Setup").afterTag("SetRenderer");
-    cubos.startupSystem(setup).tagged("Setup");
-
-    cubos.startupTag("CreateScene").afterTag("Setup");
-    cubos.startupSystem(createScene).tagged("CreateScene");
-    cubos.startupSystem(printStuff).tagged("End");
-
-    // an example of how the imgui plugin can be used to render your own stuff :)
     cubos.addPlugin(plugins::imguiPlugin);
-    cubos.tag("ImGuiExampleWindow").afterTag("BeginImGuiFrame").beforeTag("EndImGuiFrame");
-    cubos.system(imguiExampleWindow).tagged("ImGuiExampleWindow");
-
-    cubos.tag("SetLight").beforeTag("Draw");
-    cubos.system(turnOnLight).tagged("SetLight");
-    // or a tesserato tool!
     cubos.addPlugin(plugins::tools::settingsInspectorPlugin);
+
+    cubos.addResource<data::AssetManager>();
+
+    cubos.addComponent<Num>();
+    cubos.addComponent<Parent>();
+
+    cubos.startupSystem(setup).tagged("setup").afterTag("cubos.renderer.init");
+    cubos.startupSystem(createScene).tagged("create").afterTag("setup");
+    cubos.startupSystem(printStuff).afterTag("create");
+
+    cubos.system(imguiExampleWindow).tagged("cubos.imgui");
+    cubos.system(turnOnLight).beforeTag("cubos.renderer.draw");
 
     cubos.run();
 }

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -45,7 +45,7 @@ SystemBuilder& SystemBuilder::tagged(const std::string& tag)
         CUBOS_WARN("Tag '{}' was defined on opposite system type (normal/startup), possible tag/startupTag mismatch? ",
                    tag);
     }
-    dispatcher.systemSetTag(tag);
+    dispatcher.systemAddTag(tag);
     return *this;
 }
 

--- a/engine/src/cubos/engine/plugins/env_settings.cpp
+++ b/engine/src/cubos/engine/plugins/env_settings.cpp
@@ -29,5 +29,5 @@ static void startup(const Arguments& args, cubos::core::Settings& settings)
 
 void cubos::engine::plugins::envSettingsPlugin(Cubos& cubos)
 {
-    cubos.startupSystem(startup).tagged("cubos.settings").afterTag("cubos.settings.base");
+    cubos.startupSystem(startup).tagged("cubos.settings").tagged("cubos.settings.env");
 }

--- a/engine/src/cubos/engine/plugins/env_settings.cpp
+++ b/engine/src/cubos/engine/plugins/env_settings.cpp
@@ -26,5 +26,5 @@ static void startup(const Arguments& args, cubos::core::Settings& settings)
 
 void cubos::engine::plugins::envSettingsPlugin(Cubos& cubos)
 {
-    cubos.startupSystem(startup).tagged("Settings");
+    cubos.startupSystem(startup).tagged("cubos.settings").afterTag("cubos.settings.base");
 }

--- a/engine/src/cubos/engine/plugins/env_settings.cpp
+++ b/engine/src/cubos/engine/plugins/env_settings.cpp
@@ -1,5 +1,8 @@
-#include <cubos/core/settings.hpp>
 #include <cubos/engine/plugins/env_settings.hpp>
+
+#include <cubos/core/settings.hpp>
+
+using namespace cubos::engine;
 
 static void startup(const Arguments& args, cubos::core::Settings& settings)
 {

--- a/engine/src/cubos/engine/plugins/file_settings.cpp
+++ b/engine/src/cubos/engine/plugins/file_settings.cpp
@@ -27,5 +27,5 @@ static void startup(cubos::core::Settings& settings)
 
 void cubos::engine::plugins::fileSettingsPlugin(Cubos& cubos)
 {
-    cubos.startupSystem(startup).tagged("Settings");
+    cubos.startupSystem(startup).tagged("cubos.settings").tagged("cubos.settings.file");
 }

--- a/engine/src/cubos/engine/plugins/imgui.cpp
+++ b/engine/src/cubos/engine/plugins/imgui.cpp
@@ -4,12 +4,12 @@
 
 using namespace cubos::core;
 
-static void initializeImGui(const io::Window& window)
+static void init(const io::Window& window)
 {
     ui::initialize(window);
 }
 
-static void beginImGuiFrame(ecs::EventReader<io::WindowEvent> events)
+static void begin(ecs::EventReader<io::WindowEvent> events)
 {
     // Pass window events to ImGui.
     // TODO: handleEvent returns a bool indicating if the event was handled or not.
@@ -21,7 +21,7 @@ static void beginImGuiFrame(ecs::EventReader<io::WindowEvent> events)
     ui::beginFrame();
 }
 
-static void endImGuiFrame()
+static void end()
 {
     ui::endFrame();
 }
@@ -30,15 +30,12 @@ void cubos::engine::plugins::imguiPlugin(Cubos& cubos)
 {
     cubos.addPlugin(cubos::engine::plugins::windowPlugin);
 
-    cubos.startupTag("InitImGui").afterTag("OpenWindow");
+    cubos.startupTag("cubos.imgui.init").afterTag("cubos.window.init");
+    cubos.tag("cubos.imgui.begin").afterTag("cubos.window.poll");
+    cubos.tag("cubos.imgui.end").beforeTag("cubos.window.render").afterTag("cubos.imgui.begin");
+    cubos.tag("cubos.imgui").afterTag("cubos.imgui.begin").beforeTag("cubos.imgui.end");
 
-    cubos.tag("BeginImGuiFrame").afterTag("Poll");
-
-    cubos.tag("EndImGuiFrame").beforeTag("SwapBuffers");
-
-    cubos.startupSystem(initializeImGui).tagged("InitImGui");
-
-    cubos.system(beginImGuiFrame).tagged("BeginImGuiFrame");
-
-    cubos.system(endImGuiFrame).tagged("EndImGuiFrame");
+    cubos.startupSystem(init).tagged("cubos.imgui.init");
+    cubos.system(begin).tagged("cubos.imgui.begin");
+    cubos.system(end).tagged("cubos.imgui.end");
 }

--- a/engine/src/cubos/engine/plugins/tools/settings_inspector.cpp
+++ b/engine/src/cubos/engine/plugins/tools/settings_inspector.cpp
@@ -1,11 +1,12 @@
 #include <cubos/engine/plugins/tools/settings_inspector.hpp>
-#include <cubos/core/settings.hpp>
 #include <cubos/engine/plugins/imgui.hpp>
-#include <cubos/core/ui/imgui.hpp>
+
+#include <cubos/core/settings.hpp>
 #include <cubos/core/ui/serialization.hpp>
+
 #include <imgui.h>
 
-static void settingsInspectorSystem(cubos::core::Settings& settings)
+static void inspector(cubos::core::Settings& settings)
 {
     ImGui::Begin("Settings Inspector");
 
@@ -32,6 +33,6 @@ static void settingsInspectorSystem(cubos::core::Settings& settings)
 void cubos::engine::plugins::tools::settingsInspectorPlugin(Cubos& cubos)
 {
     cubos.addPlugin(cubos::engine::plugins::imguiPlugin);
-    cubos.tag("SettingsInspector").afterTag("BeginImGuiFrame").beforeTag("EndImGuiFrame");
-    cubos.system(settingsInspectorSystem).tagged("SettingsInspector");
+
+    cubos.system(inspector).tagged("cubos.imgui");
 }

--- a/engine/src/cubos/engine/plugins/transform.cpp
+++ b/engine/src/cubos/engine/plugins/transform.cpp
@@ -7,10 +7,11 @@
 #include <components/cubos/scale.hpp>
 #include <components/cubos/local_to_world.hpp>
 
-static void applyTransform(
-    cubos::core::ecs::Query<cubos::engine::ecs::LocalToWorld&, const cubos::engine::ecs::Position*,
-                            const cubos::engine::ecs::Rotation*, const cubos::engine::ecs::Scale*>
-        query)
+using namespace cubos;
+
+static void applyTransform(core::ecs::Query<engine::ecs::LocalToWorld&, const engine::ecs::Position*,
+                                            const engine::ecs::Rotation*, const engine::ecs::Scale*>
+                               query)
 {
     for (auto [entity, localToWorld, position, rotation, scale] : query)
     {
@@ -26,10 +27,10 @@ static void applyTransform(
 
 void cubos::engine::plugins::transformPlugin(Cubos& cubos)
 {
-    cubos.addComponent<ecs::Position>()
-        .addComponent<ecs::Rotation>()
-        .addComponent<ecs::Scale>()
-        .addComponent<ecs::LocalToWorld>();
+    cubos.addComponent<ecs::Position>();
+    cubos.addComponent<ecs::Rotation>();
+    cubos.addComponent<ecs::Scale>();
+    cubos.addComponent<ecs::LocalToWorld>();
 
-    cubos.system(applyTransform).tagged("Transform");
+    cubos.system(applyTransform).tagged("cubos.transform.update");
 }


### PR DESCRIPTION
Closes #303 and #326.

Originally this PR only aimed to improve the plugin docs and change the tag names to fit #303.
I then found out that a system couldn't be tagged twice, which made some code more difficult to read, and decided to fix it.