### PR TITLE
Remove afterSystem and beforeSystem

### DIFF
--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -93,21 +93,9 @@ namespace cubos::core::ecs
         /// @param tag Tag to run after.
         void systemSetAfterTag(const std::string& tag);
 
-        /// @brief Sets the current system to run after a given system.
-        /// @tparam F System type.
-        /// @param func System to run after.
-        template <typename F>
-        void systemSetAfterSystem(F func);
-
         /// @brief Sets the current system to run before the tag.
         /// @param tag Tag to run before.
         void systemSetBeforeTag(const std::string& tag);
-
-        /// @brief Sets the current system to run before the system.
-        /// @tparam F System type.
-        /// @param func System to run before.
-        template <typename F>
-        void systemSetBeforeSystem(F func);
 
         /// @brief Adds a condition to the current system.
         /// @tparam F Condition type.
@@ -221,58 +209,6 @@ namespace cubos::core::ecs
         auto* system = new System{nullptr, std::make_shared<SystemWrapper<F>>(func), {}};
         mPendingSystems.push_back(system);
         mCurrSystem = mPendingSystems.back();
-    }
-
-    template <typename F>
-    void Dispatcher::systemSetAfterSystem(F func)
-    {
-        auto it = std::find_if(mPendingSystems.begin(), mPendingSystems.end(), [&func](const System* system) {
-            auto* wrapper = dynamic_cast<SystemWrapper<F>*>(system->system.get());
-            if (!wrapper)
-            {
-                return false;
-            }
-            return wrapper->mSystem == func;
-        });
-        if (it == mPendingSystems.end())
-        {
-            CUBOS_ERROR("Tried to set system after a non-existing system!");
-            return;
-        }
-        ENSURE_CURR_SYSTEM();
-        ENSURE_SYSTEM_SETTINGS(mCurrSystem);
-        System* system = *it;
-        ENSURE_SYSTEM_SETTINGS(system);
-        // Set curr to run after this system
-        mCurrSystem->settings->after.system.push_back(system);
-        // And this system to run before curr
-        system->settings->before.system.push_back(mCurrSystem);
-    }
-
-    template <typename F>
-    void Dispatcher::systemSetBeforeSystem(F func)
-    {
-        auto it = std::find_if(mPendingSystems.begin(), mPendingSystems.end(), [&func](const System* system) {
-            auto* wrapper = dynamic_cast<SystemWrapper<F>*>(system->system.get());
-            if (!wrapper)
-            {
-                return false;
-            }
-            return wrapper->mSystem == func;
-        });
-        if (it == mPendingSystems.end())
-        {
-            CUBOS_ERROR("Tried to set system before a non-existing system!");
-            return;
-        }
-        ENSURE_CURR_SYSTEM();
-        ENSURE_SYSTEM_SETTINGS(mCurrSystem);
-        System* system = *it;
-        ENSURE_SYSTEM_SETTINGS(system);
-        // Set curr to run before this system
-        mCurrSystem->settings->before.system.push_back(system);
-        // And this system to run after curr
-        system->settings->after.system.push_back(mCurrSystem);
     }
 
     template <typename F>

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -61,12 +61,12 @@ namespace cubos::engine
         /// @brief Sets the current tag to be executed before another tag.
         /// @param tag Tag to be executed before.
         /// @return Reference to this object, for chaining.
-        TagBuilder& beforeTag(const std::string& tag);
+        TagBuilder& before(const std::string& tag);
 
         /// @brief Sets the current tag to be executed after another tag.
         /// @param tag Tag to be executed after.
         /// @return Reference to this object, for chaining.
-        TagBuilder& afterTag(const std::string& tag);
+        TagBuilder& after(const std::string& tag);
 
         /// @brief Adds a condition to the current tag. If this condition returns false, systems
         /// with this tag will not be executed. For the tagged systems to run, all conditions must
@@ -99,26 +99,12 @@ namespace cubos::engine
         /// @brief Sets the current system to be executed before another tag.
         /// @param tag Tag to be executed before.
         /// @return Reference to this object, for chaining.
-        SystemBuilder& beforeTag(const std::string& tag);
+        SystemBuilder& before(const std::string& tag);
 
         /// @brief Sets the current system to be executed after another tag.
         /// @param tag Tag to be executed after.
         /// @return Reference to this object, for chaining.
-        SystemBuilder& afterTag(const std::string& tag);
-
-        /// @brief Sets the current system to be executed before another system.
-        /// @tparam F System type.
-        /// @param func System to be executed before.
-        /// @return Reference to this object, for chaining.
-        template <typename F>
-        SystemBuilder& beforeSystem(F func);
-
-        /// @brief Sets the current system to be executed after another system.
-        /// @param func System to be executed after.
-        /// @tparam F System type.
-        /// @return Reference to this object, for chaining.
-        template <typename F>
-        SystemBuilder& afterSystem(F func);
+        SystemBuilder& after(const std::string& tag);
 
         /// @brief Adds a condition to the current system. If this condition returns false, the
         /// system will not be executed. For a system to run, all conditions must return true.
