### PR TITLE
Add `ConstructibleTrait`

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/memory/buffer_stream.cpp"
 
     "src/cubos/core/reflection/type.cpp"
+    "src/cubos/core/reflection/traits/constructible.cpp"
 
     "src/cubos/core/data/serializer.cpp"
     "src/cubos/core/data/deserializer.cpp"
@@ -99,6 +100,7 @@ set(CUBOS_CORE_INCLUDE
 
     "include/cubos/core/reflection/reflect.hpp"
     "include/cubos/core/reflection/type.hpp"
+    "include/cubos/core/reflection/traits/constructible.hpp"
 
     "include/cubos/core/data/serializer.hpp"
     "include/cubos/core/data/deserializer.hpp"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -91,6 +91,7 @@ set(CUBOS_CORE_INCLUDE
     "include/cubos/core/settings.hpp"
     "include/cubos/core/thread_pool.hpp"
 
+    "include/cubos/core/memory/move.hpp"
     "include/cubos/core/memory/stream.hpp"
     "include/cubos/core/memory/standard_stream.hpp"
     "include/cubos/core/memory/buffer_stream.hpp"

--- a/core/include/cubos/core/memory/move.hpp
+++ b/core/include/cubos/core/memory/move.hpp
@@ -1,0 +1,44 @@
+/// @file
+/// @brief Function @ref cubos::core::memory::move.
+/// @ingroup core-memory
+
+#pragma once
+
+namespace cubos::core::memory
+{
+    /// @brief Provides a type which is the same as the given type, but without any references.
+    /// @note This is a replacement for `std::remove_reference`, which allows us to avoid including
+    /// the entire `<type_traits>` header.
+    /// @tparam T
+    template <typename T>
+    struct RemoveReference
+    {
+        /// @brief Type without references.
+        using Type = T;
+    };
+
+    template <typename T>
+    struct RemoveReference<T&>
+    {
+        using Type = T;
+    };
+
+    template <typename T>
+    struct RemoveReference<T&&>
+    {
+        using Type = T;
+    };
+
+    /// @brief Returns an R-value reference to the given value
+    /// @note This is a replacement for `std::move`, which allows us to avoid including the entire
+    /// `<utility>` header.
+    /// @tparam T Value type.
+    /// @param value Value to move.
+    /// @return Moved value.
+    /// @ingroup core-memory
+    template <typename T>
+    typename RemoveReference<T>::Type&& move(T&& value)
+    {
+        return static_cast<typename RemoveReference<T>::Type&&>(value);
+    }
+} // namespace cubos::core::memory

--- a/core/include/cubos/core/reflection/module.dox
+++ b/core/include/cubos/core/reflection/module.dox
@@ -10,4 +10,11 @@ namespace cubos::core::reflection
     /// @defgroup core-reflection Reflection
     /// @ingroup core
     /// @brief Provides utilities useful for handling type-erased data.
+    /// @see Take a look at the @ref examples-core-reflection examples for demonstrations of this
+    /// module.
+    ///
+    /// @note By type-erased data, we mean that data is stored in a generic container, for example,
+    /// through a void pointer, such that its type is not known at compile-time. This could be
+    /// useful, for example, to integrate scripts into the engine, since types defined there are
+    /// only know when the application is running.
 } // namespace cubos::core::reflection

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 
+#include <cubos/core/memory/move.hpp>
+
 namespace cubos::core::reflection
 {
     /// @brief Describes how a reflected type may be constructed and destructed.
@@ -132,27 +134,26 @@ namespace cubos::core::reflection
         /// @return Builder.
         Builder&& withDefaultConstructor() &&
         {
-            mTrait = static_cast<ConstructibleTrait&&>(mTrait).withDefaultConstructor(
-                [](void* instance) { new (instance) T(); });
-            return static_cast<Builder&&>(*this);
+            mTrait = memory::move(mTrait).withDefaultConstructor([](void* instance) { new (instance) T(); });
+            return memory::move(*this);
         }
 
         /// @brief Sets the copy constructor of the type.
         /// @return Builder.
         Builder&& withCopyConstructor() &&
         {
-            mTrait = static_cast<ConstructibleTrait&&>(mTrait).withCopyConstructor(
+            mTrait = memory::move(mTrait).withCopyConstructor(
                 [](void* instance, const void* other) { new (instance) T(*static_cast<const T*>(other)); });
-            return static_cast<Builder&&>(*this);
+            return memory::move(*this);
         }
 
         /// @brief Sets the move constructor of the type.
         /// @return Builder.
         Builder&& withMoveConstructor() &&
         {
-            mTrait = static_cast<ConstructibleTrait&&>(mTrait).withMoveConstructor(
-                [](void* instance, void* other) { new (instance) T(static_cast<T&&>(*static_cast<T*>(other))); });
-            return static_cast<Builder&&>(*this);
+            mTrait = memory::move(mTrait).withMoveConstructor(
+                [](void* instance, void* other) { new (instance) T(memory::move(*static_cast<T*>(other))); });
+            return memory::move(*this);
         }
 
     private:

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <vector>
+#include <cstddef>
 
 namespace cubos::core::reflection
 {
@@ -123,7 +123,7 @@ namespace cubos::core::reflection
         /// @return Constructed trait.
         ConstructibleTrait build() &&
         {
-            return std::move(mTrait);
+            return mTrait;
         }
 
         /// @brief Sets the copy constructor of the type.
@@ -131,7 +131,7 @@ namespace cubos::core::reflection
         Builder&& withDefaultConstructor() &&
         {
             mTrait.withDefaultConstructor([](void* instance) { new (instance) T(); });
-            return std::move(*this);
+            return static_cast<Builder&&>(*this);
         }
 
         /// @brief Sets the copy constructor of the type.
@@ -140,7 +140,7 @@ namespace cubos::core::reflection
         {
             mTrait.withCopyConstructor(
                 [](void* instance, const void* other) { new (instance) T(*static_cast<const T*>(other)); });
-            return std::move(*this);
+            return static_cast<Builder&&>(*this);
         }
 
         /// @brief Sets the move constructor of the type.
@@ -148,8 +148,8 @@ namespace cubos::core::reflection
         Builder&& withMoveConstructor() &&
         {
             mTrait.withMoveConstructor(
-                [](void* instance, void* other) { new (instance) T(std::move(*static_cast<T*>(other))); });
-            return std::move(*this);
+                [](void* instance, void* other) { new (instance) T(static_cast<T&&>(*static_cast<T*>(other))); });
+            return static_cast<Builder&&>(*this);
         }
 
     private:

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -47,31 +47,31 @@ namespace cubos::core::reflection
         /// @tparam T Type to build a trait for.
         /// @return Trait builder.
         template <typename T>
-        static Builder<T> builder();
+        static Builder<T> typed();
 
         /// @brief Sets the default constructor of the type.
         ///
         /// Aborts if the default constructor has already been set.
         ///
         /// @param defaultConstructor Function pointer to the default constructor of the type.
-        /// @return Reference to this object.
-        ConstructibleTrait& withDefaultConstructor(DefaultConstructor defaultConstructor);
+        /// @return Trait.
+        ConstructibleTrait&& withDefaultConstructor(DefaultConstructor defaultConstructor) &&;
 
         /// @brief Sets the copy constructor of the type.
         ///
         /// Aborts if the copy constructor has already been set.
         ///
         /// @param copyConstructor Function pointer to the copy constructor of the type.
-        /// @return Reference to this object.
-        ConstructibleTrait& withCopyConstructor(CopyConstructor copyConstructor);
+        /// @return Trait.
+        ConstructibleTrait&& withCopyConstructor(CopyConstructor copyConstructor) &&;
 
         /// @brief Sets the move constructor of the type.
         ///
         /// Aborts if the copy constructor has already been set.
         ///
         /// @param moveConstructor Function pointer to the move constructor of the type.
-        /// @return Reference to this object.
-        ConstructibleTrait& withMoveConstructor(MoveConstructor moveConstructor);
+        /// @return Trait.
+        ConstructibleTrait&& withMoveConstructor(MoveConstructor moveConstructor) &&;
 
         /// @brief Returns the size of the type in bytes.
         /// @return Size of the type in bytes.
@@ -132,7 +132,8 @@ namespace cubos::core::reflection
         /// @return Builder.
         Builder&& withDefaultConstructor() &&
         {
-            mTrait.withDefaultConstructor([](void* instance) { new (instance) T(); });
+            mTrait = static_cast<ConstructibleTrait&&>(mTrait).withDefaultConstructor(
+                [](void* instance) { new (instance) T(); });
             return static_cast<Builder&&>(*this);
         }
 
@@ -140,7 +141,7 @@ namespace cubos::core::reflection
         /// @return Builder.
         Builder&& withCopyConstructor() &&
         {
-            mTrait.withCopyConstructor(
+            mTrait = static_cast<ConstructibleTrait&&>(mTrait).withCopyConstructor(
                 [](void* instance, const void* other) { new (instance) T(*static_cast<const T*>(other)); });
             return static_cast<Builder&&>(*this);
         }
@@ -149,7 +150,7 @@ namespace cubos::core::reflection
         /// @return Builder.
         Builder&& withMoveConstructor() &&
         {
-            mTrait.withMoveConstructor(
+            mTrait = static_cast<ConstructibleTrait&&>(mTrait).withMoveConstructor(
                 [](void* instance, void* other) { new (instance) T(static_cast<T&&>(*static_cast<T*>(other))); });
             return static_cast<Builder&&>(*this);
         }
@@ -159,7 +160,7 @@ namespace cubos::core::reflection
     };
 
     template <typename T>
-    ConstructibleTrait::Builder<T> ConstructibleTrait::builder()
+    ConstructibleTrait::Builder<T> ConstructibleTrait::typed()
     {
         return Builder<T>();
     }

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -43,6 +43,12 @@ namespace cubos::core::reflection
         /// @param destructor Function pointer to the destructor of the type.
         ConstructibleTrait(std::size_t size, std::size_t alignment, void (*destructor)(void*));
 
+        /// @brief Returns a trait builder for the given type.
+        /// @tparam T Type to build a trait for.
+        /// @return Trait builder.
+        template <typename T>
+        static Builder<T> builder();
+
         /// @brief Sets the default constructor of the type.
         ///
         /// Aborts if the default constructor has already been set.
@@ -66,12 +72,6 @@ namespace cubos::core::reflection
         /// @param moveConstructor Function pointer to the move constructor of the type.
         /// @return Reference to this object.
         ConstructibleTrait& withMoveConstructor(MoveConstructor moveConstructor);
-
-        /// @brief Returns a trait builder for the given type.
-        /// @tparam T Type to build a trait for.
-        /// @return Trait builder.
-        template <typename T>
-        static Builder<T> builder();
 
         /// @brief Returns the size of the type in bytes.
         /// @return Size of the type in bytes.

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -9,6 +9,8 @@
 namespace cubos::core::reflection
 {
     /// @brief Describes how a reflected type may be constructed and destructed.
+    /// @see See @ref examples-core-reflection-traits-constructible for an example of using this
+    /// trait.
     /// @ingroup core-reflection
     class ConstructibleTrait
     {

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -127,7 +127,7 @@ namespace cubos::core::reflection
         }
 
         /// @brief Sets the copy constructor of the type.
-        /// @return Reference to this object.
+        /// @return Builder.
         Builder&& withDefaultConstructor() &&
         {
             mTrait.withDefaultConstructor([](void* instance) { new (instance) T(); });
@@ -135,7 +135,7 @@ namespace cubos::core::reflection
         }
 
         /// @brief Sets the copy constructor of the type.
-        /// @return Reference to this object.
+        /// @return Builder.
         Builder&& withCopyConstructor() &&
         {
             mTrait.withCopyConstructor(
@@ -144,7 +144,7 @@ namespace cubos::core::reflection
         }
 
         /// @brief Sets the move constructor of the type.
-        /// @return Reference to this object.
+        /// @return Builder.
         Builder&& withMoveConstructor() &&
         {
             mTrait.withMoveConstructor(

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -1,0 +1,164 @@
+/// @file
+/// @brief Class @ref cubos::core::reflection::ConstructibleTrait.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <vector>
+
+namespace cubos::core::reflection
+{
+    /// @brief Describes how a reflected type may be constructed and destructed.
+    /// @ingroup core-reflection
+    class ConstructibleTrait
+    {
+    public:
+        /// @brief Function pointer to the destructor of a type.
+        /// @param instance Pointer to the instance to destruct.
+        using Destructor = void (*)(void* instance);
+
+        /// @brief Function pointer to the default constructor of a type.
+        /// @param instance Pointer to the location to construct the instance at.
+        using DefaultConstructor = void (*)(void* instance);
+
+        /// @brief Function pointer to the copy constructor of a type.
+        /// @param instance Pointer to the location to construct the instance at.
+        /// @param other Pointer to the instance to copy construct from.
+        using CopyConstructor = void (*)(void* instance, const void* other);
+
+        /// @brief Function pointer to the move constructor of a type.
+        /// @param instance Pointer to the location to construct the instance at.
+        /// @param other Pointer to the instance to move construct from.
+        using MoveConstructor = void (*)(void* instance, void* other);
+
+        /// @brief Builder for @ref ConstructibleTrait.
+        template <typename T>
+        class Builder;
+
+        /// @brief Constructs.
+        /// @param size Size of the type in bytes.
+        /// @param alignment Alignment of the type in bytes (must be a power of two).
+        /// @param destructor Function pointer to the destructor of the type.
+        ConstructibleTrait(std::size_t size, std::size_t alignment, void (*destructor)(void*));
+
+        /// @brief Sets the default constructor of the type.
+        ///
+        /// Aborts if the default constructor has already been set.
+        ///
+        /// @param defaultConstructor Function pointer to the default constructor of the type.
+        /// @return Reference to this object.
+        ConstructibleTrait& withDefaultConstructor(DefaultConstructor defaultConstructor);
+
+        /// @brief Sets the copy constructor of the type.
+        ///
+        /// Aborts if the copy constructor has already been set.
+        ///
+        /// @param copyConstructor Function pointer to the copy constructor of the type.
+        /// @return Reference to this object.
+        ConstructibleTrait& withCopyConstructor(CopyConstructor copyConstructor);
+
+        /// @brief Sets the move constructor of the type.
+        ///
+        /// Aborts if the copy constructor has already been set.
+        ///
+        /// @param moveConstructor Function pointer to the move constructor of the type.
+        /// @return Reference to this object.
+        ConstructibleTrait& withMoveConstructor(MoveConstructor moveConstructor);
+
+        /// @brief Returns a trait builder for the given type.
+        /// @tparam T Type to build a trait for.
+        /// @return Trait builder.
+        template <typename T>
+        static Builder<T> builder();
+
+        /// @brief Returns the size of the type in bytes.
+        /// @return Size of the type in bytes.
+        std::size_t size() const;
+
+        /// @brief Returns the alignment of the type in bytes.
+        /// @return Alignment of the type in bytes.
+        std::size_t alignment() const;
+
+        /// @brief Destructs an instance of the type.
+        /// @param instance Pointer to the instance to destruct.
+        void destruct(void* instance) const;
+
+        /// @brief Default constructs an instance of the type.
+        /// @param instance Pointer to the location to construct the instance at.
+        /// @return Whether default construction is supported.
+        bool defaultConstruct(void* instance) const;
+
+        /// @brief Copy constructs an instance of the type.
+        /// @param instance Pointer to the location to construct the instance at.
+        /// @param other Pointer to the instance to copy construct from.
+        /// @return Whether copy construction is supported.
+        bool copyConstruct(void* instance, const void* other) const;
+
+        /// @brief Move constructs an instance of the type.
+        /// @param instance Pointer to the location to construct the instance at.
+        /// @param other Pointer to the instance to move construct from.
+        /// @return Whether move construction is supported.
+        bool moveConstruct(void* instance, void* other) const;
+
+    private:
+        std::size_t mSize;
+        std::size_t mAlignment;
+        Destructor mDestructor;
+        DefaultConstructor mDefaultConstructor;
+        CopyConstructor mCopyConstructor;
+        MoveConstructor mMoveConstructor;
+    };
+
+    template <typename T>
+    class ConstructibleTrait::Builder
+    {
+    public:
+        /// @brief Constructs.
+        Builder()
+            : mTrait(sizeof(T), alignof(T), [](void* instance) { static_cast<T*>(instance)->~T(); })
+        {
+        }
+
+        /// @brief Returns the constructed trait.
+        /// @return Constructed trait.
+        ConstructibleTrait build() &&
+        {
+            return std::move(mTrait);
+        }
+
+        /// @brief Sets the copy constructor of the type.
+        /// @return Reference to this object.
+        Builder&& withDefaultConstructor() &&
+        {
+            mTrait.withDefaultConstructor([](void* instance) { new (instance) T(); });
+            return std::move(*this);
+        }
+
+        /// @brief Sets the copy constructor of the type.
+        /// @return Reference to this object.
+        Builder&& withCopyConstructor() &&
+        {
+            mTrait.withCopyConstructor(
+                [](void* instance, const void* other) { new (instance) T(*static_cast<const T*>(other)); });
+            return std::move(*this);
+        }
+
+        /// @brief Sets the move constructor of the type.
+        /// @return Reference to this object.
+        Builder&& withMoveConstructor() &&
+        {
+            mTrait.withMoveConstructor(
+                [](void* instance, void* other) { new (instance) T(std::move(*static_cast<T*>(other))); });
+            return std::move(*this);
+        }
+
+    private:
+        ConstructibleTrait mTrait;
+    };
+
+    template <typename T>
+    ConstructibleTrait::Builder<T> ConstructibleTrait::builder()
+    {
+        return Builder<T>();
+    }
+} // namespace cubos::core::reflection

--- a/core/include/cubos/core/reflection/traits/constructible_utils.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible_utils.hpp
@@ -22,17 +22,17 @@ namespace cubos::core::reflection
     {
         auto builder = ConstructibleTrait::typed<T>();
 
-        if (std::is_default_constructible<T>::value)
+        if constexpr (std::is_default_constructible<T>::value)
         {
             builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withDefaultConstructor();
         }
 
-        if (std::is_copy_constructible<T>::value)
+        if constexpr (std::is_copy_constructible<T>::value)
         {
             builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withCopyConstructor();
         }
 
-        if (std::is_move_constructible<T>::value)
+        if constexpr (std::is_move_constructible<T>::value)
         {
             builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withMoveConstructor();
         }

--- a/core/include/cubos/core/reflection/traits/constructible_utils.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible_utils.hpp
@@ -1,0 +1,42 @@
+/// @file
+/// @brief Utilities for @ref cubos::core::reflection::ConstructibleTrait.
+/// @note Avoid using this header as it includes `<type_traits>`.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <type_traits>
+
+#include <cubos/core/reflection/traits/constructible.hpp>
+
+namespace cubos::core::reflection
+{
+    /// @brief Returns a ConstructibleTrait with the default, copy and move constructors, set only
+    /// if the type has them.
+    /// @warning Avoid using this function as its header includes `<type_traits>`.
+    /// @tparam T Type.
+    /// @return ConstructibleTrait.
+    /// @ingroup core-reflection
+    template <typename T>
+    ConstructibleTrait autoConstructibleTrait()
+    {
+        auto builder = ConstructibleTrait::typed<T>();
+
+        if (std::is_default_constructible<T>::value)
+        {
+            builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withDefaultConstructor();
+        }
+
+        if (std::is_copy_constructible<T>::value)
+        {
+            builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withCopyConstructor();
+        }
+
+        if (std::is_move_constructible<T>::value)
+        {
+            builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withMoveConstructor();
+        }
+
+        return static_cast<ConstructibleTrait::Builder<T>&&>(builder).build();
+    }
+} // namespace cubos::core::reflection

--- a/core/include/cubos/core/reflection/traits/constructible_utils.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible_utils.hpp
@@ -24,19 +24,19 @@ namespace cubos::core::reflection
 
         if constexpr (std::is_default_constructible<T>::value)
         {
-            builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withDefaultConstructor();
+            builder = memory::move(builder).withDefaultConstructor();
         }
 
         if constexpr (std::is_copy_constructible<T>::value)
         {
-            builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withCopyConstructor();
+            builder = memory::move(builder).withCopyConstructor();
         }
 
         if constexpr (std::is_move_constructible<T>::value)
         {
-            builder = static_cast<ConstructibleTrait::Builder<T>&&>(builder).withMoveConstructor();
+            builder = memory::move(builder).withMoveConstructor();
         }
 
-        return static_cast<ConstructibleTrait::Builder<T>&&>(builder).build();
+        return memory::move(builder).build();
     }
 } // namespace cubos::core::reflection

--- a/core/include/cubos/core/reflection/traits/module.dox
+++ b/core/include/cubos/core/reflection/traits/module.dox
@@ -1,0 +1,2 @@
+/// @dir
+/// @brief @ref core-reflection module built-in traits.

--- a/core/samples/CMakeLists.txt
+++ b/core/samples/CMakeLists.txt
@@ -28,6 +28,7 @@ endmacro()
 
 make_sample(DIR "logging")
 make_sample(DIR "reflection/basic")
+make_sample(DIR "reflection/traits/constructible")
 make_sample(DIR "data/fs/embedded_archive" SOURCES "embed.cpp")
 make_sample(DIR "data/fs/standard_archive")
 make_sample(DIR "data/serialization")

--- a/core/samples/reflection/basic/page.md
+++ b/core/samples/reflection/basic/page.md
@@ -1,6 +1,6 @@
-# Reflection {#examples-core-reflection-basic}
+# Basic Usage {#examples-core-reflection-basic}
 
-@brief Using the reflection system.
+@brief Defining and using reflectable types.
 
 Lets say you have a type `Person`, which you want to be able to reflect. You
 can declare it as reflectable using the macro @ref CUBOS_REFLECT, for example,

--- a/core/samples/reflection/page.md
+++ b/core/samples/reflection/page.md
@@ -1,6 +1,6 @@
 # Reflection {#examples-core-reflection}
 
-@brief How to use the reflection system.
+@brief Using the @ref core-reflection module.
 
 - @subpage examples-core-reflection-basic - @copybrief examples-core-reflection-basic
 - @subpage examples-core-reflection-traits-constructible - @copybrief examples-core-reflection-traits-constructible

--- a/core/samples/reflection/page.md
+++ b/core/samples/reflection/page.md
@@ -1,0 +1,6 @@
+# Reflection {#examples-core-reflection}
+
+@brief How to use the reflection system.
+
+- @subpage examples-core-reflection-basic - @copybrief examples-core-reflection-basic
+- @subpage examples-core-reflection-traits-constructible - @copybrief examples-core-reflection-traits-constructible

--- a/core/samples/reflection/traits/constructible/main.cpp
+++ b/core/samples/reflection/traits/constructible/main.cpp
@@ -1,0 +1,48 @@
+#include <cubos/core/log.hpp>
+
+/// [Scale declaration]
+#include <cubos/core/reflection/reflect.hpp>
+
+struct Scale
+{
+    CUBOS_REFLECT;
+    float value = 1.0F;
+};
+/// [Scale declaration]
+
+/// [Scale definition]
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::ConstructibleTrait;
+using cubos::core::reflection::Type;
+
+CUBOS_REFLECT_IMPL(Scale)
+{
+    return Type::create("Scale").with(ConstructibleTrait::builder<Scale>().withDefaultConstructor().build());
+}
+/// [Scale definition]
+
+/// [Accessing the trait]
+int main()
+{
+    using cubos::core::reflection::reflect;
+
+    const auto& scaleType = reflect<Scale>();
+    CUBOS_ASSERT(scaleType.has<ConstructibleTrait>());
+    const auto& constructible = scaleType.get<ConstructibleTrait>();
+    /// [Accessing the trait]
+
+    /// [Creating a default instance]
+    // Allocate memory for the instance and default-construct it.
+    void* instance = operator new(constructible.size());
+    CUBOS_ASSERT(constructible.defaultConstruct(instance));
+    CUBOS_ASSERT(static_cast<Scale*>(instance)->value == 1.0F);
+    /// [Creating a default instance]
+
+    /// [Destroying the instance]
+    // Destroy the instance and deallocate its memory.
+    constructible.destruct(instance);
+    operator delete(instance);
+}
+/// [Destroying the instance]

--- a/core/samples/reflection/traits/constructible/main.cpp
+++ b/core/samples/reflection/traits/constructible/main.cpp
@@ -19,7 +19,7 @@ using cubos::core::reflection::Type;
 
 CUBOS_REFLECT_IMPL(Scale)
 {
-    return Type::create("Scale").with(ConstructibleTrait::builder<Scale>().withDefaultConstructor().build());
+    return Type::create("Scale").with(ConstructibleTrait::typed<Scale>().withDefaultConstructor().build());
 }
 /// [Scale definition]
 

--- a/core/samples/reflection/traits/constructible/page.md
+++ b/core/samples/reflection/traits/constructible/page.md
@@ -1,0 +1,44 @@
+# Constructible Trait {#examples-core-reflection-traits-constructible}
+
+@brief Exposing the destructor and constructors of a type.
+
+You may find it useful while working with type-erased data to be able to create
+copies of the data, destroy it, or move it around. The
+@ref cubos::core::reflection::ConstructibleTrait "ConstructibleTrait" trait
+exposes the size, alignment, destructor and constructors of a type.
+
+Lets say you have a type `Scale`, which you want to be able to reflect, with a
+default value of `1.0`:
+
+@snippet reflection/traits/constructible/main.cpp Scale declaration
+
+We're going to add the @ref cubos::core::reflection::ConstructibleTrait
+"ConstructibleTrait" trait to it, so that we can create instances of it at
+runtime:
+
+@snippet reflection/traits/constructible/main.cpp Scale definition
+
+Now, we can access the trait from the reflected type:
+
+@snippet reflection/traits/constructible/main.cpp Accessing the trait
+
+Imagine for a moment that you don't know the type of the data you're working,
+and you only have access to its reflection data through `scaleType`. If you
+want to create a default instance of the type, you can call the default
+constructor stored in the trait:
+
+@snippet reflection/traits/constructible/main.cpp Creating a default instance
+
+The @ref cubos::core::reflection::ConstructibleTrait::defaultConstruct
+"defaultConstruct" method returns a boolean which indicates if the type has a
+default constructor or not. In this case, since we added the default
+constructor to the trait, it will return `true`.
+
+This could be useful, for example, to fallback from using `moveConstruct` to
+`copyConstruct`, if the first isn't available.
+
+Don't forget to destroy the instance manually when you're done with it:
+
+@snippet reflection/traits/constructible/main.cpp Destroying the instance
+
+

--- a/core/src/cubos/core/reflection/traits/constructible.cpp
+++ b/core/src/cubos/core/reflection/traits/constructible.cpp
@@ -1,0 +1,87 @@
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using namespace cubos::core::reflection;
+
+ConstructibleTrait::ConstructibleTrait(std::size_t size, std::size_t alignment, void (*destructor)(void*))
+    : mSize(size)
+    , mAlignment(alignment)
+    , mDestructor(destructor)
+    , mDefaultConstructor(nullptr)
+    , mCopyConstructor(nullptr)
+    , mMoveConstructor(nullptr)
+{
+    CUBOS_ASSERT(mAlignment > 0, "Alignment must be positive");
+    CUBOS_ASSERT((mAlignment & (mAlignment - 1)) == 0, "Alignment must be a power of two");
+    CUBOS_ASSERT(mDestructor, "Destructor must be non-null");
+}
+
+ConstructibleTrait& ConstructibleTrait::withDefaultConstructor(DefaultConstructor defaultConstructor)
+{
+    CUBOS_ASSERT(!mDefaultConstructor, "Default constructor already set");
+    mDefaultConstructor = defaultConstructor;
+    return *this;
+}
+
+ConstructibleTrait& ConstructibleTrait::withCopyConstructor(CopyConstructor copyConstructor)
+{
+    CUBOS_ASSERT(!mCopyConstructor, "Copy constructor already set");
+    mCopyConstructor = copyConstructor;
+    return *this;
+}
+
+ConstructibleTrait& ConstructibleTrait::withMoveConstructor(MoveConstructor moveConstructor)
+{
+    CUBOS_ASSERT(!mMoveConstructor, "Move constructor already set");
+    mMoveConstructor = moveConstructor;
+    return *this;
+}
+
+std::size_t ConstructibleTrait::size() const
+{
+    return mSize;
+}
+
+std::size_t ConstructibleTrait::alignment() const
+{
+    return mAlignment;
+}
+
+void ConstructibleTrait::destruct(void* instance) const
+{
+    mDestructor(instance);
+}
+
+bool ConstructibleTrait::defaultConstruct(void* instance) const
+{
+    if (mDefaultConstructor)
+    {
+        mDefaultConstructor(instance);
+        return true;
+    }
+
+    return false;
+}
+
+bool ConstructibleTrait::copyConstruct(void* instance, const void* other) const
+{
+    if (mCopyConstructor)
+    {
+        mCopyConstructor(instance, other);
+        return true;
+    }
+
+    return false;
+}
+
+bool ConstructibleTrait::moveConstruct(void* instance, void* other) const
+{
+    if (mMoveConstructor)
+    {
+        mMoveConstructor(instance, other);
+        return true;
+    }
+
+    return false;
+}

--- a/core/src/cubos/core/reflection/traits/constructible.cpp
+++ b/core/src/cubos/core/reflection/traits/constructible.cpp
@@ -17,25 +17,25 @@ ConstructibleTrait::ConstructibleTrait(std::size_t size, std::size_t alignment, 
     CUBOS_ASSERT(mDestructor, "Destructor must be non-null");
 }
 
-ConstructibleTrait& ConstructibleTrait::withDefaultConstructor(DefaultConstructor defaultConstructor)
+ConstructibleTrait&& ConstructibleTrait::withDefaultConstructor(DefaultConstructor defaultConstructor) &&
 {
     CUBOS_ASSERT(!mDefaultConstructor, "Default constructor already set");
     mDefaultConstructor = defaultConstructor;
-    return *this;
+    return static_cast<ConstructibleTrait&&>(*this);
 }
 
-ConstructibleTrait& ConstructibleTrait::withCopyConstructor(CopyConstructor copyConstructor)
+ConstructibleTrait&& ConstructibleTrait::withCopyConstructor(CopyConstructor copyConstructor) &&
 {
     CUBOS_ASSERT(!mCopyConstructor, "Copy constructor already set");
     mCopyConstructor = copyConstructor;
-    return *this;
+    return static_cast<ConstructibleTrait&&>(*this);
 }
 
-ConstructibleTrait& ConstructibleTrait::withMoveConstructor(MoveConstructor moveConstructor)
+ConstructibleTrait&& ConstructibleTrait::withMoveConstructor(MoveConstructor moveConstructor) &&
 {
     CUBOS_ASSERT(!mMoveConstructor, "Move constructor already set");
     mMoveConstructor = moveConstructor;
-    return *this;
+    return static_cast<ConstructibleTrait&&>(*this);
 }
 
 std::size_t ConstructibleTrait::size() const

--- a/core/src/cubos/core/reflection/traits/constructible.cpp
+++ b/core/src/cubos/core/reflection/traits/constructible.cpp
@@ -21,21 +21,21 @@ ConstructibleTrait&& ConstructibleTrait::withDefaultConstructor(DefaultConstruct
 {
     CUBOS_ASSERT(!mDefaultConstructor, "Default constructor already set");
     mDefaultConstructor = defaultConstructor;
-    return static_cast<ConstructibleTrait&&>(*this);
+    return memory::move(*this);
 }
 
 ConstructibleTrait&& ConstructibleTrait::withCopyConstructor(CopyConstructor copyConstructor) &&
 {
     CUBOS_ASSERT(!mCopyConstructor, "Copy constructor already set");
     mCopyConstructor = copyConstructor;
-    return static_cast<ConstructibleTrait&&>(*this);
+    return memory::move(*this);
 }
 
 ConstructibleTrait&& ConstructibleTrait::withMoveConstructor(MoveConstructor moveConstructor) &&
 {
     CUBOS_ASSERT(!mMoveConstructor, "Move constructor already set");
     mMoveConstructor = moveConstructor;
-    return static_cast<ConstructibleTrait&&>(*this);
+    return memory::move(*this);
 }
 
 std::size_t ConstructibleTrait::size() const

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
 
     reflection/reflect.cpp
     reflection/type.cpp
+    reflection/traits/constructible.cpp
 
     data/fs/embedded_archive.cpp
     data/fs/standard_archive.cpp

--- a/core/tests/reflection/traits/constructible.cpp
+++ b/core/tests/reflection/traits/constructible.cpp
@@ -1,0 +1,108 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/traits/constructible.hpp>
+
+#include "../../utils.hpp"
+
+using cubos::core::reflection::ConstructibleTrait;
+
+struct SimpleConstructible
+{
+    static constexpr int DEFAULT = 0x12345678;
+
+    int value;
+
+    SimpleConstructible()
+        : value(DEFAULT)
+    {
+    }
+};
+
+TEST_CASE("reflection::ConstructibleTrait")
+{
+    SUBCASE("size and alignment are correct")
+    {
+        auto trait = ConstructibleTrait::builder<DetectDestructor>().build();
+        CHECK(trait.size() == sizeof(DetectDestructor));
+        CHECK(trait.alignment() == alignof(DetectDestructor));
+    }
+
+    SUBCASE("destructor works")
+    {
+        auto ptr = operator new(sizeof(DetectDestructor));
+
+        auto trait = ConstructibleTrait::builder<DetectDestructor>().build();
+        bool destroyed = false;
+        auto detector = new (ptr) DetectDestructor(&destroyed);
+
+        REQUIRE_FALSE(destroyed);
+        trait.destruct(detector);
+        CHECK(destroyed);
+    }
+
+    SUBCASE("non-assigned constructors work as expected")
+    {
+        auto ptr = operator new(sizeof(DetectDestructor));
+
+        auto trait = ConstructibleTrait::builder<DetectDestructor>().build();
+        DetectDestructor detector{};
+
+        CHECK_FALSE(trait.defaultConstruct(ptr));
+        CHECK_FALSE(trait.copyConstruct(ptr, &detector));
+        CHECK_FALSE(trait.moveConstruct(ptr, &detector));
+
+        operator delete(ptr);
+    }
+
+    SUBCASE("default constructor works")
+    {
+        auto ptr = operator new(sizeof(SimpleConstructible));
+
+        auto trait = ConstructibleTrait::builder<SimpleConstructible>().withDefaultConstructor().build();
+        REQUIRE(trait.defaultConstruct(ptr));
+
+        auto simple = static_cast<SimpleConstructible*>(ptr);
+        CHECK(simple->value == SimpleConstructible::DEFAULT);
+        trait.destruct(ptr);
+
+        operator delete(ptr);
+    }
+
+    SUBCASE("copy constructor works")
+    {
+        auto ptr = operator new(sizeof(SimpleConstructible));
+
+        auto trait = ConstructibleTrait::builder<SimpleConstructible>().withCopyConstructor().build();
+        SimpleConstructible copied{};
+        copied.value = 1;
+        REQUIRE(trait.copyConstruct(ptr, &copied));
+
+        auto simple = static_cast<SimpleConstructible*>(ptr);
+        CHECK(simple->value == copied.value);
+        trait.destruct(ptr);
+
+        operator delete(ptr);
+    }
+
+    SUBCASE("move constructor works")
+    {
+        auto ptr = operator new(sizeof(DetectDestructor));
+
+        auto trait = ConstructibleTrait::builder<DetectDestructor>().withMoveConstructor().build();
+        bool destroyed = false;
+
+        // The destroyed flag is moved from the 'moved' detector to the detector at 'ptr', and thus
+        // the flag is not set when 'moved' is destructed.
+        {
+            DetectDestructor moved{&destroyed};
+            REQUIRE(trait.moveConstruct(ptr, &moved));
+            REQUIRE_FALSE(destroyed);
+        }
+
+        CHECK_FALSE(destroyed);
+        trait.destruct(ptr);
+        CHECK(destroyed);
+
+        operator delete(ptr);
+    }
+}

--- a/core/tests/reflection/traits/constructible.cpp
+++ b/core/tests/reflection/traits/constructible.cpp
@@ -22,7 +22,7 @@ TEST_CASE("reflection::ConstructibleTrait")
 {
     SUBCASE("size and alignment are correct")
     {
-        auto trait = ConstructibleTrait::builder<DetectDestructor>().build();
+        auto trait = ConstructibleTrait::typed<DetectDestructor>().build();
         CHECK(trait.size() == sizeof(DetectDestructor));
         CHECK(trait.alignment() == alignof(DetectDestructor));
     }
@@ -31,20 +31,22 @@ TEST_CASE("reflection::ConstructibleTrait")
     {
         auto ptr = operator new(sizeof(DetectDestructor));
 
-        auto trait = ConstructibleTrait::builder<DetectDestructor>().build();
+        auto trait = ConstructibleTrait::typed<DetectDestructor>().build();
         bool destroyed = false;
         auto detector = new (ptr) DetectDestructor(&destroyed);
 
         REQUIRE_FALSE(destroyed);
         trait.destruct(detector);
         CHECK(destroyed);
+
+        operator delete(ptr);
     }
 
     SUBCASE("non-assigned constructors work as expected")
     {
         auto ptr = operator new(sizeof(DetectDestructor));
 
-        auto trait = ConstructibleTrait::builder<DetectDestructor>().build();
+        auto trait = ConstructibleTrait::typed<DetectDestructor>().build();
         DetectDestructor detector{};
 
         CHECK_FALSE(trait.defaultConstruct(ptr));
@@ -58,7 +60,7 @@ TEST_CASE("reflection::ConstructibleTrait")
     {
         auto ptr = operator new(sizeof(SimpleConstructible));
 
-        auto trait = ConstructibleTrait::builder<SimpleConstructible>().withDefaultConstructor().build();
+        auto trait = ConstructibleTrait::typed<SimpleConstructible>().withDefaultConstructor().build();
         REQUIRE(trait.defaultConstruct(ptr));
 
         auto simple = static_cast<SimpleConstructible*>(ptr);
@@ -72,7 +74,7 @@ TEST_CASE("reflection::ConstructibleTrait")
     {
         auto ptr = operator new(sizeof(SimpleConstructible));
 
-        auto trait = ConstructibleTrait::builder<SimpleConstructible>().withCopyConstructor().build();
+        auto trait = ConstructibleTrait::typed<SimpleConstructible>().withCopyConstructor().build();
         SimpleConstructible copied{};
         copied.value = 1;
         REQUIRE(trait.copyConstruct(ptr, &copied));
@@ -88,7 +90,7 @@ TEST_CASE("reflection::ConstructibleTrait")
     {
         auto ptr = operator new(sizeof(DetectDestructor));
 
-        auto trait = ConstructibleTrait::builder<DetectDestructor>().withMoveConstructor().build();
+        auto trait = ConstructibleTrait::typed<DetectDestructor>().withMoveConstructor().build();
         bool destroyed = false;
 
         // The destroyed flag is moved from the 'moved' detector to the detector at 'ptr', and thus

--- a/docs/pages/3_examples/1_core/main.md
+++ b/docs/pages/3_examples/1_core/main.md
@@ -6,15 +6,7 @@
 you plan to work on the engine itself, it's possible, if not probable, that you
 will need to use some of the features of the @ref core library directly.
 
-## Fully documented examples
-
 The following examples have fully documented tutorials:
+
 - @subpage examples-core-logging - @copybrief examples-core-logging
-- @subpage examples-core-reflection-basic - @copybrief examples-core-reflection-basic
-
-## Undocumented examples
-
-The following examples are not yet documented, but may still be useful to learn
-some of the features:
-
-@note Under construction.
+- @subpage examples-core-reflection - @copybrief examples-core-reflection


### PR DESCRIPTION
# Description

Adds the `ConstructibleTrait`, which holds the default, copy and move constructors of a type, and its size, alignment and destructor.
This is useful for creating and managing new instances of type-erased data. 

## Checklist

- [x] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
- [X] Write new samples.
