### PR TITLE
Asset is nuked when save fails

### DIFF
--- a/core/include/cubos/core/data/fs/file_system.hpp
+++ b/core/include/cubos/core/data/fs/file_system.hpp
@@ -119,5 +119,17 @@ namespace cubos::core::data
         /// @param mode Mode to open the file in.
         /// @return File stream, or nullptr if an error occurred.
         static std::unique_ptr<memory::Stream> open(std::string_view path, File::OpenMode mode);
+
+        /// @brief Copies a file from the source path to the destination path.
+        ///
+        /// This method opens the source file in binary mode, reads its contents, and writes them to
+        /// the destination file. If the destination file already exists, it will be overwritten.
+        ///
+        /// @note The source file needs to exist.
+        ///
+        /// @param sourcePath Absolute path of the source file.
+        /// @param destinationPath Absolute path of the destination file.
+        /// @return Whether the file was successfully copied.
+        static bool copy(std::string_view sourcePath, std::string_view destinationPath);
     };
 } // namespace cubos::core::data

--- a/core/src/cubos/core/data/fs/file_system.cpp
+++ b/core/src/cubos/core/data/fs/file_system.cpp
@@ -113,25 +113,25 @@ bool FileSystem::copy(std::string_view sourcePath, std::string_view destinationP
 {
     auto srcStream = FileSystem::open(sourcePath, File::OpenMode::Read);
 
-    if (!srcStream)
+    if (srcStream == nullptr)
     {
-        CUBOS_ERROR("Failed to open source stream");
+        CUBOS_ERROR("Could not open source file '{}' for copying", sourcePath);
         return false;
     }
 
     auto dstFile = FileSystem::create(destinationPath);
 
-    if (!dstFile)
+    if (dstFile == nullptr)
     {
-        CUBOS_ERROR("Failed to create destination file '{}'", destinationPath);
+        CUBOS_ERROR("Could not create destination file '{}' for copying", destinationPath);
         return false;
     }
 
     auto dstStream = dstFile->open(File::OpenMode::Write);
 
-    if (!dstStream)
+    if (dstStream == nullptr)
     {
-        CUBOS_ERROR("Failed to open destination stream");
+        CUBOS_ERROR("Could not open destination file '{}' for copying", destinationPath);
         return false;
     }
 
@@ -145,11 +145,6 @@ bool FileSystem::copy(std::string_view sourcePath, std::string_view destinationP
         if (bytesRead > 0)
         {
             dstStream->write(buffer, bytesRead);
-        }
-
-        if (bytesRead < ChunkSize)
-        {
-            break;
         }
     }
 


### PR DESCRIPTION
# Description

Added `FileSystem::copy` and basically it tries to create a `.swp` file and save the contents there. In case it fails, nothing happens to the original asset file. If everything goes right, we copy the contents from `.swp` to the original file

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
- [X] Write new samples.
