### PR TITLE
Do not use `std::clamp` on axis.cpp

### DIFF
--- a/engine/src/cubos/engine/input/axis.cpp
+++ b/engine/src/cubos/engine/input/axis.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <cubos/core/io/keyboard.hpp>
 #include <cubos/core/log.hpp>
 
@@ -45,9 +47,11 @@ float InputAxis::value() const
 
 void InputAxis::value(float value)
 {
-    if (std::abs(value) > 1.0F)
+    mValue = value;
+
+    if (std::abs(mValue) > 1.0F)
     {
-        CUBOS_WARN("Axis value out of range: {}", value);
+        CUBOS_WARN("Axis value out of range: {}", mValue);
+        mValue = mValue > 1.0F ? 1.0F : -1.0F;
     }
-    mValue = std::clamp(value, -1.0F, 1.0F);
 }


### PR DESCRIPTION
# Description

Stopped using `std::clamp` instead of including `<algorithm>`.