@@ -223,20 +209,6 @@ namespace cubos::engine
     TagBuilder& TagBuilder::runIf(F func)
     {
         mDispatcher.tagAddCondition(func);
-        return *this;
-    }
-
-    template <typename F>
-    SystemBuilder& SystemBuilder::beforeSystem(F func)
-    {
-        mDispatcher.systemSetBeforeSystem(func);
-        return *this;
-    }
-
-    template <typename F>
-    SystemBuilder& SystemBuilder::afterSystem(F func)
-    {
-        mDispatcher.systemSetAfterSystem(func);
         return *this;
     }
 

--- a/engine/samples/cars/main.cpp
+++ b/engine/samples/cars/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
     cubos.addResource<Spawner>();
 
     cubos.startupSystem(settings).tagged("cubos.settings");
-    cubos.startupSystem(setup).tagged("cubos.assets").afterTag("cubos.renderer.init");
+    cubos.startupSystem(setup).tagged("cubos.assets").after("cubos.renderer.init");
     cubos.system(spawn);
     cubos.system(move);
 

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -154,9 +154,9 @@ int main()
 
     cubos.startupSystem(addColliders);
 
-    cubos.system(updateTransform).beforeTag("cubos.transform.update");
-    cubos.system(updateCollided).tagged("updated").afterTag("cubos.collisions");
-    cubos.system(render).afterTag("updated");
+    cubos.system(updateTransform).before("cubos.transform.update");
+    cubos.system(updateCollided).tagged("updated").after("cubos.collisions");
+    cubos.system(render).after("updated");
 
     cubos.run();
     return 0;

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -29,7 +29,7 @@ int main()
             }
         })
         .tagged("A")
-        .beforeTag("B");
+        .before("B");
     cubos
         .system(
             [](ecs::EventWriter<MyEvent> writer, ecs::Write<State> state, ecs::Write<cubos::engine::ShouldQuit> quit) {
@@ -59,7 +59,7 @@ int main()
             }
         })
         .tagged("C")
-        .afterTag("B");
+        .after("B");
     cubos
         .system([](ecs::EventReader<MyEvent> reader) {
             for (const auto& event : reader)
@@ -68,7 +68,7 @@ int main()
             }
         })
         .tagged("D")
-        .afterTag("C");
+        .after("C");
 
     // Should print:
     // B wrote 1 2 3

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -220,7 +220,7 @@ int main()
     cubos.startupSystem(config).tagged("cubos.settings");
     cubos.startupSystem(init).tagged("cubos.assets");
 
-    cubos.system(update).afterTag("cubos.input.update");
+    cubos.system(update).after("cubos.input.update");
 
     cubos.run();
     return 0;

--- a/engine/samples/renderer/main.cpp
+++ b/engine/samples/renderer/main.cpp
@@ -95,7 +95,7 @@ int main()
     cubos.startupSystem(settingsSystem).tagged("cubos.settings");
 
     /// [Adding the systems]
-    cubos.startupSystem(setPaletteSystem).afterTag("cubos.renderer.init");
+    cubos.startupSystem(setPaletteSystem).after("cubos.renderer.init");
     cubos.startupSystem(spawnVoxelGridSystem);
     cubos.startupSystem(spawnLightSystem);
     cubos.startupSystem(setEnvironmentSystem);

--- a/engine/samples/scene/main.cpp
+++ b/engine/samples/scene/main.cpp
@@ -56,6 +56,6 @@ int main(int argc, char** argv)
 
     cubos.startupSystem(settings).tagged("cubos.settings");
     cubos.startupSystem(spawnScene).tagged("spawn").tagged("cubos.assets");
-    cubos.startupSystem(printStuff).afterTag("spawn");
+    cubos.startupSystem(printStuff).after("spawn");
     cubos.run();
 }

