### PR TITLE
Wrong ID displayed on the World Inspector

### DIFF
--- a/engine/src/cubos/engine/tools/world_inspector/plugin.cpp
+++ b/engine/src/cubos/engine/tools/world_inspector/plugin.cpp
@@ -20,7 +20,7 @@ static void inspectWorld(Write<World> world)
         {
             ImGui::PushID(n);
 
-            ImGui::BulletText("%s", std::to_string(n).c_str());
+            ImGui::BulletText("%s", std::to_string(entity.index).c_str());
 
             ImGui::SameLine();
             if (ImGui::Button("Select"))


### PR DESCRIPTION
# Description

Fixed wrong ID displayed on the World Inspector by using `entity.index` instead of loop index(`n` )

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
