### PR TITLE
Move system stuff to the `ecs/system` directory

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -76,10 +76,10 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/ecs/component/registry.cpp"
     "src/cubos/core/ecs/component/manager.cpp"
     "src/cubos/core/ecs/system/system.cpp"
+    "src/cubos/core/ecs/system/dispatcher.cpp"
     "src/cubos/core/ecs/commands.cpp"
     "src/cubos/core/ecs/blueprint.cpp"
     "src/cubos/core/ecs/world.cpp"
-    "src/cubos/core/ecs/dispatcher.cpp"
 )
 
 # Create core library

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -77,7 +77,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/ecs/component/manager.cpp"
     "src/cubos/core/ecs/system/system.cpp"
     "src/cubos/core/ecs/system/dispatcher.cpp"
-    "src/cubos/core/ecs/commands.cpp"
+    "src/cubos/core/ecs/system/commands.cpp"
     "src/cubos/core/ecs/blueprint.cpp"
     "src/cubos/core/ecs/world.cpp"
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -75,10 +75,10 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/ecs/entity/manager.cpp"
     "src/cubos/core/ecs/component/registry.cpp"
     "src/cubos/core/ecs/component/manager.cpp"
+    "src/cubos/core/ecs/system/system.cpp"
     "src/cubos/core/ecs/commands.cpp"
     "src/cubos/core/ecs/blueprint.cpp"
     "src/cubos/core/ecs/world.cpp"
-    "src/cubos/core/ecs/system.cpp"
     "src/cubos/core/ecs/dispatcher.cpp"
 )
 

--- a/core/include/cubos/core/ecs/blueprint.hpp
+++ b/core/include/cubos/core/ecs/blueprint.hpp
@@ -7,8 +7,8 @@
 #include <cubos/core/data/old/binary_deserializer.hpp>
 #include <cubos/core/data/old/binary_serializer.hpp>
 #include <cubos/core/data/old/serialization_map.hpp>
-#include <cubos/core/ecs/commands.hpp>
 #include <cubos/core/ecs/entity/hash.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/memory/buffer_stream.hpp>
 #include <cubos/core/memory/type_map.hpp>
 

--- a/core/include/cubos/core/ecs/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/dispatcher.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <cubos/core/ecs/system.hpp>
+#include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/log.hpp>
 
 #define ENSURE_CURR_SYSTEM()                                                                                           \

