### PR TITLE
Correctly check if anisotropy extension is available in `OGLRenderDevice`

### DIFF
--- a/core/src/cubos/core/gl/ogl_render_device.cpp
+++ b/core/src/cubos/core/gl/ogl_render_device.cpp
@@ -1655,9 +1655,9 @@ Sampler OGLRenderDevice::createSampler(const SamplerDesc& desc)
     glGenSamplers(1, &id);
     glSamplerParameteri(id, GL_TEXTURE_MIN_FILTER, static_cast<GLint>(minFilter));
     glSamplerParameteri(id, GL_TEXTURE_MAG_FILTER, static_cast<GLint>(magFilter));
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
-        glSamplerParameteri(id, GL_TEXTURE_MAX_ANISOTROPY, static_cast<GLint>(desc.maxAnisotropy));
+        glSamplerParameteri(id, GL_TEXTURE_MAX_ANISOTROPY_EXT, static_cast<GLint>(desc.maxAnisotropy));
     }
     glSamplerParameteri(id, GL_TEXTURE_WRAP_S, static_cast<GLint>(addressU));
     glSamplerParameteri(id, GL_TEXTURE_WRAP_T, static_cast<GLint>(addressV));
@@ -1707,7 +1707,7 @@ Texture1D OGLRenderDevice::createTexture1D(const Texture1DDesc& desc)
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
         glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0F);
     }
@@ -1751,7 +1751,7 @@ Texture2D OGLRenderDevice::createTexture2D(const Texture2DDesc& desc)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0F);
     }
@@ -1803,7 +1803,7 @@ Texture2DArray OGLRenderDevice::createTexture2DArray(const Texture2DArrayDesc& d
     glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
         glTexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0F);
     }
@@ -1854,7 +1854,7 @@ Texture3D OGLRenderDevice::createTexture3D(const Texture3DDesc& desc)
     glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
         glTexParameterf(GL_TEXTURE_3D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0F);
     }
@@ -1912,7 +1912,7 @@ CubeMap OGLRenderDevice::createCubeMap(const CubeMapDesc& desc)
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
         glTexParameterf(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0F);
     }
@@ -1967,7 +1967,7 @@ CubeMapArray OGLRenderDevice::createCubeMapArray(const CubeMapArrayDesc& desc)
     glTexParameteri(GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    if (GL_ARB_texture_filter_anisotropic)
+    if (GLAD_GL_ARB_texture_filter_anisotropic != 0)
     {
         glTexParameterf(GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0F);
     }
@@ -2519,7 +2519,7 @@ int OGLRenderDevice::getProperty(Property prop)
     switch (prop)
     {
     case Property::MaxAnisotropy:
-        if (!GL_ARB_texture_filter_anisotropic)
+        if (GLAD_GL_ARB_texture_filter_anisotropic == 0)
         {
             return 1;
         }


### PR DESCRIPTION
# Description

Read the #633 for more information.

## Checklist

- [x] Self-review changes.
