### PR TITLE
Stop using old serialization in `Blueprint`

### DIFF
--- a/core/include/cubos/core/ecs/blueprint.hpp
+++ b/core/include/cubos/core/ecs/blueprint.hpp
@@ -17,7 +17,7 @@ namespace cubos::core::ecs
 {
     /// @brief Collection of entities and their respective components.
     ///
-    /// Blueprints are in a way the 'Prefab' of @b CUBOS. They act as tiny @ref World which can
+    /// Blueprints are in a way the 'Prefab' of @b CUBOS. They act as a tiny @ref World which can
     /// then be spawned into an actual @ref World, as many times as needed.
     ///
     /// When a blueprint is spawned, all of its components are scanned using the @ref
@@ -47,7 +47,7 @@ namespace cubos::core::ecs
 
         /// @brief Move constructs.
         /// @param other Blueprint to move from.
-        Blueprint(Blueprint&& other);
+        Blueprint(Blueprint&& other) noexcept;
 
         /// @brief Creates a new entity in the blueprint and returns it.
         ///

--- a/core/include/cubos/core/ecs/component/manager.hpp
+++ b/core/include/cubos/core/ecs/component/manager.hpp
@@ -142,6 +142,12 @@ namespace cubos::core::ecs
         WriteStorage<T> write() const;
 
         /// @brief Adds a component to an entity.
+        /// @param id Entity index.
+        /// @param type Component type.
+        /// @param value Component value to move.
+        void add(uint32_t id, const reflection::Type& type, void* value);
+
+        /// @brief Adds a component to an entity.
         /// @tparam T Component type.
         /// @param id Entity index.
         /// @param value Initial component value.
@@ -275,9 +281,7 @@ namespace cubos::core::ecs
     template <typename T>
     void ComponentManager::add(uint32_t id, T value)
     {
-        const std::size_t componentId = this->getID<T>();
-        auto storage = static_cast<Storage<T>*>(mEntries[componentId - 1].storage.get());
-        storage->insert(id, std::move(value));
+        this->add(id, reflection::reflect<T>(), &value);
     }
 
     template <typename T>

--- a/core/include/cubos/core/ecs/component/map_storage.hpp
+++ b/core/include/cubos/core/ecs/component/map_storage.hpp
@@ -16,7 +16,7 @@ namespace cubos::core::ecs
     class MapStorage : public Storage<T>
     {
     public:
-        T* insert(uint32_t index, T value) override;
+        void insert(uint32_t index, void* value) override;
         T* get(uint32_t index) override;
         const T* get(uint32_t index) const override;
         void erase(uint32_t index) override;
@@ -26,10 +26,9 @@ namespace cubos::core::ecs
     };
 
     template <typename T>
-    T* MapStorage<T>::insert(uint32_t index, T value)
+    void MapStorage<T>::insert(uint32_t index, void* value)
     {
-        mData[index] = value;
-        return &mData[index];
+        mData[index] = std::move(*static_cast<T*>(value));
     }
 
     template <typename T>

--- a/core/include/cubos/core/ecs/component/null_storage.hpp
+++ b/core/include/cubos/core/ecs/component/null_storage.hpp
@@ -17,7 +17,7 @@ namespace cubos::core::ecs
     class NullStorage : public Storage<T>
     {
     public:
-        T* insert(uint32_t index, T value) override;
+        void insert(uint32_t index, void* value) override;
         T* get(uint32_t index) override;
         const T* get(uint32_t index) const override;
         void erase(uint32_t index) override;
@@ -27,9 +27,8 @@ namespace cubos::core::ecs
     };
 
     template <typename T>
-    T* NullStorage<T>::insert(uint32_t /*unused*/, T /*unused*/)
+    void NullStorage<T>::insert(uint32_t /*unused*/, void* /*unused*/)
     {
-        return &mData;
     }
 
     template <typename T>

--- a/core/include/cubos/core/ecs/component/registry.hpp
+++ b/core/include/cubos/core/ecs/component/registry.hpp
@@ -8,6 +8,7 @@
 
 #include <cubos/core/data/old/deserializer.hpp>
 #include <cubos/core/ecs/blueprint.hpp>
+#include <cubos/core/ecs/component/storage.hpp>
 #include <cubos/core/memory/type_map.hpp>
 
 namespace cubos::core::ecs
@@ -98,7 +99,7 @@ namespace cubos::core::ecs
                         return false;
                     }
 