--- a/core/include/cubos/core/ecs/system/accessors.hpp
+++ b/core/include/cubos/core/ecs/system/accessors.hpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief Class @ref cubos::core::ecs::Read and related types.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
@@ -14,7 +14,7 @@ namespace cubos::core::ecs
     /// Can be used as a pointer with both the `->` and `*` operators.
     ///
     /// @tparam T Resource or component type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T>
     class Read
     {
@@ -50,7 +50,7 @@ namespace cubos::core::ecs
     /// Can be used as a pointer with both the `->` and `*` operators.
     ///
     /// @tparam T Resource or component type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T>
     class Write
     {
@@ -87,7 +87,7 @@ namespace cubos::core::ecs
     /// Can be used as a pointer with both the `->` and `*` operators.
     ///
     /// @tparam T Resource or component type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T>
     class OptRead
     {
@@ -139,7 +139,7 @@ namespace cubos::core::ecs
     /// Can be used as a pointer with both the `->` and `*` operators.
     ///
     /// @tparam T Resource or component type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T>
     class OptWrite
     {

--- a/core/include/cubos/core/ecs/system/commands.hpp
+++ b/core/include/cubos/core/ecs/system/commands.hpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief Class @ref cubos::core::ecs::Commands and related types.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
@@ -18,7 +18,7 @@ namespace cubos::core::ecs
     class Dispatcher;
 
     /// @brief Allows editing an entity created by a @ref Commands object.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     class EntityBuilder final
     {
     public:
@@ -54,7 +54,7 @@ namespace cubos::core::ecs
     };
 
     /// @brief Used to edit a blueprint spawned by a @ref Commands object.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     class BlueprintBuilder final
     {
     public:
@@ -102,11 +102,11 @@ namespace cubos::core::ecs
         BlueprintBuilder(data::old::SerializationMap<Entity, std::string, EntityHash>&& map, CommandBuffer& commands);
     };
 
-    /// @brief Used to write ECS commands and execute them at a later time.
+    /// @brief System argument used to write ECS commands and execute them at a later time.
     ///
     /// Internally wraps a reference to a CommandBuffer object.
     ///
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     class Commands final
     {
     public:
@@ -151,7 +151,7 @@ namespace cubos::core::ecs
     };
 
     /// @brief Stores commands to execute them later.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     class CommandBuffer final
     {
     public:

--- a/core/include/cubos/core/ecs/system/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/system/dispatcher.hpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief Class @ref cubos::core::ecs::Dispatcher.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
@@ -51,7 +51,7 @@
 namespace cubos::core::ecs
 {
     /// @brief Used to add systems and relations between them and then dispatch them all at once.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     class Dispatcher
     {
     public:

--- a/core/include/cubos/core/ecs/system/event/pipe.hpp
+++ b/core/include/cubos/core/ecs/system/event/pipe.hpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief Resource @ref cubos::core::ecs::EventPipe.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
@@ -15,7 +15,7 @@ namespace cubos::core::ecs
     /// @brief Resource which stores events of type @p T.
     /// @note This resource is meant to be used through @ref EventReader and @ref EventWriter.
     /// @tparam T Event type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T>
     class EventPipe
     {

--- a/core/include/cubos/core/ecs/system/event/reader.hpp
+++ b/core/include/cubos/core/ecs/system/event/reader.hpp
@@ -1,12 +1,12 @@
 /// @file
 /// @brief Class @ref cubos::core::ecs::EventReader.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
 #include <optional>
 
-#include <cubos/core/ecs/event_pipe.hpp>
+#include <cubos/core/ecs/system/event/pipe.hpp>
 
 namespace cubos::core::ecs
 {
@@ -18,7 +18,7 @@ namespace cubos::core::ecs
     /// @see Systems can send events using @ref EventWriter.
     /// @tparam T Event.
     /// @tparam M Filter mask.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T, unsigned int M = DEFAULT_FILTER_MASK>
     class EventReader
     {

--- a/core/include/cubos/core/ecs/system/event/writer.hpp
+++ b/core/include/cubos/core/ecs/system/event/writer.hpp
@@ -1,10 +1,10 @@
 /// @file
 /// @brief Class @ref cubos::core::ecs::EventWriter.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
-#include <cubos/core/ecs/event_pipe.hpp>
+#include <cubos/core/ecs/system/event/pipe.hpp>
 
 namespace cubos::core::ecs
 {
@@ -12,7 +12,7 @@ namespace cubos::core::ecs
     /// systems.
     /// @see Systems can read sent events using @ref EventReader.
     /// @tparam T
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename T>
     class EventWriter
     {

--- a/core/include/cubos/core/ecs/system/module.dox
+++ b/core/include/cubos/core/ecs/system/module.dox
@@ -1,6 +1,9 @@
 /// @dir
 /// @brief @ref core-ecs-system directory.
 
+/// @dir event
+/// @brief Event system arguments directory.
+
 namespace cubos::core::ecs
 {
     /// @defgroup core-ecs-system System

--- a/core/include/cubos/core/ecs/system/module.dox
+++ b/core/include/cubos/core/ecs/system/module.dox
@@ -1,0 +1,9 @@
+/// @dir
+/// @brief @ref core-ecs-system directory.
+
+namespace cubos::core::ecs
+{
+    /// @defgroup core-ecs-system System
+    /// @ingroup core-ecs
+    /// @brief System part of the ECS.
+}

--- a/core/include/cubos/core/ecs/system/query.hpp
+++ b/core/include/cubos/core/ecs/system/query.hpp
@@ -4,7 +4,7 @@
 /// This file is a bit scary, but it's not as bad as it looks. It's mostly template specializations
 /// to handle the different types of arguments a query can take.
 ///
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
@@ -19,7 +19,7 @@
 namespace cubos::core::ecs
 {
     /// @brief Describes a query.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     struct QueryInfo
     {
         std::unordered_set<std::type_index> read;    ///< Componenst read.
@@ -89,8 +89,8 @@ namespace cubos::core::ecs
         };
     } // namespace impl
 
-    /// @brief Holds the result of a query over all entities in world which match the given
-    /// arguments.
+    /// @brief System argument which holds the result of a query over all entities in world which
+    /// match the given arguments.
     ///
     /// An example of a valid query is:
     ///
@@ -103,7 +103,7 @@ namespace cubos::core::ecs
     /// not present in the entity. Whenever mutability is not needed, Read/OptRead should be used.
     ///
     /// @tparam ComponentTypes Component accessor types to be queried.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename... ComponentTypes>
     class Query
     {

--- a/core/include/cubos/core/ecs/system/query.hpp
+++ b/core/include/cubos/core/ecs/system/query.hpp
@@ -13,7 +13,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include <cubos/core/ecs/accessors.hpp>
+#include <cubos/core/ecs/system/accessors.hpp>
 #include <cubos/core/ecs/world.hpp>
 
 namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -12,10 +12,10 @@
 #include <typeindex>
 #include <unordered_set>
 
-#include <cubos/core/ecs/event_reader.hpp>
-#include <cubos/core/ecs/event_writer.hpp>
 #include <cubos/core/ecs/system/accessors.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
+#include <cubos/core/ecs/system/event/reader.hpp>
+#include <cubos/core/ecs/system/event/writer.hpp>
 #include <cubos/core/ecs/system/query.hpp>
 #include <cubos/core/ecs/world.hpp>
 

--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -15,8 +15,8 @@
 #include <cubos/core/ecs/accessors.hpp>
 #include <cubos/core/ecs/event_reader.hpp>
 #include <cubos/core/ecs/event_writer.hpp>
-#include <cubos/core/ecs/query.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
+#include <cubos/core/ecs/system/query.hpp>
 #include <cubos/core/ecs/world.hpp>
 
 namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -12,9 +12,9 @@
 #include <typeindex>
 #include <unordered_set>
 
-#include <cubos/core/ecs/accessors.hpp>
 #include <cubos/core/ecs/event_reader.hpp>
 #include <cubos/core/ecs/event_writer.hpp>
+#include <cubos/core/ecs/system/accessors.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/ecs/system/query.hpp>
 #include <cubos/core/ecs/world.hpp>

--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -4,7 +4,7 @@
 /// This file is a bit scary, but it's not as bad as it looks. It's mostly template specializations
 /// to handle the different types of arguments a system can take.
 ///
-/// @ingroup core-ecs
+/// @ingroup core-ecs-system
 
 #pragma once
 
@@ -22,7 +22,7 @@
 namespace cubos::core::ecs
 {
     /// @brief Describes a system.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     struct SystemInfo
     {
         /// @brief Whether the system uses commands or not.
@@ -62,7 +62,7 @@ namespace cubos::core::ecs
 
     /// @brief Base class for system wrappers.
     /// @tparam R Return type of the wrapped system.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename R>
     class AnySystemWrapper
     {
@@ -304,7 +304,7 @@ namespace cubos::core::ecs
 
     /// @brief Wrapper for a system of type @p F.
     /// @tparam F Type of the system function/method/lambda.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-system
     template <typename F>
     class SystemWrapper final : public AnySystemWrapper<typename impl::SystemTraits<F>::Return>
     {

--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -13,10 +13,10 @@
 #include <unordered_set>
 
 #include <cubos/core/ecs/accessors.hpp>
-#include <cubos/core/ecs/commands.hpp>
 #include <cubos/core/ecs/event_reader.hpp>
 #include <cubos/core/ecs/event_writer.hpp>
 #include <cubos/core/ecs/query.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/ecs/world.hpp>
 
 namespace cubos::core::ecs

--- a/core/samples/ecs/events/main.cpp
+++ b/core/samples/ecs/events/main.cpp
@@ -1,6 +1,6 @@
-#include <cubos/core/ecs/event_pipe.hpp>
-#include <cubos/core/ecs/event_reader.hpp>
-#include <cubos/core/ecs/event_writer.hpp>
+#include <cubos/core/ecs/system/event/pipe.hpp>
+#include <cubos/core/ecs/system/event/reader.hpp>
+#include <cubos/core/ecs/system/event/writer.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/stream.hpp>
 

--- a/core/samples/ecs/general/main.cpp
+++ b/core/samples/ecs/general/main.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 
 #include <cubos/core/ecs/blueprint.hpp>
-#include <cubos/core/ecs/commands.hpp>
 #include <cubos/core/ecs/component/map_storage.hpp>
 #include <cubos/core/ecs/component/null_storage.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/component/vec_storage.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/ecs/system/dispatcher.hpp>
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>

--- a/core/samples/ecs/general/main.cpp
+++ b/core/samples/ecs/general/main.cpp
@@ -6,7 +6,7 @@
 #include <cubos/core/ecs/component/null_storage.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/component/vec_storage.hpp>
-#include <cubos/core/ecs/dispatcher.hpp>
+#include <cubos/core/ecs/system/dispatcher.hpp>
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 

--- a/core/samples/ecs/general/main.cpp
+++ b/core/samples/ecs/general/main.cpp
@@ -7,7 +7,7 @@
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/component/vec_storage.hpp>
 #include <cubos/core/ecs/dispatcher.hpp>
-#include <cubos/core/ecs/system.hpp>
+#include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 
 using namespace cubos::core;

--- a/core/src/cubos/core/ecs/system/commands.cpp
+++ b/core/src/cubos/core/ecs/system/commands.cpp
@@ -1,5 +1,5 @@
 #include <cubos/core/ecs/blueprint.hpp>
-#include <cubos/core/ecs/commands.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 
 using namespace cubos::core::ecs;
 

--- a/core/src/cubos/core/ecs/system/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/system/dispatcher.cpp
@@ -1,6 +1,6 @@
 #include <algorithm>
 
-#include <cubos/core/ecs/dispatcher.hpp>
+#include <cubos/core/ecs/system/dispatcher.hpp>
 
 using namespace cubos::core::ecs;
 

--- a/core/src/cubos/core/ecs/system/system.cpp
+++ b/core/src/cubos/core/ecs/system/system.cpp
@@ -1,4 +1,4 @@
-#include <cubos/core/ecs/system.hpp>
+#include <cubos/core/ecs/system/system.hpp>
 
 using namespace cubos::core::ecs;
 

--- a/core/tests/ecs/commands.cpp
+++ b/core/tests/ecs/commands.cpp
@@ -1,6 +1,6 @@
 #include <doctest/doctest.h>
 
-#include <cubos/core/ecs/commands.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 
 #include "utils.hpp"
 

--- a/core/tests/ecs/dispatcher.cpp
+++ b/core/tests/ecs/dispatcher.cpp
@@ -2,7 +2,7 @@
 
 #include <doctest/doctest.h>
 
-#include <cubos/core/ecs/dispatcher.hpp>
+#include <cubos/core/ecs/system/dispatcher.hpp>
 
 #include "utils.hpp"
 

--- a/core/tests/ecs/query.cpp
+++ b/core/tests/ecs/query.cpp
@@ -1,6 +1,6 @@
 #include <doctest/doctest.h>
 
-#include <cubos/core/ecs/query.hpp>
+#include <cubos/core/ecs/system/query.hpp>
 
 #include "utils.hpp"
 

--- a/core/tests/ecs/system.cpp
+++ b/core/tests/ecs/system.cpp
@@ -3,7 +3,7 @@
 
 #include <doctest/doctest.h>
 
-#include <cubos/core/ecs/system.hpp>
+#include <cubos/core/ecs/system/system.hpp>
 
 #include "utils.hpp"
 

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -7,8 +7,8 @@
 #include <set>
 #include <string>
 
-#include <cubos/core/ecs/event_pipe.hpp>
 #include <cubos/core/ecs/system/dispatcher.hpp>
+#include <cubos/core/ecs/system/event/pipe.hpp>
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -9,7 +9,7 @@
 
 #include <cubos/core/ecs/dispatcher.hpp>
 #include <cubos/core/ecs/event_pipe.hpp>
-#include <cubos/core/ecs/system.hpp>
+#include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 
 namespace cubos::engine

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -7,8 +7,8 @@
 #include <set>
 #include <string>
 
-#include <cubos/core/ecs/dispatcher.hpp>
 #include <cubos/core/ecs/event_pipe.hpp>
+#include <cubos/core/ecs/system/dispatcher.hpp>
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -1,5 +1,5 @@
-#include <cubos/core/ecs/event_reader.hpp>
-#include <cubos/core/ecs/event_writer.hpp>
+#include <cubos/core/ecs/system/event/reader.hpp>
+#include <cubos/core/ecs/system/event/writer.hpp>
 
 #include <cubos/engine/cubos.hpp>
 

--- a/engine/src/cubos/engine/collisions/broad_phase.hpp
+++ b/engine/src/cubos/engine/collisions/broad_phase.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cubos/core/ecs/query.hpp>
+#include <cubos/core/ecs/system/query.hpp>
 
 #include <cubos/engine/collisions/aabb.hpp>
 #include <cubos/engine/collisions/broad_phase_collisions.hpp>

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -1,6 +1,6 @@
 #include <utility>
 
-#include <cubos/core/ecs/commands.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/log.hpp>
 
 #include <cubos/engine/cubos.hpp>

--- a/engine/src/cubos/engine/renderer/plugin.cpp
+++ b/engine/src/cubos/engine/renderer/plugin.cpp
@@ -1,4 +1,4 @@
-#include <cubos/core/ecs/query.hpp>
+#include <cubos/core/ecs/system/query.hpp>
 
 #include <cubos/engine/renderer/deferred_renderer.hpp>
 #include <cubos/engine/renderer/directional_light.hpp>

--- a/engine/src/cubos/engine/tools/scene_editor/plugin.cpp
+++ b/engine/src/cubos/engine/tools/scene_editor/plugin.cpp
@@ -5,7 +5,7 @@
 #include <misc/cpp/imgui_stdlib.h>
 
 #include <cubos/core/data/old/debug_serializer.hpp>
-#include <cubos/core/ecs/commands.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/imgui/plugin.hpp>


### PR DESCRIPTION
Closes #643.

# Description

Moves all system related code to the `ecs/system` dir.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
