### PR TITLE
Add `Type` class and reflection macros and functions

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,6 +32,8 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/memory/standard_stream.cpp"
     "src/cubos/core/memory/buffer_stream.cpp"
 
+    "src/cubos/core/reflection/type.cpp"
+
     "src/cubos/core/data/serializer.cpp"
     "src/cubos/core/data/deserializer.cpp"
     "src/cubos/core/data/debug_serializer.cpp"
@@ -95,6 +97,7 @@ set(CUBOS_CORE_INCLUDE
     "include/cubos/core/memory/guards.hpp"
 
     "include/cubos/core/reflection/reflect.hpp"
+    "include/cubos/core/reflection/type.hpp"
 
     "include/cubos/core/data/serializer.hpp"
     "include/cubos/core/data/deserializer.hpp"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -94,6 +94,8 @@ set(CUBOS_CORE_INCLUDE
     "include/cubos/core/memory/type_map.hpp"
     "include/cubos/core/memory/guards.hpp"
 
+    "include/cubos/core/reflection/reflect.hpp"
+
     "include/cubos/core/data/serializer.hpp"
     "include/cubos/core/data/deserializer.hpp"
     "include/cubos/core/data/debug_serializer.hpp"

--- a/core/include/cubos/core/al/module.dox
+++ b/core/include/cubos/core/al/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-al module.
 
-#pragma once
-
 /// @namespace cubos::core::al
 /// @brief @ref core-al module.
 /// @ingroup core-al

--- a/core/include/cubos/core/data/fs/module.dox
+++ b/core/include/cubos/core/data/fs/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief Filesystem utilities directory.
 
-#pragma once
-
 namespace cubos::core::data
 {
     /// @defgroup core-data-fs Filesystem

--- a/core/include/cubos/core/data/module.dox
+++ b/core/include/cubos/core/data/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-data module.
 
-#pragma once
-
 /// @namespace cubos::core::data
 /// @brief @ref core-data module.
 /// @ingroup core-data

--- a/core/include/cubos/core/ecs/module.dox
+++ b/core/include/cubos/core/ecs/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-ecs module.
 
-#pragma once
-
 /// @namespace cubos::core::ecs
 /// @brief @ref core-ecs module.
 /// @ingroup core-ecs

--- a/core/include/cubos/core/geom/module.dox
+++ b/core/include/cubos/core/geom/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-geom module.
 
-#pragma once
-
 /// @namespace cubos::core::geom
 /// @brief @ref core-geom module.
 /// @ingroup core-geom

--- a/core/include/cubos/core/gl/module.dox
+++ b/core/include/cubos/core/gl/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-gl module.
 
-#pragma once
-
 /// @namespace cubos::core::gl
 /// @brief @ref core-gl module.
 /// @ingroup core-gl

--- a/core/include/cubos/core/io/module.dox
+++ b/core/include/cubos/core/io/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-io module.
 
-#pragma once
-
 /// @namespace cubos::core::io
 /// @brief @ref core-io module.
 /// @ingroup core-io

--- a/core/include/cubos/core/memory/module.dox
+++ b/core/include/cubos/core/memory/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-memory module.
 
-#pragma once
-
 /// @namespace cubos::core::memory
 /// @brief @ref core-memory module.
 /// @ingroup core-memory

--- a/core/include/cubos/core/module.dox
+++ b/core/include/cubos/core/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core module.
 
-#pragma once
-
 /// @namespace cubos::core
 /// @brief @ref core namespace.
 

--- a/core/include/cubos/core/reflection/module.dox
+++ b/core/include/cubos/core/reflection/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-reflection module.
 
-#pragma once
-
 /// @namespace cubos::core::reflection
 /// @brief @ref core-reflection module.
 /// @ingroup core-reflection

--- a/core/include/cubos/core/reflection/module.dox
+++ b/core/include/cubos/core/reflection/module.dox
@@ -1,0 +1,15 @@
+/// @dir
+/// @brief @ref core-reflection module.
+
+#pragma once
+
+/// @namespace cubos::core::reflection
+/// @brief @ref core-reflection module.
+/// @ingroup core-reflection
+
+namespace cubos::core::reflection
+{
+    /// @defgroup core-reflection Reflection
+    /// @ingroup core
+    /// @brief Provides utilities useful for handling type-erased data.
+} // namespace cubos::core::reflection

--- a/core/include/cubos/core/reflection/reflect.hpp
+++ b/core/include/cubos/core/reflection/reflect.hpp
@@ -1,0 +1,206 @@
+/// @file
+/// @brief Function @ref cubos::core::reflection::reflect and related macros.
+///
+/// Meant to be as minimal as possible in order to keep compile times low.
+///
+/// @ingroup core-reflection
+
+#pragma once
+
+namespace cubos::core::reflection
+{
+    class Type;
+
+    /// @brief Defines the reflection function for the given type @p T.
+    ///
+    /// By default, this function calls the static member function `reflect` of the type, which
+    /// should return a pointer to an instance of @ref Type.
+    ///
+    /// To implement reflection for your type, you should either:
+    /// - Define a static member function `reflect` with return type `const Type&` on your type.
+    /// - Specialize this class for your type.
+    ///
+    /// The first option is preferred, as it is less verbose. However, when handling external
+    /// types, to which member functions cannot be added, the second option is necessary.
+    ///
+    /// Both options can and should be shortened by using the macros:
+    /// - @ref CUBOS_REFLECT - declaring the reflection member function.
+    /// - @ref CUBOS_REFLECT_IMPL - defining the reflection member function.
+    /// - @ref CUBOS_REFLECT_EXTERNAL_DECL - declaring the reflection specialization.
+    /// - @ref CUBOS_REFLECT_EXTERNAL_IMPL - defining the reflection specialization's function.
+    ///
+    /// @tparam T %Type to reflect.
+    /// @ingroup core-reflection
+    template <typename T>
+    struct Reflect
+    {
+        // If you get a compiler error here, either you:
+        // 1. Are trying to reflect an external type and have not included the file which declares
+        //    the type to be reflectable (take a look at the external/ subdir), or
+        // 2. Have not implemented reflection for the external type.
+        // 3. Have not implemented reflection for your type.
+        //
+        // Refer to the documentation above for more information on how to implement reflection on
+        // your type or an external type.
+        static const Type& type()
+        {
+            return T::reflect(); // Read the comment above if you get a compiler error here!
+        }
+    };
+
+    /// @brief Reflects the given type @p T.
+    ///
+    /// Fails to compile if the type does not implement reflection, or, in the case of external
+    /// types, if its reflection specialization has not been included.
+    ///
+    /// Internally, this function stores a static instance of the reflection data for the given
+    /// type. Thus the reflection data is only initialized once, the first time this function is
+    /// called, which means that the returned reference can be safely used as an identifier for the
+    /// type.
+    ///
+    /// The reflection data is obtained by calling the @ref Reflect<T>::type() function.
+    ///
+    /// @tparam T %Type to reflect.
+    /// @return %Type information.
+    /// @ingroup core-reflection
+    template <typename T>
+    const Type& reflect()
+    {
+        static const Type& type = Reflect<T>::type();
+        return type;
+    }
+} // namespace cubos::core::reflection
+
+/// @brief Helper macro used to pass arguments with commas to other macros, wrapped in parentheses.
+///
+/// @code{.cpp}
+/// #define FOO(T) T foo;
+/// FOO(int); // expands to int foo;
+/// FOO(std::map<int, int>); // error: too many arguments to macro 'FOO'
+///
+/// // Instead, use CUBOS_PACK:
+/// #define FOO(T) CUBOS_PACK T foo;
+/// FOO((int)); // expands to CUBOS_PACK(int) foo, which expands to int foo;
+/// FOO((std::map<int, int>)); // expands to CUBOS_PACK(std::map<int, int>) foo, which expands to
+///                            // std::map<int, int> foo;
+/// @endcode
+///
+/// @ingroup core-reflection
+#define CUBOS_PACK(...) __VA_ARGS__
+
+/// @brief Declares a reflection method.
+///
+/// @code{.cpp}
+/// // my_type.hpp
+/// #include <cubos/core/reflection/reflect.hpp>
+///
+/// struct MyType
+/// {
+///     CUBOS_REFLECT; // declares `static const Type& reflect()`
+/// };
+/// @endcode
+///
+/// @see Meant to be used with @ref CUBOS_REFLECT_IMPL.
+/// @ingroup core-reflection
+#define CUBOS_REFLECT static const cubos::core::reflection::Type& reflect()
+
+/// @brief Defines a reflection method.
+///
+/// @code{.cpp}
+/// // my_type.cpp
+/// #include "my_type.hpp"
+///
+/// CUBOS_REFLECT_IMPL(MyType) // defines `const Type& MyType::reflect()`
+/// {
+///     return /* create your type here */;
+/// }
+/// @endcode
+///
+/// @see Meant to be used with @ref CUBOS_REFLECT.
+/// @param T Type to reflect.
+/// @ingroup core-reflection
+#define CUBOS_REFLECT_IMPL(T) const cubos::core::reflection::Type& T::reflect()
+
+/// @brief Declares a specialization of @ref cubos::core::reflection::Reflect for a templated type.
+/// @note Should be preceded by a template declaration.
+///
+/// @code{.cpp}
+/// // templated_type_reflection.hpp
+/// #include <cubos/core/reflection/reflect.hpp>
+///
+/// template <typename T>
+/// CUBOS_REFLECT_EXTERNAL_DECL_TEMPLATE(TemplatedType<T>);
+/// @endcode
+///
+/// @see Meant to be used with @ref CUBOS_REFLECT_EXTERNAL_IMPL.
+/// @param T Type to reflect.
+/// @ingroup core-reflection
+#define CUBOS_REFLECT_EXTERNAL_DECL_TEMPLATE(T)                                                                        \
+    struct cubos::core::reflection::Reflect<T>                                                                         \
+    {                                                                                                                  \
+        static const cubos::core::reflection::Type& type();                                                            \
+    }
+
+/// @brief Declares a specialization of @ref cubos::core::reflection::Reflect for a type.
+///
+/// @code{.cpp}
+/// // not_my_type_reflection.hpp
+/// #include <cubos/core/reflection/reflect.hpp>
+///
+/// CUBOS_REFLECT_EXTERNAL_DECL(NotMyType);
+/// @endcode
+///
+/// @see Meant to be used with @ref CUBOS_REFLECT_EXTERNAL_IMPL.
+/// @param T Type to reflect.
+/// @ingroup core-reflection
+#define CUBOS_REFLECT_EXTERNAL_DECL(T)                                                                                 \
+    template <>                                                                                                        \
+    CUBOS_REFLECT_EXTERNAL_DECL_TEMPLATE(T)
+
+/// @brief Implements a specialization of @ref cubos::core::reflection::Reflect for a type.
+///
+/// @code{.cpp}
+/// // not_my_type_reflection.cpp
+/// #include "not_my_type_reflection.hpp"
+///
+/// CUBOS_REFLECT_EXTERNAL_IMPL(NotMyType)
+/// {
+///     return /* create your type here */;
+/// }
+/// @endcode
+///
+/// @code{.cpp}
+/// // templated_type_reflection.hpp
+/// template <typename T>
+/// CUBOS_REFLECT_EXTERNAL_IMPL(TemplatedType<T>)
+/// {
+///     return /* create your type here */;
+/// }
+/// @endcode
+///
+/// @see Meant to be used with either @ref CUBOS_REFLECT_EXTERNAL_DECL or
+/// @ref CUBOS_REFLECT_EXTERNAL_DECL_TEMPLATE.
+/// @param T Type to reflect.
+/// @ingroup core-reflection
+#define CUBOS_REFLECT_EXTERNAL_IMPL(T) const cubos::core::reflection::Type& cubos::core::reflection::Reflect<T>::type()
+
+/// @brief Both declares and implements a specialization of @ref cubos::core::reflection::Reflect for a type.
+///
+/// @code{.cpp}
+/// // templated_type_reflection.hpp
+/// #include <cubos/core/reflection/reflect.hpp>
+///
+/// CUBOS_REFLECT_EXTERNAL_TEMPLATE((T), (TemplatedType<T>))
+/// {
+///     return /* create your type here */;
+/// }
+/// @endcode
+///
+/// @param args Template parameters, wrapped in parentheses.
+/// @param T Type to reflect, wrapped in parentheses.
+/// @ingroup core-reflection
+#define CUBOS_REFLECT_EXTERNAL_TEMPLATE(args, T)                                                                       \
+    template <CUBOS_PACK args>                                                                                         \
+    CUBOS_REFLECT_EXTERNAL_DECL_TEMPLATE(CUBOS_PACK T);                                                                \
+    template <CUBOS_PACK args>                                                                                         \
+    CUBOS_REFLECT_EXTERNAL_IMPL(CUBOS_PACK T)

--- a/core/include/cubos/core/reflection/reflect.hpp
+++ b/core/include/cubos/core/reflection/reflect.hpp
@@ -190,7 +190,7 @@ namespace cubos::core::reflection
 /// // templated_type_reflection.hpp
 /// #include <cubos/core/reflection/reflect.hpp>
 ///
-/// CUBOS_REFLECT_EXTERNAL_TEMPLATE((T), (TemplatedType<T>))
+/// CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename T), (TemplatedType<T>))
 /// {
 ///     return /* create your type here */;
 /// }

--- a/core/include/cubos/core/reflection/reflect.hpp
+++ b/core/include/cubos/core/reflection/reflect.hpp
@@ -18,7 +18,7 @@ namespace cubos::core::reflection
     ///
     /// To implement reflection for your type, you should either:
     /// - Define a static member function `reflect` with return type `const Type&` on your type.
-    /// - Specialize this class for your type.
+    /// - Specialize this struct for your type.
     ///
     /// The first option is preferred, as it is less verbose. However, when handling external
     /// types, to which member functions cannot be added, the second option is necessary.

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -98,11 +98,11 @@ namespace cubos::core::reflection
         /// @return Pointer to the trait.
         const void* get(uintptr_t id) const;
 
-        /// @brief Gets an unique identifier for the given type.
+        /// @brief Gets an unique identifier for the given trait type.
         /// @note This function is used as an alternative to `std::type_index`, which would require
         /// including the `<typeindex>` header.
         /// @tparam T %Trait type.
-        /// @return Unique identifier for the given type.
+        /// @return Unique identifier for the given trait type.
         template <typename T>
         static uintptr_t id()
         {

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -39,8 +39,7 @@ namespace cubos::core::reflection
 
         /// @brief Adds the given trait to the type.
         ///
-        /// Aborts if the trait is already present in the type, or if its not move or copy
-        /// constructible. Fails to compile if the trait's type is not reflectable.
+        /// Aborts if the trait is already present in the type.
         ///
         /// @tparam T %Trait type.
         /// @param trait %Trait value.
@@ -52,9 +51,6 @@ namespace cubos::core::reflection
         }
 
         /// @brief Returns whether the type has the given trait.
-        ///
-        /// Fails to compile if the trait's type is not reflectable.
-        ///
         /// @tparam T %Trait type.
         /// @return Whether the type has the given trait.
         template <typename T>
@@ -66,7 +62,6 @@ namespace cubos::core::reflection
         /// @brief Returns the given trait of the type.
         ///
         /// Aborts if the type does not have the given trait.
-        /// Fails to compile if the trait's type is not reflectable.
         ///
         /// @tparam T %Trait type.
         /// @return Reference to the trait.
@@ -85,7 +80,7 @@ namespace cubos::core::reflection
 
         /// @brief Adds the given trait to the type.
         /// @param id Identifies the type of the trait.
-        /// @param trait %Trait value to be moved into the type.
+        /// @param trait Allocated trait value.
         /// @param deleter Used to delete the trait when the type is destroyed.
         /// @return Reference to this type, for chaining.
         Type& with(uintptr_t id, void* trait, void (*deleter)(void*));

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -37,6 +37,15 @@ namespace cubos::core::reflection
         /// @return Name of the type.
         const std::string& name() const;
 
+        /// @brief Checks if this type represents the type @p T.
+        /// @tparam T Type to check.
+        /// @return Whether this type represents the type @p T.
+        template <typename T>
+        bool is() const
+        {
+            return this == &reflect<T>();
+        }
+
         /// @brief Adds the given trait to the type.
         ///
         /// Aborts if the trait is already present in the type.

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -1,0 +1,131 @@
+/// @file
+/// @brief Class @ref cubos::core::reflection::Type.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::core::reflection
+{
+    /// @brief Describes a reflected type.
+    ///
+    /// Holds the name of a type and the traits associated with it. Traits can be of any type,
+    /// which means you can define your own custom traits.
+    ///
+    /// @see This class holds the data returned by the @ref reflect() function.
+    /// @ingroup core-reflection
+    class Type final
+    {
+    public:
+        Type(const Type&) = delete;
+        Type(Type&&) = delete;
+
+        /// @brief Constructs with a type the given name.
+        /// @param name Name of the type.
+        /// @return Reference to the type.
+        static Type& create(std::string name);
+
+        /// @brief Destroys the given type.
+        /// @param type Type to destroy.
+        static void destroy(Type& type);
+
+        /// @brief Returns the name of the type.
+        /// @return Name of the type.
+        const std::string& name() const;
+
+        /// @brief Adds the given trait to the type.
+        ///
+        /// Aborts if the trait is already present in the type, or if its not move or copy
+        /// constructible. Fails to compile if the trait's type is not reflectable.
+        ///
+        /// @tparam T %Trait type.
+        /// @param trait %Trait value.
+        /// @return Reference to this type, for chaining.
+        template <typename T>
+        Type& with(T trait)
+        {
+            return this->with(Type::id<T>(), new T(trait), [](void* trait) { delete static_cast<T*>(trait); });
+        }
+
+        /// @brief Returns whether the type has the given trait.
+        ///
+        /// Fails to compile if the trait's type is not reflectable.
+        ///
+        /// @tparam T %Trait type.
+        /// @return Whether the type has the given trait.
+        template <typename T>
+        bool has() const
+        {
+            return this->has(Type::id<T>());
+        }
+
+        /// @brief Returns the given trait of the type.
+        ///
+        /// Aborts if the type does not have the given trait.
+        /// Fails to compile if the trait's type is not reflectable.
+        ///
+        /// @tparam T %Trait type.
+        /// @return Reference to the trait.
+        template <typename T>
+        const T& get() const
+        {
+            return *static_cast<const T*>(this->get(Type::id<T>()));
+        }
+
+    private:
+        ~Type();
+
+        /// @brief Constructs with the given name.
+        /// @param name Name of the type.
+        explicit Type(std::string name);
+
+        /// @brief Adds the given trait to the type.
+        /// @param id Identifies the type of the trait.
+        /// @param trait %Trait value to be moved into the type.
+        /// @param deleter Used to delete the trait when the type is destroyed.
+        /// @return Reference to this type, for chaining.
+        Type& with(uintptr_t id, void* trait, void (*deleter)(void*));
+
+        /// @brief Returns whether the type has the given trait.
+        /// @param id Identifies the type of the trait.
+        /// @return Whether the type has the given trait.
+        bool has(uintptr_t id) const;
+
+        /// @brief Returns the given trait of the type.
+        ///
+        /// Aborts if the type does not have the given trait.
+        ///
+        /// @param id Identifies the type of the trait.
+        /// @return Pointer to the trait.
+        const void* get(uintptr_t id) const;
+
+        /// @brief Gets an unique identifier for the given type.
+        /// @note This function is used as an alternative to `std::type_index`, which would require
+        /// including the `<typeindex>` header.
+        /// @tparam T %Trait type.
+        /// @return Unique identifier for the given type.
+        template <typename T>
+        static uintptr_t id()
+        {
+            // This variable is unused, but since there is one for each type, its address is
+            // guaranteed to be unique for each type.
+            static const bool var = false;
+            return reinterpret_cast<uintptr_t>(&var);
+        }
+
+        /// @brief %Trait entry in the type.
+        struct Trait
+        {
+            uintptr_t id;           ///< Type identifier.
+            void* value;            ///< Value, allocated on the heap.
+            void (*deleter)(void*); ///< Deleter function.
+        };
+
+        std::string mName;
+        std::vector<Trait> mTraits;
+    };
+} // namespace cubos::core::reflection

--- a/core/include/cubos/core/ui/module.dox
+++ b/core/include/cubos/core/ui/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref core-ui module.
 
-#pragma once
-
 /// @namespace cubos::core::ui
 /// @brief @ref core-ui module.
 /// @ingroup core-ui

--- a/core/samples/CMakeLists.txt
+++ b/core/samples/CMakeLists.txt
@@ -27,6 +27,7 @@ macro(make_sample)
 endmacro()
 
 make_sample(DIR "logging")
+make_sample(DIR "reflection/basic")
 make_sample(DIR "data/fs/embedded_archive" SOURCES "embed.cpp")
 make_sample(DIR "data/fs/standard_archive")
 make_sample(DIR "data/serialization")

--- a/core/samples/reflection/basic/main.cpp
+++ b/core/samples/reflection/basic/main.cpp
@@ -1,0 +1,69 @@
+#include <cubos/core/log.hpp>
+
+/// [Person definition]
+#include <cubos/core/reflection/reflect.hpp>
+
+struct Person
+{
+    CUBOS_REFLECT;
+    int age;
+    float weight;
+};
+/// [Person definition]
+
+/// [Person reflection]
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::Type;
+
+CUBOS_REFLECT_IMPL(Person)
+{
+    return Type::create("Person");
+}
+/// [Person reflection]
+
+/// [Position definition]
+struct Position
+{
+    CUBOS_REFLECT;
+    float x, y;
+};
+/// [Position definition]
+
+/// [Your own trait]
+struct ColorTrait
+{
+    float r, g, b;
+};
+/// [Your own trait]
+
+/// [Adding your own trait]
+CUBOS_REFLECT_IMPL(Position)
+{
+    return Type::create("Position").with(ColorTrait{.r = 0.0F, .g = 1.0F, .b = 0.0F});
+}
+/// [Adding your own trait]
+
+/// [Accessing type name]
+int main()
+{
+    using cubos::core::reflection::reflect;
+
+    const auto& personType = reflect<Person>();
+    CUBOS_ASSERT(personType.name() == "Person");
+    /// [Accessing type name]
+
+    /// [Checking traits]
+    const auto& positionType = reflect<Position>();
+    CUBOS_ASSERT(positionType.has<ColorTrait>());
+    CUBOS_ASSERT(!personType.has<ColorTrait>());
+    /// [Checking traits]
+
+    /// [Accessing traits]
+    const auto& colorTrait = positionType.get<ColorTrait>();
+    CUBOS_ASSERT(colorTrait.r == 0.0F);
+    CUBOS_ASSERT(colorTrait.g == 1.0F);
+    CUBOS_ASSERT(colorTrait.b == 0.0F);
+    return 0;
+}
+/// [Accessing traits]

--- a/core/samples/reflection/basic/page.md
+++ b/core/samples/reflection/basic/page.md
@@ -8,9 +8,11 @@ in your header, like this:
 
 @snippet reflection/basic/main.cpp Person definition
 
-The @ref core/reflection/reflect.hpp is a very lightweight header, and thus you
-should avoid including any other reflection headers in your headers whenever
-possible, in order to reduce compile times.
+The file @ref core/reflection/reflect.hpp is a very lightweight header which
+you should include when declaring types as reflectable. It only defines the
+reflection macros and the reflection function. Avoid including other
+unnecessary reflection headers, which might be heavier, in order to reduce
+compile times.
 
 In your source file, you must define the reflection data for your type. This is
 done through the @ref CUBOS_REFLECT_IMPL macro:

--- a/core/samples/reflection/basic/page.md
+++ b/core/samples/reflection/basic/page.md
@@ -1,0 +1,47 @@
+# Reflection {#examples-core-reflection-basic}
+
+@brief Using the reflection system.
+
+Lets say you have a type `Person`, which you want to be able to reflect. You
+can declare it as reflectable using the macro @ref CUBOS_REFLECT, for example,
+in your header, like this:
+
+@snippet reflection/basic/main.cpp Person definition
+
+The @ref core/reflection/reflect.hpp is a very lightweight header, and thus you
+should avoid including any other reflection headers in your headers whenever
+possible, in order to reduce compile times.
+
+In your source file, you must define the reflection data for your type. This is
+done through the @ref CUBOS_REFLECT_IMPL macro:
+
+@snippet reflection/basic/main.cpp Person reflection
+
+To access this reflection data, you should use the
+@ref cubos::core::reflection::reflect function, which is also defined in the
+@ref core/reflection/reflect.hpp header.
+
+@snippet reflection/basic/main.cpp Accessing type name
+
+Lets say you want to associate your own data to your types, to describe them
+further. For example, imagine you're making a GUI editor for your game and you
+which to display the fields of your types in a tree view, with different colors
+for different types. You could associate colors to your types by defining a
+trait:
+
+@snippet reflection/basic/main.cpp Your own trait
+
+Now, when you define your type reflection, you add your trait with the
+@ref cubos::core::reflection::Type::with "Type::with" method.
+
+@snippet reflection/basic/main.cpp Adding your own trait
+
+To check if a type has a trait, you use the
+@ref cubos::core::reflection::Type::has "Type::has" method.
+
+@snippet reflection/basic/main.cpp Checking traits
+
+To actually access the trait data, you use the
+@ref cubos::core::reflection::Type::get "Type::get" method.
+
+@snippet reflection/basic/main.cpp Accessing traits

--- a/core/src/cubos/core/reflection/type.cpp
+++ b/core/src/cubos/core/reflection/type.cpp
@@ -1,0 +1,71 @@
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using namespace cubos::core::reflection;
+
+Type& Type::create(std::string name)
+{
+    return *(new Type(name));
+}
+
+void Type::destroy(Type& type)
+{
+    delete &type;
+}
+
+const std::string& Type::name() const
+{
+    return mName;
+}
+
+Type& Type::with(uintptr_t id, void* trait, void (*deleter)(void*))
+{
+    CUBOS_ASSERT(!this->has(id), "Trait already present in type \"{}\"", this->name());
+
+    mTraits.emplace_back(Trait{
+        .id = id,
+        .value = trait,
+        .deleter = deleter,
+    });
+
+    return *this;
+}
+
+bool Type::has(uintptr_t id) const
+{
+    for (const auto& trait : mTraits)
+    {
+        if (trait.id == id)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+const void* Type::get(uintptr_t id) const
+{
+    for (const auto& trait : mTraits)
+    {
+        if (trait.id == id)
+        {
+            return trait.value;
+        }
+    }
+
+    CUBOS_FAIL("No such trait in type \"{}\"", this->name());
+}
+
+Type::~Type()
+{
+    for (auto& trait : mTraits)
+    {
+        trait.deleter(trait.value);
+    }
+}
+
+Type::Type(std::string name)
+    : mName(std::move(name))
+{
+}

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(
     cubos-core-tests
     main.cpp
 
+    reflection/type.cpp
+
     data/fs/embedded_archive.cpp
     data/fs/standard_archive.cpp
     data/fs/file_system.cpp

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     cubos-core-tests
     main.cpp
 
+    reflection/reflect.cpp
     reflection/type.cpp
 
     data/fs/embedded_archive.cpp

--- a/core/tests/reflection/reflect.cpp
+++ b/core/tests/reflection/reflect.cpp
@@ -1,0 +1,48 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::reflect;
+using cubos::core::reflection::Type;
+
+/// @brief Type which is reflected internally.
+struct Internal
+{
+    CUBOS_REFLECT;
+};
+
+CUBOS_REFLECT_IMPL(Internal)
+{
+    return Type::create("Internal");
+}
+
+/// @brief Type which is reflected externally.
+struct External
+{
+};
+
+CUBOS_REFLECT_EXTERNAL_DECL(External);
+CUBOS_REFLECT_EXTERNAL_IMPL(External)
+{
+    return Type::create("External");
+}
+
+/// @brief Templated type.
+template <typename T>
+struct Templated
+{
+};
+
+CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename T), (Templated<T>))
+{
+    return Type::create("Templated<" + reflect<T>().name() + ">");
+}
+
+TEST_CASE("reflection::reflect")
+{
+    CHECK(reflect<Internal>().name() == "Internal");
+    CHECK(reflect<External>().name() == "External");
+    CHECK(reflect<Templated<Internal>>().name() == "Templated<Internal>");
+    CHECK(reflect<Templated<External>>().name() == "Templated<External>");
+    CHECK(reflect<Templated<Templated<Internal>>>().name() == "Templated<Templated<Internal>>");
+}

--- a/core/tests/reflection/reflect.cpp
+++ b/core/tests/reflection/reflect.cpp
@@ -41,7 +41,12 @@ CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename T), (Templated<T>))
 TEST_CASE("reflection::reflect")
 {
     CHECK(reflect<Internal>().name() == "Internal");
+    CHECK(reflect<Internal>().is<Internal>());
+
     CHECK(reflect<External>().name() == "External");
+    CHECK(reflect<External>().is<External>());
+    CHECK_FALSE(reflect<External>().is<Internal>());
+
     CHECK(reflect<Templated<Internal>>().name() == "Templated<Internal>");
     CHECK(reflect<Templated<External>>().name() == "Templated<External>");
     CHECK(reflect<Templated<Templated<Internal>>>().name() == "Templated<Templated<Internal>>");

--- a/core/tests/reflection/type.cpp
+++ b/core/tests/reflection/type.cpp
@@ -1,0 +1,38 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::reflect;
+using cubos::core::reflection::Type;
+
+TEST_CASE("reflection::Type")
+{
+    auto& type = Type::create("Foo");
+    CHECK(type.name() == "Foo");
+
+    SUBCASE("without traits")
+    {
+        CHECK_FALSE(type.has<bool>());
+        CHECK_FALSE(type.has<int>());
+    }
+
+    SUBCASE("with one trait")
+    {
+        type.with<bool>(false);
+        REQUIRE(type.has<bool>());
+        CHECK_FALSE(type.has<int>());
+        CHECK_FALSE(type.get<bool>());
+    }
+
+    SUBCASE("with two traits")
+    {
+        type.with<bool>(true);
+        type.with<int>(42);
+        REQUIRE(type.has<bool>());
+        REQUIRE(type.has<int>());
+        CHECK(type.get<bool>());
+        CHECK(type.get<int>() == 42);
+    }
+
+    Type::destroy(type);
+}

--- a/docs/pages/3_examples/1_core/main.md
+++ b/docs/pages/3_examples/1_core/main.md
@@ -10,6 +10,7 @@ will need to use some of the features of the @ref core library directly.
 
 The following examples have fully documented tutorials:
 - @subpage examples-core-logging - @copybrief examples-core-logging
+- @subpage examples-core-reflection-basic - @copybrief examples-core-reflection-basic
 
 ## Undocumented examples
 

--- a/engine/include/cubos/engine/module.dox
+++ b/engine/include/cubos/engine/module.dox
@@ -1,8 +1,6 @@
 /// @dir
 /// @brief @ref engine module.
 
-#pragma once
-
 /// @namespace cubos::engine
 /// @brief @ref engine module.
 


### PR DESCRIPTION
# Description

Add:
- `reflect.hpp` file which defines reflection macros and the `reflect` function, used to fetch reflection data.
- `Type` class, which stores the type's name and its traits.
- `core-sample.reflection` which shows how to use types and traits.

## Checklist

- [x] Self-review changes.
- [X] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [X] Write new samples.
