### PR TITLE
Add voxels plugin

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -30,6 +30,8 @@ set(CUBOS_ENGINE_SOURCE
     "src/cubos/engine/scene/plugin.cpp"
     "src/cubos/engine/scene/bridge.cpp"
 
+    "src/cubos/engine/voxels/plugin.cpp"
+
     "src/cubos/engine/renderer/plugin.cpp"
     "src/cubos/engine/renderer/frame.cpp"
     "src/cubos/engine/renderer/renderer.cpp"
@@ -68,6 +70,8 @@ set(CUBOS_ENGINE_INCLUDE
     "include/cubos/engine/scene/plugin.hpp"
     "include/cubos/engine/scene/scene.hpp"
     "include/cubos/engine/scene/bridge.hpp"
+
+    "include/cubos/engine/voxels/plugin.hpp"
 
     "include/cubos/engine/renderer/plugin.hpp"
     "include/cubos/engine/renderer/frame.hpp"

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -74,6 +74,7 @@ set(CUBOS_ENGINE_INCLUDE
     "include/cubos/engine/scene/bridge.hpp"
 
     "include/cubos/engine/voxels/plugin.hpp"
+    "include/cubos/engine/voxels/grid_bridge.hpp"
 
     "include/cubos/engine/renderer/plugin.hpp"
     "include/cubos/engine/renderer/frame.hpp"

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CUBOS_ENGINE_SOURCE
     "src/cubos/engine/assets/plugin.cpp"
     "src/cubos/engine/assets/assets.cpp"
     "src/cubos/engine/assets/bridge.cpp"
+    "src/cubos/engine/assets/binary_bridge.cpp"
     "src/cubos/engine/assets/asset.cpp"
     "src/cubos/engine/assets/meta.cpp"
 
@@ -64,6 +65,7 @@ set(CUBOS_ENGINE_INCLUDE
     "include/cubos/engine/assets/plugin.hpp"
     "include/cubos/engine/assets/assets.hpp"
     "include/cubos/engine/assets/bridge.hpp"
+    "include/cubos/engine/assets/binary_bridge.hpp"
     "include/cubos/engine/assets/asset.hpp"
     "include/cubos/engine/assets/meta.hpp"
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -75,6 +75,7 @@ set(CUBOS_ENGINE_INCLUDE
 
     "include/cubos/engine/voxels/plugin.hpp"
     "include/cubos/engine/voxels/grid_bridge.hpp"
+    "include/cubos/engine/voxels/palette_bridge.hpp"
 
     "include/cubos/engine/renderer/plugin.hpp"
     "include/cubos/engine/renderer/frame.hpp"

--- a/engine/include/cubos/engine/assets/binary_bridge.hpp
+++ b/engine/include/cubos/engine/assets/binary_bridge.hpp
@@ -3,7 +3,7 @@
 #include <cubos/core/data/binary_deserializer.hpp>
 #include <cubos/core/data/binary_serializer.hpp>
 
-#include <cubos/engine/assets/bridge.hpp>
+#include <cubos/engine/assets/assets.hpp>
 
 namespace cubos::engine
 {
@@ -29,5 +29,33 @@ namespace cubos::engine
         /// @param serializer The serializer to write the asset to.
         virtual void saveImpl(const Assets& assets, const AnyAsset& handle,
                               core::data::BinarySerializer& serializer) = 0;
+    };
+
+    /// Automatic implementation of BinaryBridge using a templated type.
+    /// The type must be default constructible, serializable and deserializable.
+    /// No extra context is passed to the serializer or deserializer, so this is only useful for
+    /// simple types which do not require any context.
+    /// @tparam T The type of asset to load and save.
+    template <typename T>
+    class BinaryBridgeImpl : public BinaryBridge
+    {
+    protected:
+        void loadImpl(Assets& assets, const AnyAsset& handle, core::data::BinaryDeserializer& deserializer) override
+        {
+            T data{};
+            deserializer.read(data);
+            if (!deserializer.failed())
+            {
+                // Write the data to the asset only on success.
+                assets.store(handle, std::move(data));
+            }
+        }
+
+        void saveImpl(const Assets& assets, const AnyAsset& handle, core::data::BinarySerializer& serializer) override
+        {
+            // Read the data from the asset.
+            auto data = assets.read<T>(handle);
+            serializer.write(data, nullptr); // Binary serializer does not use names.
+        }
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/assets/binary_bridge.hpp
+++ b/engine/include/cubos/engine/assets/binary_bridge.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cubos/core/data/binary_deserializer.hpp>
+#include <cubos/core/data/binary_serializer.hpp>
+
+#include <cubos/engine/assets/bridge.hpp>
+
+namespace cubos::engine
+{
+    /// An abstract bridge type defined to reduce boilerplate code in bridge implementations which
+    /// use binary (de)serialization to load and save assets.
+    class BinaryBridge : public AssetBridge
+    {
+    public:
+        bool load(Assets& assets, const AnyAsset& handle) override;
+        bool save(const Assets& assets, const AnyAsset& handle) override;
+
+    protected:
+        /// Called after the file has been opened and the deserializer has been created.
+        /// Errors can be reported by calling `deserializer.fail()`.
+        /// @param assets The assets manager.
+        /// @param handle The asset handle.
+        /// @param deserializer The deserializer to read the asset from.
+        virtual void loadImpl(Assets& assets, const AnyAsset& handle, core::data::BinaryDeserializer& deserializer) = 0;
+
+        /// Called after the file has been opened and the serializer has been created.
+        /// @param assets The assets manager.
+        /// @param handle The asset handle.
+        /// @param serializer The serializer to write the asset to.
+        virtual void saveImpl(const Assets& assets, const AnyAsset& handle,
+                              core::data::BinarySerializer& serializer) = 0;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/voxels/grid_bridge.hpp
+++ b/engine/include/cubos/engine/voxels/grid_bridge.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cubos/core/gl/grid.hpp>
+
+#include <cubos/engine/assets/binary_bridge.hpp>
+
+namespace cubos::engine
+{
+    /// A bridge to load and save `Grid` assets.
+    class GridBridge : public BinaryBridgeImpl<core::gl::Grid>
+    {
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/voxels/palette_bridge.hpp
+++ b/engine/include/cubos/engine/voxels/palette_bridge.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cubos/core/gl/palette.hpp>
+
+#include <cubos/engine/assets/binary_bridge.hpp>
+
+namespace cubos::engine
+{
+    /// A bridge to load and save `Palette` assets.
+    class PaletteBridge : public BinaryBridgeImpl<core::gl::Palette>
+    {
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/voxels/plugin.hpp
+++ b/engine/include/cubos/engine/voxels/plugin.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/scene/scene.hpp>
+
+namespace cubos::engine
+{
+    /// Plugin which adds grid and palette asset bridges to CUBOS.
+    ///
+    /// @details Registers the `GridBridge` and `PaletteBridge` asset bridges with the `.grd` and
+    /// `.pal` extensions, which load assets of the `Grid` and `Palette` types, respectively.
+    ///
+    /// Dependencies:
+    /// - `assetsPlugin`
+    ///
+    /// @param cubos CUBOS. main class.
+    void voxelsPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/src/cubos/engine/assets/binary_bridge.cpp
+++ b/engine/src/cubos/engine/assets/binary_bridge.cpp
@@ -1,0 +1,59 @@
+#include <cubos/core/data/binary_deserializer.hpp>
+#include <cubos/core/data/binary_serializer.hpp>
+#include <cubos/core/data/file_system.hpp>
+#include <cubos/core/log.hpp>
+
+#include <cubos/engine/assets/assets.hpp>
+#include <cubos/engine/assets/binary_bridge.hpp>
+
+using cubos::core::data::BinaryDeserializer;
+using cubos::core::data::BinarySerializer;
+using cubos::core::data::File;
+using cubos::core::data::FileSystem;
+using namespace cubos::engine;
+
+bool BinaryBridge::load(Assets& assets, const AnyAsset& handle)
+{
+    // Open the file.
+    auto path = assets.readMeta(handle)->get("path").value();
+    auto stream = FileSystem::open(path, File::OpenMode::Read);
+    if (stream == nullptr)
+    {
+        CUBOS_ERROR("Could not open file '{}'", path);
+        return false;
+    }
+
+    // Deserialize the asset from the file stream.
+    BinaryDeserializer deserializer{*stream};
+    this->loadImpl(assets, handle, deserializer);
+    if (deserializer.failed())
+    {
+        CUBOS_ERROR("Could not binary deserialize file '{}'", path);
+        return false;
+    }
+
+    return true;
+}
+
+bool BinaryBridge::save(const Assets& assets, const AnyAsset& handle)
+{
+    // Open the file.
+    auto path = assets.readMeta(handle)->get("path").value();
+    auto stream = FileSystem::open(path, File::OpenMode::Write);
+    if (stream == nullptr)
+    {
+        CUBOS_ERROR("Could not open file '{}'", path);
+        return false;
+    }
+
+    // Serialize the asset to the file stream.
+    BinarySerializer serializer{*stream};
+    this->saveImpl(assets, handle, serializer);
+    if (serializer.failed())
+    {
+        CUBOS_ERROR("Could not binary serialize asset to file '{}'", path);
+        return false;
+    }
+
+    return true;
+}

--- a/engine/src/cubos/engine/voxels/plugin.cpp
+++ b/engine/src/cubos/engine/voxels/plugin.cpp
@@ -1,4 +1,5 @@
 #include <cubos/engine/assets/plugin.hpp>
+#include <cubos/engine/voxels/grid_bridge.hpp>
 #include <cubos/engine/voxels/plugin.hpp>
 
 using cubos::core::ecs::Write;
@@ -7,6 +8,7 @@ using namespace cubos::engine;
 static void bridges(Write<Assets> assets)
 {
     // Add the bridges to load .grd and .pal files.
+    assets->registerBridge(".grd", std::make_unique<GridBridge>());
 }
 
 void cubos::engine::voxelsPlugin(Cubos& cubos)

--- a/engine/src/cubos/engine/voxels/plugin.cpp
+++ b/engine/src/cubos/engine/voxels/plugin.cpp
@@ -1,0 +1,17 @@
+#include <cubos/engine/assets/plugin.hpp>
+#include <cubos/engine/voxels/plugin.hpp>
+
+using cubos::core::ecs::Write;
+using namespace cubos::engine;
+
+static void bridges(Write<Assets> assets)
+{
+    // Add the bridges to load .grd and .pal files.
+}
+
+void cubos::engine::voxelsPlugin(Cubos& cubos)
+{
+    cubos.addPlugin(assetsPlugin);
+
+    cubos.startupSystem(bridges).tagged("cubos.assets.bridge");
+}

--- a/engine/src/cubos/engine/voxels/plugin.cpp
+++ b/engine/src/cubos/engine/voxels/plugin.cpp
@@ -1,5 +1,6 @@
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/voxels/grid_bridge.hpp>
+#include <cubos/engine/voxels/palette_bridge.hpp>
 #include <cubos/engine/voxels/plugin.hpp>
 
 using cubos::core::ecs::Write;
@@ -9,6 +10,7 @@ static void bridges(Write<Assets> assets)
 {
     // Add the bridges to load .grd and .pal files.
     assets->registerBridge(".grd", std::make_unique<GridBridge>());
+    assets->registerBridge(".pal", std::make_unique<PaletteBridge>());
 }
 
 void cubos::engine::voxelsPlugin(Cubos& cubos)


### PR DESCRIPTION
Add the `voxelsPlugin`, which adds two assets bridges: `GridBridge` and `PaletteBridge`.
Since both assets are just binary (de)serialized, abstractions `BinaryBridge` and `BinaryBridgeImpl` were created to reduce code duplication.