-                    blueprint.add(id, comp);
+                    blueprint.add(id, std::move(comp));
                     return true;
                 },
             .storageCreator =

--- a/core/include/cubos/core/ecs/component/storage.hpp
+++ b/core/include/cubos/core/ecs/component/storage.hpp
@@ -21,6 +21,11 @@ namespace cubos::core::ecs
     public:
         virtual ~IStorage() = default;
 
+        /// @brief Inserts a value into the storage.
+        /// @param index Index where to insert the value.
+        /// @param value Value to be moved.
+        virtual void insert(uint32_t index, void* value) = 0;
+
         /// @brief Remove a value from the storage.
         /// @param index Index of the value to be removed.
         virtual void erase(uint32_t index) = 0;
@@ -53,11 +58,6 @@ namespace cubos::core::ecs
         /// @brief Component type.
         using Type = T;
 
-        /// @brief Inserts a value into the storage.
-        /// @param index Index where to insert the value.
-        /// @param value Value to be inserted.
-        virtual T* insert(uint32_t index, T value) = 0;
-
         /// @brief Gets a value from the storage.
         /// @param index Index of the value to be retrieved.
         /// @return Pointer to the value.
@@ -80,7 +80,7 @@ namespace cubos::core::ecs
             T value;
             if (package.into(value, context))
             {
-                this->insert(index, std::move(value));
+                this->insert(index, &value);
                 return true;
             }
 

--- a/core/include/cubos/core/ecs/component/vec_storage.hpp
+++ b/core/include/cubos/core/ecs/component/vec_storage.hpp
@@ -15,7 +15,7 @@ namespace cubos::core::ecs
     class VecStorage : public Storage<T>
     {
     public:
-        T* insert(uint32_t index, T value) override;
+        void insert(uint32_t index, void* value) override;
         T* get(uint32_t index) override;
         const T* get(uint32_t index) const override;
         void erase(uint32_t index) override;
@@ -25,20 +25,18 @@ namespace cubos::core::ecs
     };
 
     template <typename T>
-    T* VecStorage<T>::insert(uint32_t index, T value)
+    void VecStorage<T>::insert(uint32_t index, void* value)
     {
         if (mData.size() <= index)
         {
             mData.resize(index);
-            mData.emplace_back(std::move(value));
+            mData.emplace_back(std::move(*static_cast<T*>(value)));
         }
         else
         {
             mData[index].~T();
-            new (&mData[index]) T(std::move(value));
+            new (&mData[index]) T(std::move(*static_cast<T*>(value)));
         }
-
-        return &mData[index];
     }
 
     template <typename T>

--- a/core/include/cubos/core/ecs/system/commands.hpp
+++ b/core/include/cubos/core/ecs/system/commands.hpp
@@ -263,9 +263,9 @@ namespace cubos::core::ecs
                      "Entity does not have the requested component");
 
         auto& buf = mCommands.mBuffers.at<ComponentType>();
-        auto it = buf->components.find(this->entity(name));
-        CUBOS_ASSERT(it != buf->components.end(), "Entity does not have the requested component");
-        return it->second;
+        auto it = buf.components.find(this->entity(name));
+        CUBOS_ASSERT(it != buf.components.end(), "Entity does not have the requested component");
+        return *static_cast<ComponentType*>(it->second.get());
     }
 
     template <typename... ComponentTypes>

--- a/core/include/cubos/core/memory/type_map.hpp
+++ b/core/include/cubos/core/memory/type_map.hpp
@@ -124,6 +124,20 @@ namespace cubos::core::memory
 
         /// @brief Gets an iterator to the beginning of the map.
         /// @return Iterator.
