### PR TITLE
feat(memory): use reflection on TypeMap

### DIFF
--- a/core/include/cubos/core/ecs/blueprint.hpp
+++ b/core/include/cubos/core/ecs/blueprint.hpp
@@ -191,16 +191,15 @@ namespace cubos::core::ecs
 
         (
             [&]() {
-                auto ptr = mBuffers.at<ComponentTypes>();
                 IBuffer* buf;
-                if (ptr == nullptr)
+                if (mBuffers.contains<ComponentTypes>())
                 {
-                    buf = new Buffer<ComponentTypes>();
-                    mBuffers.set<ComponentTypes>(buf);
+                    buf = mBuffers.at<ComponentTypes>();
                 }
                 else
                 {
-                    buf = *ptr;
+                    buf = new Buffer<ComponentTypes>();
+                    mBuffers.insert<ComponentTypes>(buf);
                 }
 
                 auto ser = data::old::BinarySerializer(buf->stream);

--- a/core/include/cubos/core/ecs/component/manager.hpp
+++ b/core/include/cubos/core/ecs/component/manager.hpp
@@ -13,6 +13,7 @@
 #include <typeindex>
 
 #include <cubos/core/ecs/component/storage.hpp>
+#include <cubos/core/memory/type_map.hpp>
 
 namespace cubos::core::ecs
 {
@@ -33,7 +34,7 @@ namespace cubos::core::ecs
     /// @param type Component type.
     /// @return Registered name of the component type.
     /// @ingroup core-ecs-component
-    std::optional<std::string_view> getComponentName(std::type_index type);
+    std::optional<std::string_view> getComponentName(const reflection::Type& type);
 
     /// @brief Utility struct used to reference a storage of component type @p T for reading.
     /// @tparam T Component type.
@@ -110,12 +111,12 @@ namespace cubos::core::ecs
         /// Must be called before any component of this type is used in any way.
         ///
         /// @param type Type of the component.
-        void registerComponent(std::type_index type);
+        void registerComponent(const reflection::Type& type);
 
         /// @brief Gets the identifier of a registered component type.
         /// @param type Component type.
         /// @return Component identifier.
-        std::size_t getIDFromIndex(std::type_index type) const;
+        std::size_t getID(const reflection::Type& type) const;
 
         /// @brief Gets the identifier of a registered component type.
         /// @tparam T Component type.
@@ -126,7 +127,7 @@ namespace cubos::core::ecs
         /// @brief Gets the type of a component from its identifier.
         /// @param id Component identifier.
         /// @return Component type index.
-        std::type_index getType(std::size_t id) const;
+        const reflection::Type& getType(std::size_t id) const;
 
         //// @brief Locks a storage for reading and returns it.
         /// @tparam T Component type.
@@ -187,10 +188,8 @@ namespace cubos::core::ecs
             std::unique_ptr<std::shared_mutex> mutex; ///< Read/write lock for the storage.
         };
 
-        /// @brief Maps component types to component IDs.
-        std::unordered_map<std::type_index, std::size_t> mTypeToIds;
-
-        std::vector<Entry> mEntries; ///< Registered component storages.
+        memory::TypeMap<std::size_t> mTypeToIds; ///< Maps component types to component IDs.
+        std::vector<Entry> mEntries;             ///< Registered component storages.
     };
 
     // Implementation.
@@ -198,7 +197,7 @@ namespace cubos::core::ecs
     template <typename T>
     std::optional<std::string_view> getComponentName()
     {
-        return getComponentName(typeid(T));
+        return getComponentName(reflection::reflect<T>());
     }
 
     template <typename T>
@@ -248,13 +247,13 @@ namespace cubos::core::ecs
     template <typename T>
     void ComponentManager::registerComponent()
     {
-        this->registerComponent(typeid(T));
+        this->registerComponent(reflection::reflect<T>());
     }
 
     template <typename T>
     std::size_t ComponentManager::getID() const
     {
-        return this->getIDFromIndex(typeid(T));
+        return this->getID(reflection::reflect<T>());
     }
 
     template <typename T>

--- a/core/include/cubos/core/memory/type_map.hpp
+++ b/core/include/cubos/core/memory/type_map.hpp
@@ -23,7 +23,7 @@ namespace cubos::core::memory
         /// @param value Value.
         void insert(const reflection::Type& type, V value)
         {
-            mMap.emplace(&type, std::move(value));
+            mMap.insert_or_assign(&type, std::move(value));
         }
 
         /// @brief Sets the value associated to the given type.

--- a/core/src/cubos/core/ecs/blueprint.cpp
+++ b/core/src/cubos/core/ecs/blueprint.cpp
@@ -52,16 +52,15 @@ void Blueprint::merge(const std::string& prefix, const Blueprint& other)
     /// Then, merge the buffers.
     for (const auto& buffer : other.mBuffers)
     {
-        auto* ptr = mBuffers.at(buffer.first);
         IBuffer* buf;
-        if (ptr == nullptr)
+        if (mBuffers.contains(*buffer.first))
         {
-            buf = buffer.second->create();
-            mBuffers.set(buffer.first, buf);
+            buf = mBuffers.at(*buffer.first);
         }
         else
         {
-            buf = *ptr;
+            buf = buffer.second->create();
+            mBuffers.insert(*buffer.first, buf);
         }
 
         buf->merge(buffer.second, prefix, src, dst);

--- a/core/src/cubos/core/ecs/component/registry.cpp
+++ b/core/src/cubos/core/ecs/component/registry.cpp
@@ -14,29 +14,29 @@ bool Registry::create(std::string_view name, data::old::Deserializer& des, Bluep
     return false;
 }
 
-std::unique_ptr<IStorage> Registry::createStorage(std::type_index type)
+std::unique_ptr<IStorage> Registry::createStorage(const reflection::Type& type)
 {
     auto& creators = Registry::entriesByType();
-    if (auto* it = creators.at(type))
+    if (creators.contains(type))
     {
-        return (*it)->storageCreator();
+        return creators.at(type)->storageCreator();
     }
 
     return nullptr;
 }
 
-std::optional<std::string_view> Registry::name(std::type_index type)
+std::optional<std::string_view> Registry::name(const reflection::Type& type)
 {
     auto& entries = Registry::entriesByType();
-    if (auto* it = entries.at(type))
+    if (entries.contains(type))
     {
-        return (*it)->name;
+        return entries.at(type)->name;
     }
 
     return std::nullopt;
 }
 
-std::optional<std::type_index> Registry::type(std::string_view name)
+const reflection::Type* Registry::type(std::string_view name)
 {
     auto& entries = Registry::entriesByName();
     if (auto it = entries.find(std::string(name)); it != entries.end())
@@ -44,7 +44,7 @@ std::optional<std::type_index> Registry::type(std::string_view name)
         return it->second->type;
     }
 
-    return std::nullopt;
+    return nullptr;
 }
 
 memory::TypeMap<std::shared_ptr<Registry::Entry>>& Registry::entriesByType()

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -58,15 +58,15 @@ bool World::unpack(Entity entity, const data::old::Package& package, data::old::
 
     for (const auto& field : package.fields())
     {
-        auto type = Registry::type(field.first);
-        if (!type.has_value())
+        const auto* type = Registry::type(field.first);
+        if (type == nullptr)
         {
             CUBOS_ERROR("Unknown component type '{}'", field.first);
             success = false;
             continue;
         }
 
-        auto id = mComponentManager.getIDFromIndex(*type);
+        auto id = mComponentManager.getID(*type);
         if (mComponentManager.unpack(entity.index, id, field.second, context))
         {
             mask.set(id);

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     data/context.cpp
 
     memory/any_vector.cpp
+    memory/type_map.cpp
     memory/unordered_bimap.cpp
 
     ecs/utils.cpp

--- a/core/tests/ecs/registry.cpp
+++ b/core/tests/ecs/registry.cpp
@@ -2,6 +2,7 @@
 
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/component/vec_storage.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include "utils.hpp"
 
@@ -13,6 +14,7 @@ using cubos::core::ecs::Commands;
 using cubos::core::ecs::Registry;
 using cubos::core::ecs::VecStorage;
 using cubos::core::ecs::World;
+using cubos::core::reflection::reflect;
 
 TEST_CASE("ecs::Registry")
 {
@@ -23,18 +25,18 @@ TEST_CASE("ecs::Registry")
     auto entity = blueprint.create("entity");
 
     // Initially "foo" of type int isn't registered.
-    CHECK_FALSE(Registry::type("foo").has_value());
-    CHECK_FALSE(Registry::name(typeid(int)).has_value());
+    CHECK(Registry::type("foo") == nullptr);
+    CHECK_FALSE(Registry::name(reflect<int>()).has_value());
 
     // After registering, it can now be found.
     Registry::add<int, VecStorage<int>>("foo");
-    REQUIRE(Registry::type("foo").has_value());
-    CHECK(*Registry::type("foo") == typeid(int));
-    REQUIRE(Registry::name(typeid(int)).has_value());
-    CHECK(*Registry::name(typeid(int)) == "foo");
+    REQUIRE(Registry::type("foo") != nullptr);
+    CHECK(Registry::type("foo") == &reflect<int>());
+    REQUIRE(Registry::name(reflect<int>()).has_value());
+    CHECK(*Registry::name(reflect<int>()) == "foo");
 
     // Create a storage for it and check if its of the correct type.
-    auto storage = Registry::createStorage(typeid(int));
+    auto storage = Registry::createStorage(reflect<int>());
     CHECK(dynamic_cast<VecStorage<int>*>(storage.get()) != nullptr);
 
     // Instantiate the component into a blueprint, from a package.

--- a/core/tests/ecs/system.cpp
+++ b/core/tests/ecs/system.cpp
@@ -4,6 +4,7 @@
 #include <doctest/doctest.h>
 
 #include <cubos/core/ecs/system/system.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include "utils.hpp"
 

--- a/core/tests/memory/type_map.cpp
+++ b/core/tests/memory/type_map.cpp
@@ -1,0 +1,77 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/memory/type_map.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+TEST_CASE("memory::TypeMap")
+{
+    using cubos::core::memory::TypeMap;
+    using cubos::core::reflection::reflect;
+
+    TypeMap<int> map{};
+
+    SUBCASE("just initialized")
+    {
+    }
+
+    SUBCASE("had entries")
+    {
+        map.insert<bool>(1);
+        CHECK_FALSE(map.empty());
+        CHECK(map.size() == 1);
+
+        CHECK(map.contains<bool>());
+        CHECK(map.at<bool>() == 1);
+
+        CHECK(map.begin() != map.end());
+        CHECK(map.begin()->first == &reflect<bool>());
+        CHECK(map.begin()->second == 1);
+        CHECK(++map.begin() == map.end());
+
+        map.insert<bool>(2);
+        CHECK_FALSE(map.empty());
+        CHECK(map.size() == 1);
+        CHECK(map.at<bool>() == 2);
+
+        map.insert<float>(4);
+        map.insert<double>(8);
+        CHECK_FALSE(map.empty());
+        CHECK(map.size() == 3);
+        CHECK(static_cast<const TypeMap<int>&>(map).at<bool>() == 2);
+        CHECK(map.at<float>() == 4);
+        CHECK(map.at<double>() == 8);
+
+        SUBCASE("remove")
+        {
+            CHECK(map.erase<bool>());
+            CHECK_FALSE(map.erase<bool>());
+            CHECK_FALSE(map.empty());
+            CHECK(map.size() == 2);
+            CHECK_FALSE(map.contains<bool>());
+            CHECK(map.contains<float>());
+            CHECK(map.contains<double>());
+
+            CHECK(map.erase<float>());
+            CHECK(map.erase<double>());
+        }
+
+        SUBCASE("clear")
+        {
+            map.clear();
+        }
+    }
+
+    // Shouldn't contain anything
+    CHECK(map.empty());
+    CHECK(map.size() == 0);
+
+    CHECK_FALSE(map.contains<bool>());
+    CHECK_FALSE(map.contains<float>());
+    CHECK_FALSE(map.contains<double>());
+
+    CHECK(map.begin() == map.end());
+
+    CHECK_FALSE(map.erase<bool>());
+    CHECK_FALSE(map.erase<float>());
+    CHECK_FALSE(map.erase<double>());
+}


### PR DESCRIPTION
# Description

Changes `TypeMap` to use reflection instead of `std::type_index`.
Had to change existing ECS code which depended on this use the reflection type instead of `std::type_index`.
Most of that code will be removed or refactored on a later PR.

## Checklist

- [x] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
- [X] ~~Write new samples.~~
