### PR TITLE
fix(meta): fixed `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,6 @@
 ---
 BasedOnStyle: Microsoft
 NamespaceIndentation: All
-SortIncludes: 'false'
 IndentWidth: 4
 AccessModifierOffset: -4
 DerivePointerAlignment: false


### PR DESCRIPTION
# Description

Removed duplicate key `SortIncludes` mapping.

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
