### PR TITLE
Add `clang-tools` to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
             ccache
             pkg-config
 
+            # = formatting =
+            clang-tools
+
             # = docs =
             doxygen
             (python3.withPackages (ps: [


### PR DESCRIPTION
# Description

Required for the `clang-format` hook to work.