### PR TITLE
Add `ActiveVoxelPalette` resource to `rendererplugin`

### DIFF
--- a/engine/include/cubos/engine/assets/assets.hpp
+++ b/engine/include/cubos/engine/assets/assets.hpp
@@ -176,6 +176,18 @@ namespace cubos::engine
         /// @return Whether the version was updated.
         bool update(AnyAsset& handle) const;
 
+        /// @brief Updates the given handle to the latest version of the asset.
+        ///
+        /// Can be used to implement hot-reloading.
+        ///
+        /// @param handle Handle to update.
+        /// @return Whether the version was updated.
+        template <typename T>
+        bool update(Asset<T>& handle) const
+        {
+            return update(static_cast<AnyAsset&>(handle));
+        }
+
         /// @brief Unloads the given asset. Can be used to force assets to be reloaded.
         /// @param handle Handle to unload.
         void invalidate(const AnyAsset& handle);

--- a/engine/include/cubos/engine/renderer/plugin.hpp
+++ b/engine/include/cubos/engine/renderer/plugin.hpp
@@ -43,6 +43,7 @@ namespace cubos::engine
     /// - @ref RendererFrame - holds the current frame information.
     /// - @ref RendererEnvironment - holds the environment information (ambient light, sky gradient).
     /// - @ref ActiveCameras - holds the entities which represents the active cameras.
+    /// - @ref ActiveVoxelPalette - holds an asset handle to the currently active palette.
     ///
     /// ## Components
     /// - @ref RenderableGrid - a grid to be rendered.
@@ -84,6 +85,18 @@ namespace cubos::engine
         /// the screen is split. At most, 4 cameras are supported at the same time.
         /// @note These entities must have @ref Camera @ref LocalToWorld components.
         core::ecs::Entity entities[4];
+    };
+
+    /// @brief Resource which holds an asset handle to the currently active palette.
+    /// @ingroup renderer-plugin
+    struct ActiveVoxelPalette
+    {
+        /// @brief Asset handle to the currently active palette.
+        Asset<VoxelPalette> asset;
+
+        /// @brief Previous asset handle save in order to check if asset changed later.
+        /// @todo ECS should have a .changed function to make this process easier (#273).
+        Asset<VoxelPalette> prev;
     };
 
     /// @brief Plugin entry function.


### PR DESCRIPTION
# Description

Renderer now has a resource `ActiveVoxelPalette` which stores a handle to the current palette asset.

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
- [X] Write new samples. (soon on `voxelPaletteEditor`
