### PR TITLE
Add include checks to clang tidy and disable it by default

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,9 @@ Checks: "\
   performance-*,\
   -performance-no-int-to-ptr,\
   misc-redundant-expression,\
+  misc-include-cleaner,\
+  misc-header-include-cycle,\
+  misc-definitions-in-headers,\
   cppcoreguidelines-virtual-class-destructor"
 WarningsAsErrors: '*'
 FormatStyle: file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ function(cubos_common_target_options target)
     # Enable clang-tidy
     find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
     if(CLANG_TIDY_EXE)
-        option(USE_CLANG_TIDY "Enable clang-tidy" ON)
+        option(USE_CLANG_TIDY "Enable clang-tidy" OFF)
         if(USE_CLANG_TIDY)
             set(CLANG_TIDY_COMMAND "${CLANG_TIDY_EXE}")
             if(FIX_CLANG_TIDY_ERRORS)


### PR DESCRIPTION
Blocked by #631.

# Description

Add include checks.
Disable `clang-tidy` by default.

## Checklist

- [X] Self-review changes.
