### PR TITLE
 fix(engine): add assignment of 'reflectedId' in AnyAsset::operator Asset<T>()

### DIFF
--- a/engine/include/cubos/engine/assets/asset.hpp
+++ b/engine/include/cubos/engine/assets/asset.hpp
@@ -169,6 +169,7 @@ namespace cubos::engine
     inline AnyAsset::operator Asset<T>() const
     {
         Asset<T> asset;
+        asset.reflectedId = reflectedId;
         asset.mId = mId;
         asset.mRefCount = mRefCount;
         asset.mVersion = mVersion;


### PR DESCRIPTION
Fixed crashing when loading assets.