### PR TITLE
Move resource stuff to the `ecs/resource` directory

### DIFF
--- a/core/include/cubos/core/ecs/resource/manager.hpp
+++ b/core/include/cubos/core/ecs/resource/manager.hpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief Class @ref cubos::core::ecs::ResourceManager and related types.
-/// @ingroup core-ecs
+/// @ingroup core-ecs-resource
 
 #pragma once
 
@@ -15,7 +15,7 @@ namespace cubos::core::ecs
 {
     /// @brief Utility struct used to reference a resource of type @p T for reading.
     /// @tparam T Resource type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-resource
     template <typename T>
     class ReadResource
     {
@@ -42,7 +42,7 @@ namespace cubos::core::ecs
 
     /// @brief Utility struct used to reference a resource of type @p T for writing.
     /// @tparam T Resource type.
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-resource
     template <typename T>
     class WriteResource
     {
@@ -71,7 +71,7 @@ namespace cubos::core::ecs
     ///
     /// Used internally by @ref World.
     ///
-    /// @ingroup core-ecs
+    /// @ingroup core-ecs-resource
     class ResourceManager final
     {
     public:

--- a/core/include/cubos/core/ecs/resource/module.dox
+++ b/core/include/cubos/core/ecs/resource/module.dox
@@ -1,0 +1,9 @@
+/// @dir
+/// @brief @ref core-ecs-resource directory.
+
+namespace cubos::core::ecs
+{
+    /// @defgroup core-ecs-resource Resource
+    /// @ingroup core-ecs
+    /// @brief Resource part of the ECS.
+}

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -10,7 +10,7 @@
 
 #include <cubos/core/ecs/component/manager.hpp>
 #include <cubos/core/ecs/entity/manager.hpp>
-#include <cubos/core/ecs/resource_manager.hpp>
+#include <cubos/core/ecs/resource/manager.hpp>
 #include <cubos/core/log.hpp>
 
 namespace cubos::core::ecs


### PR DESCRIPTION
Closes #646.

# Description

Moves the resource manager to the `ecs/resource` directory.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