+        auto begin()
+        {
+            return mMap.begin();
+        }
+
+        /// @brief Gets an iterator to the end of the map.
+        /// @return Iterator.
+        auto end()
+        {
+            return mMap.end();
+        }
+
+        /// @brief Gets an iterator to the beginning of the map.
+        /// @return Iterator.
         auto begin() const
         {
             return mMap.begin();

--- a/core/samples/ecs/general/main.cpp
+++ b/core/samples/ecs/general/main.cpp
@@ -135,9 +135,11 @@ void spawner(ecs::Commands cmds)
     cmds.create(Position{0, 15, 7}, Velocity{0, 4, 1});
     cmds.create(Position{0, 12, 7}, Velocity{0, 5, 1});
 
-    ecs::Blueprint epicBlueprint;
-    ecs::Entity main = epicBlueprint.create("main", Position{0, 0, 0}, Velocity{0, 0, 0});
-    epicBlueprint.create("sub", Parent{main});
+    ecs::Blueprint epicBlueprint{};
+    auto main = epicBlueprint.create("main");
+    epicBlueprint.add(main, Position{0, 0, 0}, Velocity{0, 0, 0});
+    auto sub = epicBlueprint.create("sub");
+    epicBlueprint.add(sub, Parent{main});
 
     cmds.spawn(epicBlueprint).add("main", Position{1, 1, 1});
     cmds.spawn(epicBlueprint).add("main", Position{2, 2, 2});

--- a/core/src/cubos/core/ecs/blueprint.cpp
+++ b/core/src/cubos/core/ecs/blueprint.cpp
@@ -1,78 +1,159 @@
 #include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/traits/array.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/traits/dictionary.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/type.hpp>
 
-using namespace cubos::core::ecs;
+using cubos::core::ecs::Blueprint;
+using cubos::core::ecs::Entity;
+using cubos::core::ecs::EntityHash;
+using cubos::core::memory::AnyValue;
+using cubos::core::memory::UnorderedBimap;
+using cubos::core::reflection::ConstructibleTrait;
+using cubos::core::reflection::Type;
 
-Blueprint::~Blueprint()
+Blueprint::Blueprint() = default;
+
+Blueprint::Blueprint(Blueprint&& other) = default;
+
+Entity Blueprint::create(std::string name)
 {
-    for (const auto& buffer : mBuffers)
-    {
-        delete buffer.second;
-    }
+    CUBOS_ASSERT(!mBimap.containsRight(name), "An entity with the name '{}' already exists on the blueprint", name);
+    CUBOS_ASSERT(validEntityName(name), "Blueprint entity name '{}' is invalid, read the docs", name);
+
+    Entity entity{static_cast<uint32_t>(mBimap.size()), 0};
+    mBimap.insert(entity, std::move(name));
+    return entity;
 }
 
-bool Blueprint::addFromDeserializer(Entity entity, const std::string& name, data::old::Deserializer& deserializer)
+void Blueprint::add(Entity entity, AnyValue component)
 {
-    assert(entity.generation == 0);
-    return Registry::create(name, deserializer, *this, entity);
-}
+    CUBOS_ASSERT(component.type().get<ConstructibleTrait>().hasCopyConstruct(),
+                 "Blueprint components must be copy constructible, but '{}' isn't", component.type().name());
 
-Entity Blueprint::entity(const std::string& name) const
-{
-    if (!mMap.hasId(name))
+    // Sanity check to catch errors where the user passes an entity which doesn't belong to this blueprint.
+    // We can't make sure it never happens, but we might as well catch some of the possible cases.
+    CUBOS_ASSERT(mBimap.containsLeft(entity), "Entity wasn't created with this blueprint");
+
+    if (!mComponents.contains(component.type()))
     {
-        return {};
+        mComponents.insert(component.type(), {});
     }
 
-    return mMap.getRef(name);
+    mComponents.at(component.type()).erase(entity);
+    mComponents.at(component.type()).emplace(entity, std::move(component));
 }
 
 void Blueprint::merge(const std::string& prefix, const Blueprint& other)
 {
-    // First, merge the maps.
-    data::old::SerializationMap<Entity, std::string, EntityHash> srcMap;
-    for (uint32_t i = 0; i < static_cast<uint32_t>(other.mMap.size()); ++i)
-    {
-        // Deserialize from the source buffer using the original entity names.
-        // Serialize into the destination buffer using the prefixed entity names.
+    other.instantiate(
+        [&](std::string name) -> Entity {
+            name = prefix + '.' + name;
 
-        auto srcName = other.mMap.getId(Entity(i, 0));
-        auto dstName = prefix + ".";
-        dstName += srcName;
+            CUBOS_ASSERT(!mBimap.containsRight(name),
+                         "A blueprint with the prefix '{}' was already merged to the blueprint", prefix);
 
-        srcMap.add(Entity(static_cast<uint32_t>(mMap.size()), 0), srcName);
-        mMap.add(Entity(static_cast<uint32_t>(mMap.size()), 0), dstName);
-    }
-
-    data::old::Context src;
-    data::old::Context dst;
-    src.push(srcMap);
-    dst.push(mMap);
-
-    /// Then, merge the buffers.
-    for (const auto& buffer : other.mBuffers)
-    {
-        IBuffer* buf;
-        if (mBuffers.contains(*buffer.first))
-        {
-            buf = mBuffers.at(*buffer.first);
-        }
-        else
-        {
-            buf = buffer.second->create();
-            mBuffers.insert(*buffer.first, buf);
-        }
-
-        buf->merge(buffer.second, prefix, src, dst);
-    }
+            Entity entity{static_cast<uint32_t>(mBimap.size()), 0};
+            mBimap.insert(entity, std::move(name));
+            return entity;
+        },
+        [&](Entity entity, AnyValue component) { this->add(entity, std::move(component)); });
 }
 
 void Blueprint::clear()
 {
-    mMap.clear();
-    for (const auto& buffer : mBuffers)
+    mBimap.clear();
+    mComponents.clear();
+}
+
+const UnorderedBimap<Entity, std::string, EntityHash>& Blueprint::bimap() const
+{
+    return mBimap;
+}
+
+static void convertToInstancedEntities(const std::unordered_map<Entity, Entity, EntityHash>& toInstanced,
+                                       const Type& type, void* value)
+{
+    using namespace cubos::core::reflection;
+
+    if (type.is<Entity>())
     {
-        delete buffer.second;
+        auto& entity = *static_cast<Entity*>(value);
+        if (!entity.isNull())
+        {
+            CUBOS_ASSERT(
+                toInstanced.contains(entity),
+                "Entities stored in components must either be null or reference valid entities on their blueprints");
+            entity = toInstanced.at(entity);
+        }
     }
-    mBuffers.clear();
+    else if (type.has<DictionaryTrait>())
+    {
+        const auto& trait = type.get<DictionaryTrait>();
+        CUBOS_ASSERT(!trait.keyType().is<Entity>(),
+                     "Dictionaries using entities as keys are not supported on blueprint components");
+
+        for (auto [entryKey, entryValue] : trait.view(value))
+        {
+            convertToInstancedEntities(toInstanced, trait.valueType(), entryValue);
+        }
+    }
+    else if (type.has<ArrayTrait>())
+    {
+        const auto& trait = type.get<ArrayTrait>();
+        for (auto* element : trait.view(value))
+        {
+            convertToInstancedEntities(toInstanced, trait.elementType(), element);
+        }
+    }
+    else if (type.has<FieldsTrait>())
+    {
+        const auto& trait = type.get<FieldsTrait>();
+        for (auto [field, fieldValue] : trait.view(value))
+        {
+            convertToInstancedEntities(toInstanced, field->type(), fieldValue);
+        }
+    }
+}
+
+void Blueprint::instantiate(void* userData, Create create, Add add) const
+{
+    // Instantiate our entities and create a map from them to their instanced counterparts.
+    std::unordered_map<Entity, Entity, EntityHash> thisToInstance{};
+    for (const auto& [entity, name] : mBimap)
+    {
+        thisToInstance.emplace(entity, create(userData, name));
+    }
+
+    // Add copies of our components to their instantiated entities. Since the components themselves
+    // may contain handle which point to entities in this blueprint, we must recurse into them and
+    // convert them to point to the instantiated entities.
+    // them and convert any handles
+    for (const auto& [type, components] : mComponents)
+    {
+        for (const auto& [entity, component] : components)
+        {
+            auto copied = AnyValue::copyConstruct(component.type(), component.get());
+            convertToInstancedEntities(thisToInstance, copied.type(), copied.get());
+            add(userData, thisToInstance.at(entity), std::move(copied));
+        }
+    }
+}
+
+bool Blueprint::validEntityName(const std::string& name)
+{
+    for (const auto& c : name)
+    {
+        bool isLowerAlpha = c >= 'a' && c <= 'z';
+        bool isNumeric = c >= '0' && c <= '9';
+        if (!isLowerAlpha && !isNumeric && c != '-')
+        {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/core/src/cubos/core/ecs/blueprint.cpp
+++ b/core/src/cubos/core/ecs/blueprint.cpp
@@ -17,7 +17,7 @@ using cubos::core::reflection::Type;
 
 Blueprint::Blueprint() = default;
 
-Blueprint::Blueprint(Blueprint&& other) = default;
+Blueprint::Blueprint(Blueprint&& other) noexcept = default;
 
 Entity Blueprint::create(std::string name)
 {

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -45,7 +45,7 @@ const reflection::Type& ComponentManager::getType(std::size_t id) const
 void ComponentManager::add(uint32_t id, const reflection::Type& type, void* value)
 {
     const std::size_t componentId = this->getID(type);
-    auto storage = static_cast<IStorage*>(mEntries[componentId - 1].storage.get());
+    auto* storage = static_cast<IStorage*>(mEntries[componentId - 1].storage.get());
     storage->insert(id, value);
 }
 

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -42,6 +42,13 @@ const reflection::Type& ComponentManager::getType(std::size_t id) const
     CUBOS_FAIL("No component found with ID {}", id);
 }
 
+void ComponentManager::add(uint32_t id, const reflection::Type& type, void* value)
+{
+    const std::size_t componentId = this->getID(type);
+    auto storage = static_cast<IStorage*>(mEntries[componentId - 1].storage.get());
+    storage->insert(id, value);
+}
+
 void ComponentManager::remove(uint32_t id, std::size_t componentId)
 {
     mEntries[componentId - 1].storage->erase(id);

--- a/core/src/cubos/core/ecs/system/commands.cpp
+++ b/core/src/cubos/core/ecs/system/commands.cpp
@@ -90,7 +90,7 @@ BlueprintBuilder CommandBuffer::spawn(const Blueprint& blueprint)
 {
     data::old::SerializationMap<Entity, std::string, EntityHash> map{};
     blueprint.instantiate(
-        [&](std::string name) -> Entity {
+        [&](const std::string& name) -> Entity {
             auto entity = this->create().entity();
             map.add(entity, name);
             return entity;

--- a/core/tests/ecs/blueprint.cpp
+++ b/core/tests/ecs/blueprint.cpp
@@ -1,6 +1,8 @@
 #include <doctest/doctest.h>
 
 #include <cubos/core/ecs/blueprint.hpp>
+#include <cubos/core/ecs/component/registry.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 
 #include "utils.hpp"
 
@@ -10,6 +12,7 @@ using cubos::core::ecs::Blueprint;
 using cubos::core::ecs::CommandBuffer;
 using cubos::core::ecs::Commands;
 using cubos::core::ecs::Entity;
+using cubos::core::ecs::Registry;
 using cubos::core::ecs::World;
 
 TEST_CASE("ecs::Blueprint")
@@ -23,22 +26,24 @@ TEST_CASE("ecs::Blueprint")
     SUBCASE("create an entity and clear the blueprint immediately")
     {
         // If an entity is created, then the returned identifier must not be null
-        auto foo = blueprint.create("foo", IntegerComponent{0});
+        auto foo = blueprint.create("foo");
         CHECK_FALSE(foo.isNull());
+        blueprint.add(foo, IntegerComponent{0});
 
         // Searching for an entity with the same name should return the same identifier
-        CHECK(blueprint.entity("foo") == foo);
+        CHECK(blueprint.bimap().atLeft("foo") == foo);
 
         blueprint.clear();
     }
 
     // If the blueprint is empty/has been initialized then searching for an entity should always
     // return a null identifier.
-    CHECK(blueprint.entity("foo").isNull());
+    CHECK_FALSE(blueprint.bimap().containsRight("foo"));
 
     // Create two entities on the blueprint.
     auto bar = blueprint.create("bar");
-    auto baz = blueprint.create("baz", IntegerComponent{2});
+    auto baz = blueprint.create("baz");
+    blueprint.add(baz, IntegerComponent{2});
 
     // Add a ParentComponent to "baz" with id = "bar", using a deserializer.
     {
@@ -47,7 +52,7 @@ TEST_CASE("ecs::Blueprint")
 
         // Unpack the identifier of "bar" into a ParentComponent.
         Unpackager unpackager{barPkg};
-        blueprint.addFromDeserializer(baz, "parent", unpackager);
+        Registry::create("parent", unpackager, blueprint, baz);
     }
 
     SUBCASE("spawn the blueprint")
@@ -77,15 +82,16 @@ TEST_CASE("ecs::Blueprint")
     {
         // Create another blueprint with one entity.
         Blueprint merged{};
-        auto foo = merged.create("foo", IntegerComponent{1});
+        auto foo = merged.create("foo");
+        merged.add(foo, IntegerComponent{1});
 
         // Merge the original blueprint into the new one.
         merged.merge("sub", blueprint);
 
         // Then the new blueprint has the correct entities.
-        CHECK(merged.entity("foo") == foo);
-        CHECK_FALSE(merged.entity("sub.bar").isNull());
-        CHECK_FALSE(merged.entity("sub.baz").isNull());
+        CHECK(merged.bimap().atLeft("foo") == foo);
+        CHECK(merged.bimap().containsRight("sub.bar"));
+        CHECK(merged.bimap().containsRight("sub.baz"));
 
         // Spawn the blueprint into the world and get the identifiers of the spawned entities.
         auto spawned = cmds.spawn(merged);

--- a/core/tests/ecs/registry.cpp
+++ b/core/tests/ecs/registry.cpp
@@ -1,7 +1,9 @@
 #include <doctest/doctest.h>
 
+#include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/component/vec_storage.hpp>
+#include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 
 #include "utils.hpp"

--- a/core/tests/ecs/utils.cpp
+++ b/core/tests/ecs/utils.cpp
@@ -2,6 +2,8 @@
 
 #include <cubos/core/ecs/component/reflection.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/unordered_map.hpp>
+#include <cubos/core/reflection/external/vector.hpp>
 
 CUBOS_REFLECT_IMPL(IntegerComponent)
 {
@@ -27,4 +29,18 @@ CUBOS_REFLECT_IMPL(DetectDestructorComponent)
                   .withMoveConstructor()
                   .build())
         .with(FieldsTrait().withField("detect", &DetectDestructorComponent::detect));
+}
+
+CUBOS_REFLECT_IMPL(EntityArrayComponent)
+{
+    return cubos::core::ecs::ComponentTypeBuilder<EntityArrayComponent>("EntityArrayComponent")
+        .withField("vec", &EntityArrayComponent::vec)
+        .build();
+}
+
+CUBOS_REFLECT_IMPL(EntityDictionaryComponent)
+{
+    return cubos::core::ecs::ComponentTypeBuilder<EntityDictionaryComponent>("EntityDictionaryComponent")
+        .withField("map", &EntityDictionaryComponent::map)
+        .build();
 }

--- a/core/tests/ecs/utils.hpp
+++ b/core/tests/ecs/utils.hpp
@@ -32,10 +32,26 @@ struct [[cubos::component("detect_destructor")]] DetectDestructorComponent
     [[cubos::ignore]] DetectDestructor detect;
 };
 
+struct [[cubos::component("entity_array")]] EntityArrayComponent
+{
+    CUBOS_REFLECT;
+
+    std::vector<cubos::core::ecs::Entity> vec;
+};
+
+struct [[cubos::component("entity_dictionary")]] EntityDictionaryComponent
+{
+    CUBOS_REFLECT;
+
+    std::unordered_map<int, cubos::core::ecs::Entity> map;
+};
+
 /// Adds the utility components to a world.
 inline void setupWorld(cubos::core::ecs::World& world)
 {
     world.registerComponent<IntegerComponent>();
     world.registerComponent<ParentComponent>();
     world.registerComponent<DetectDestructorComponent>();
+    world.registerComponent<EntityArrayComponent>();
+    world.registerComponent<EntityDictionaryComponent>();
 }

--- a/engine/src/cubos/engine/tools/scene_editor/plugin.cpp
+++ b/engine/src/cubos/engine/tools/scene_editor/plugin.cpp
@@ -81,7 +81,7 @@ static void openScene(const Asset<Scene>& sceneToSpawn, Commands& commands, cons
     closeScene(commands, scene);
     auto sceneRead = assets.read(sceneToSpawn);
     auto builder = commands.spawn(sceneRead->blueprint);
-    for (const auto& [entity, name] : sceneRead->blueprint.getMap())
+    for (const auto& [entity, name] : sceneRead->blueprint.bimap())
     {
         placeEntity(name, builder.entity(name), scene);
     }


### PR DESCRIPTION
# Description

Changes `Blueprint` to use only reflection and none of the old serialization code.
Changes `Commands` to support the new `Blueprint` interface.
Changes component storages so that type-erased components can be added to them.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