--- a/engine/samples/systems/main.cpp
+++ b/engine/samples/systems/main.cpp
@@ -40,8 +40,8 @@ int main()
 {
     cubos::engine::Cubos cubos;
 
-    cubos.startupTag("B").beforeTag("C");
-    cubos.startupTag("C").afterTag("A");
+    cubos.startupTag("B").before("C");
+    cubos.startupTag("C").after("A");
     cubos.startupTag("A");
 
     // Order using tags
@@ -49,21 +49,8 @@ int main()
     cubos.startupSystem(tagC).tagged("C");
     cubos.startupSystem(tagA).tagged("A");
 
-    // Order using systems
-    cubos.startupSystem(systemC);
-    cubos.startupSystem(systemA).beforeSystem(systemC).afterTag("C");
-    cubos.startupSystem(systemB).afterSystem(systemA);
-
-    // Lambda between systems and tags
-    auto lambda = []() { CUBOS_INFO("--- INTERMISSION ---"); };
-    cubos.startupSystem(lambda).afterTag("C").beforeSystem(systemA);
-
-    // System inheritance
-    cubos.startupSystem(systemInherit1).tagged("A");
-    cubos.startupSystem(systemInherit2).afterTag("B").beforeSystem(systemInherit1);
-
     // Closed loop. This will prevent chain compilation!
-    // cubos.startupTag("A").afterTag("C");
+    // cubos.startupTag("A").after("C");
 
     // Conditions, determining system execution
     auto lambdaCondYes = []() { CUBOS_INFO("System ran with condition true!"); };

--- a/engine/src/cubos/engine/assets/plugin.cpp
+++ b/engine/src/cubos/engine/assets/plugin.cpp
@@ -37,8 +37,8 @@ void cubos::engine::assetsPlugin(Cubos& cubos)
 {
     cubos.addResource<Assets>();
 
-    cubos.startupTag("cubos.assets.init").afterTag("cubos.settings");
-    cubos.startupTag("cubos.assets.bridge").afterTag("cubos.assets.init").beforeTag("cubos.assets");
+    cubos.startupTag("cubos.assets.init").after("cubos.settings");
+    cubos.startupTag("cubos.assets.bridge").after("cubos.assets.init").before("cubos.assets");
 
     cubos.startupSystem(init).tagged("cubos.assets.init");
     cubos.system(cleanup).tagged("cubos.assets.cleanup");

--- a/engine/src/cubos/engine/collisions/plugin.cpp
+++ b/engine/src/cubos/engine/collisions/plugin.cpp
@@ -20,16 +20,16 @@ void cubos::engine::collisionsPlugin(Cubos& cubos)
     cubos.system(addMissingAABBs<SimplexCollider>).tagged("cubos.collisions.aabb.missing");
     cubos.system(addMissingAABBs<CapsuleCollider>).tagged("cubos.collisions.aabb.missing");
     cubos.system(addMissingAABBs<PlaneCollider>).tagged("cubos.collisions.aabb.missing");
-    cubos.tag("cubos.collisions.aabb.missing").beforeTag("cubos.collisions.aabb");
+    cubos.tag("cubos.collisions.aabb.missing").before("cubos.collisions.aabb");
 
     cubos.system(updateBoxAABBs).tagged("cubos.collisions.aabb");
     cubos.system(updateCapsuleAABBs).tagged("cubos.collisions.aabb");
     cubos.system(updateSimplexAABBs).tagged("cubos.collisions.aabb");
-    cubos.tag("cubos.collisions.aabb").afterTag("cubos.transform.update");
+    cubos.tag("cubos.collisions.aabb").after("cubos.transform.update");
 
-    cubos.system(updateMarkers).tagged("cubos.collisions.broad.markers").afterTag("cubos.collisions.aabb");
-    cubos.system(sweep).tagged("cubos.collisions.broad.sweep").afterTag("cubos.collisions.broad.markers");
-    cubos.system(findPairs).tagged("cubos.collisions.broad").afterTag("cubos.collisions.broad.sweep");
+    cubos.system(updateMarkers).tagged("cubos.collisions.broad.markers").after("cubos.collisions.aabb");
+    cubos.system(sweep).tagged("cubos.collisions.broad.sweep").after("cubos.collisions.broad.markers");
+    cubos.system(findPairs).tagged("cubos.collisions.broad").after("cubos.collisions.broad.sweep");
 
-    cubos.tag("cubos.collisions.broad").beforeTag("cubos.collisions");
+    cubos.tag("cubos.collisions.broad").before("cubos.collisions");
 }

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -29,14 +29,14 @@ TagBuilder::TagBuilder(core::ecs::Dispatcher& dispatcher, std::vector<std::strin
 {
 }
 
-TagBuilder& TagBuilder::beforeTag(const std::string& tag)
+TagBuilder& TagBuilder::before(const std::string& tag)
 {
     mTags.push_back(tag);
     mDispatcher.tagSetBeforeTag(tag);
     return *this;
 }
 
-TagBuilder& TagBuilder::afterTag(const std::string& tag)
+TagBuilder& TagBuilder::after(const std::string& tag)
 {
     mTags.push_back(tag);
     mDispatcher.tagSetAfterTag(tag);
@@ -60,7 +60,7 @@ SystemBuilder& SystemBuilder::tagged(const std::string& tag)
     return *this;
 }
 
-SystemBuilder& SystemBuilder::beforeTag(const std::string& tag)
+SystemBuilder& SystemBuilder::before(const std::string& tag)
 {
     if (std::find(mTags.begin(), mTags.end(), tag) != mTags.end())
     {
@@ -71,7 +71,7 @@ SystemBuilder& SystemBuilder::beforeTag(const std::string& tag)
     return *this;
 }
 
-SystemBuilder& SystemBuilder::afterTag(const std::string& tag)
+SystemBuilder& SystemBuilder::after(const std::string& tag)
 {
     if (std::find(mTags.begin(), mTags.end(), tag) != mTags.end())
     {

--- a/engine/src/cubos/engine/imgui/plugin.cpp
+++ b/engine/src/cubos/engine/imgui/plugin.cpp
@@ -38,10 +38,10 @@ void cubos::engine::imguiPlugin(Cubos& cubos)
 {
     cubos.addPlugin(cubos::engine::windowPlugin);
 
-    cubos.startupTag("cubos.imgui.init").afterTag("cubos.window.init");
-    cubos.tag("cubos.imgui.begin").afterTag("cubos.window.poll");
-    cubos.tag("cubos.imgui.end").beforeTag("cubos.window.render").afterTag("cubos.imgui.begin");
-    cubos.tag("cubos.imgui").afterTag("cubos.imgui.begin").beforeTag("cubos.imgui.end");
+    cubos.startupTag("cubos.imgui.init").after("cubos.window.init");
+    cubos.tag("cubos.imgui.begin").after("cubos.window.poll");
+    cubos.tag("cubos.imgui.end").before("cubos.window.render").after("cubos.imgui.begin");
+    cubos.tag("cubos.imgui").after("cubos.imgui.begin").before("cubos.imgui.end");
 
     cubos.startupSystem(init).tagged("cubos.imgui.init");
     cubos.system(begin).tagged("cubos.imgui.begin");

--- a/engine/src/cubos/engine/input/plugin.cpp
+++ b/engine/src/cubos/engine/input/plugin.cpp
@@ -33,5 +33,5 @@ void cubos::engine::inputPlugin(Cubos& cubos)
     cubos.addResource<Input>();
 
     cubos.startupSystem(bridge).tagged("cubos.assets.bridge");
-    cubos.system(update).tagged("cubos.input.update").afterTag("cubos.window.poll");
+    cubos.system(update).tagged("cubos.input.update").after("cubos.window.poll");
 }

--- a/engine/src/cubos/engine/renderer/plugin.cpp
+++ b/engine/src/cubos/engine/renderer/plugin.cpp
@@ -196,9 +196,9 @@ void cubos::engine::rendererPlugin(Cubos& cubos)
     cubos.addComponent<DirectionalLight>();
     cubos.addComponent<PointLight>();
 
-    cubos.startupTag("cubos.renderer.init").afterTag("cubos.window.init");
-    cubos.tag("cubos.renderer.frame").afterTag("cubos.transform.update");
-    cubos.tag("cubos.renderer.render").afterTag("cubos.renderer.frame").beforeTag("cubos.window.render");
+    cubos.startupTag("cubos.renderer.init").after("cubos.window.init");
+    cubos.tag("cubos.renderer.frame").after("cubos.transform.update");
+    cubos.tag("cubos.renderer.render").after("cubos.renderer.frame").before("cubos.window.render");
 
     cubos.startupSystem(init).tagged("cubos.renderer.init");
     cubos.system(frameGrids).tagged("cubos.renderer.frame");
@@ -207,5 +207,5 @@ void cubos::engine::rendererPlugin(Cubos& cubos)
     cubos.system(framePointLights).tagged("cubos.renderer.frame");
     cubos.system(frameEnvironment).tagged("cubos.renderer.frame");
     cubos.system(draw).tagged("cubos.renderer.draw");
-    cubos.system(resize).afterTag("cubos.window.poll").beforeTag("cubos.renderer.draw");
+    cubos.system(resize).after("cubos.window.poll").before("cubos.renderer.draw");
 }

--- a/engine/src/cubos/engine/window/plugin.cpp
+++ b/engine/src/cubos/engine/window/plugin.cpp
@@ -42,8 +42,8 @@ void cubos::engine::windowPlugin(Cubos& cubos)
     cubos.addResource<Window>();
     cubos.addEvent<WindowEvent>();
 
-    cubos.startupTag("cubos.window.init").afterTag("cubos.settings");
-    cubos.tag("cubos.window.poll").beforeTag("cubos.window.render");
+    cubos.startupTag("cubos.window.init").after("cubos.settings");
+    cubos.tag("cubos.window.poll").before("cubos.window.render");
 
     cubos.startupSystem(init).tagged("cubos.window.init");
     cubos.system(poll).tagged("cubos.window.poll");


### PR DESCRIPTION
# Description

Removed all code related to ordering systems by systems, and renamed `afterTag()` and `beforeTag()` to `after()` and `before()`, respectively.
