### PR TITLE
Allow accessing components in an entity through `World`

### DIFF
--- a/core/include/cubos/core/ecs/component/manager.hpp
+++ b/core/include/cubos/core/ecs/component/manager.hpp
@@ -169,6 +169,14 @@ namespace cubos::core::ecs
         /// @param id Entity index.
         void removeAll(uint32_t id);
 
+        /// @brief Gets the storage of the given component type.
+        /// @param id Component type identifier.
+        /// @return Component storage.
+        IStorage* storage(std::size_t id);
+
+        /// @copydoc storage(std::size_t)
+        const IStorage* storage(std::size_t id) const;
+
         /// @brief Creates a package from a component of an entity.
         /// @param id Entity index.
         /// @param componentId Component identifier.

--- a/core/include/cubos/core/ecs/component/map_storage.hpp
+++ b/core/include/cubos/core/ecs/component/map_storage.hpp
@@ -17,8 +17,8 @@ namespace cubos::core::ecs
     {
     public:
         void insert(uint32_t index, void* value) override;
-        T* get(uint32_t index) override;
-        const T* get(uint32_t index) const override;
+        void* get(uint32_t index) override;
+        const void* get(uint32_t index) const override;
         void erase(uint32_t index) override;
 
     private:
@@ -32,13 +32,13 @@ namespace cubos::core::ecs
     }
 
     template <typename T>
-    T* MapStorage<T>::get(uint32_t index)
+    void* MapStorage<T>::get(uint32_t index)
     {
         return &mData.at(index);
     }
 
     template <typename T>
-    const T* MapStorage<T>::get(uint32_t index) const
+    const void* MapStorage<T>::get(uint32_t index) const
     {
         return &mData.at(index);
     }

--- a/core/include/cubos/core/ecs/component/null_storage.hpp
+++ b/core/include/cubos/core/ecs/component/null_storage.hpp
@@ -18,8 +18,8 @@ namespace cubos::core::ecs
     {
     public:
         void insert(uint32_t index, void* value) override;
-        T* get(uint32_t index) override;
-        const T* get(uint32_t index) const override;
+        void* get(uint32_t index) override;
+        const void* get(uint32_t index) const override;
         void erase(uint32_t index) override;
 
     private:
@@ -32,13 +32,13 @@ namespace cubos::core::ecs
     }
 
     template <typename T>
-    T* NullStorage<T>::get(uint32_t /*unused*/)
+    void* NullStorage<T>::get(uint32_t /*unused*/)
     {
         return &mData;
     }
 
     template <typename T>
-    const T* NullStorage<T>::get(uint32_t /*unused*/) const
+    const void* NullStorage<T>::get(uint32_t /*unused*/) const
     {
         return &mData;
     }

--- a/core/include/cubos/core/ecs/component/storage.hpp
+++ b/core/include/cubos/core/ecs/component/storage.hpp
@@ -30,6 +30,16 @@ namespace cubos::core::ecs
         /// @param index Index of the value to be removed.
         virtual void erase(uint32_t index) = 0;
 
+        /// @brief Gets a value from the storage.
+        /// @param index Index of the value to be retrieved.
+        /// @return Pointer to the value.
+        virtual void* get(uint32_t index) = 0;
+
+        /// @brief Gets a value from the storage.
+        /// @param index Index of the value to be retrieved.
+        /// @return Pointer to the value.
+        virtual const void* get(uint32_t index) const = 0;
+
         /// @brief Packages a value. If the value doesn't exist, undefined behavior will occur.
         /// @param index Index of the value to package.
         /// @param context Optional context used for serialization.
@@ -58,21 +68,11 @@ namespace cubos::core::ecs
         /// @brief Component type.
         using Type = T;
 
-        /// @brief Gets a value from the storage.
-        /// @param index Index of the value to be retrieved.
-        /// @return Pointer to the value.
-        virtual T* get(uint32_t index) = 0;
-
-        /// @brief Gets a value from the storage.
-        /// @param index Index of the value to be retrieved.
-        /// @return Pointer to the value.
-        virtual const T* get(uint32_t index) const = 0;
-
         // Implementation.
 
         inline data::old::Package pack(uint32_t index, data::old::Context* context) const override
         {
-            return data::old::Package::from(*this->get(index), context);
+            return data::old::Package::from(*static_cast<const T*>(this->get(index)), context);
         }
 
         inline bool unpack(uint32_t index, const data::old::Package& package, data::old::Context* context) override

--- a/core/include/cubos/core/ecs/component/vec_storage.hpp
+++ b/core/include/cubos/core/ecs/component/vec_storage.hpp
@@ -16,8 +16,8 @@ namespace cubos::core::ecs
     {
     public:
         void insert(uint32_t index, void* value) override;
-        T* get(uint32_t index) override;
-        const T* get(uint32_t index) const override;
+        void* get(uint32_t index) override;
+        const void* get(uint32_t index) const override;
         void erase(uint32_t index) override;
 
     private:
@@ -40,13 +40,13 @@ namespace cubos::core::ecs
     }
 
     template <typename T>
-    T* VecStorage<T>::get(uint32_t index)
+    void* VecStorage<T>::get(uint32_t index)
     {
         return &mData[index];
     }
 
     template <typename T>
-    const T* VecStorage<T>::get(uint32_t index) const
+    const void* VecStorage<T>::get(uint32_t index) const
     {
         return &mData[index];
     }

--- a/core/include/cubos/core/ecs/system/query.hpp
+++ b/core/include/cubos/core/ecs/system/query.hpp
@@ -260,7 +260,7 @@ namespace cubos::core::ecs
     template <typename Component>
     Write<Component> impl::QueryFetcher<Write<Component>>::arg(const World& /*unused*/, Type& lock, Entity entity)
     {
-        return {*lock.get().get(entity.index)};
+        return {*static_cast<Component*>(lock.get().get(entity.index))};
     }
 
     template <typename Component>
@@ -278,7 +278,7 @@ namespace cubos::core::ecs
     template <typename Component>
     Read<Component> impl::QueryFetcher<Read<Component>>::arg(const World& /*unused*/, Type& lock, Entity entity)
     {
-        return {*lock.get().get(entity.index)};
+        return {*static_cast<const Component*>(lock.get().get(entity.index))};
     }
 
     template <typename Component>
@@ -297,9 +297,9 @@ namespace cubos::core::ecs
     template <typename Component>
     OptWrite<Component> impl::QueryFetcher<OptWrite<Component>>::arg(const World& world, Type& lock, Entity entity)
     {
-        if (world.has<Component>(entity))
+        if (world.components(entity).has<Component>())
         {
-            return {lock.get().get(entity.index)};
+            return {static_cast<Component*>(lock.get().get(entity.index))};
         }
 
         return {nullptr};
@@ -321,9 +321,9 @@ namespace cubos::core::ecs
     template <typename Component>
     OptRead<Component> impl::QueryFetcher<OptRead<Component>>::arg(const World& world, Type& lock, Entity entity)
     {
-        if (world.has<Component>(entity))
+        if (world.components(entity).has<Component>())
         {
-            return {lock.get().get(entity.index)};
+            return {static_cast<const Component*>(lock.get().get(entity.index))};
         }
 
         return {nullptr};

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -149,9 +149,12 @@ namespace cubos::core::ecs
         ComponentManager mComponentManager;
     };
 
-    class World::Components
+    class World::Components final
     {
     public:
+        /// @brief Used to iterate over the the components.
+        class Iterator;
+
         /// @brief Constructs.
         /// @param world World.
         /// @param entity Entity.
@@ -192,14 +195,25 @@ namespace cubos::core::ecs
             return *static_cast<T*>(this->get(reflection::reflect<T>()));
         }
 
+        /// @brief Returns an iterator to the first component.
+        /// @return Iterator.
+        Iterator begin();
+
+        /// @brief Returns an iterator to the entry after the last component.
+        /// @return Iterator.
+        Iterator end();
+
     private:
         World& mWorld;
         Entity mEntity;
     };
 
-    class World::ConstComponents
+    class World::ConstComponents final
     {
     public:
+        /// @brief Used to iterate over the the components.
+        class Iterator;
+
         /// @brief Constructs.
         /// @param world World.
         /// @param entity Entity.
@@ -240,9 +254,107 @@ namespace cubos::core::ecs
             return *static_cast<const T*>(this->get(reflection::reflect<T>()));
         }
 
+        /// @brief Returns an iterator to the first component.
+        /// @return Iterator.
+        Iterator begin() const;
+
+        /// @brief Returns an iterator to the entry after the last component.
+        /// @return Iterator.
+        Iterator end() const;
+
     private:
         const World& mWorld;
         Entity mEntity;
+    };
+
+    class World::Components::Iterator final
+    {
+    public:
+        /// @brief Output structure for the iterator.
+        struct Component
+        {
+            const reflection::Type* type; ///< Component type.
+            void* value;                  ///< Component value.
+        };
+
+        /// @brief Constructs.
+        /// @param components Components view.
+        /// @param end Whether the iterator represents the end or the beginning.
+        Iterator(Components& components, bool end);
+
+        /// @brief Copy constructs.
+        /// @param other Other iterator.
+        Iterator(const Iterator& other) = default;
+
+        /// @brief Compares two iterators.
+        /// @param other Other iterator.
+        /// @return Whether the iterators point to the same component.
+        bool operator==(const Iterator& other) const;
+
+        /// @brief Accesses the component referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Entry.
+        const Component& operator*() const;
+
+        /// @brief Accesses the component referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Entry.
+        const Component* operator->() const;
+
+        /// @brief Advances the iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Reference to this.
+        Iterator& operator++();
+
+    private:
+        World::Components& mComponents;
+        std::size_t mId{1};
+        mutable Component mComponent;
+    };
+
+    class World::ConstComponents::Iterator final
+    {
+    public:
+        /// @brief Output structure for the iterator.
+        struct Component
+        {
+            const reflection::Type* type; ///< Component type.
+            const void* value;            ///< Component value.
+        };
+
+        /// @brief Constructs.
+        /// @param components Components view.
+        /// @param end Whether the iterator represents the end or the beginning.
+        Iterator(const ConstComponents& components, bool end);
+
+        /// @brief Copy constructs.
+        /// @param other Other iterator.
+        Iterator(const Iterator& other) = default;
+
+        /// @brief Compares two iterators.
+        /// @param other Other iterator.
+        /// @return Whether the iterators point to the same component.
+        bool operator==(const Iterator& other) const;
+
+        /// @brief Accesses the component referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Entry.
+        const Component& operator*() const;
+
+        /// @brief Accesses the component referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Entry.
+        const Component* operator->() const;
+
+        /// @brief Advances the iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Reference to this.
+        Iterator& operator++();
+
+    private:
+        const World::ConstComponents& mComponents;
+        std::size_t mId{1};
+        mutable Component mComponent;
     };
 
     // Implementation.

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -64,12 +64,12 @@ void ComponentManager::removeAll(uint32_t id)
 
 IStorage* ComponentManager::storage(std::size_t id)
 {
-    return mEntries.at(id).storage.get();
+    return mEntries.at(id - 1).storage.get();
 }
 
 const IStorage* ComponentManager::storage(std::size_t id) const
 {
-    return mEntries.at(id).storage.get();
+    return mEntries.at(id - 1).storage.get();
 }
 
 ComponentManager::Entry::Entry(std::unique_ptr<IStorage> storage)

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -62,6 +62,16 @@ void ComponentManager::removeAll(uint32_t id)
     }
 }
 
+IStorage* ComponentManager::storage(std::size_t id)
+{
+    return mEntries.at(id).storage.get();
+}
+
+const IStorage* ComponentManager::storage(std::size_t id) const
+{
+    return mEntries.at(id).storage.get();
+}
+
 ComponentManager::Entry::Entry(std::unique_ptr<IStorage> storage)
     : storage(std::move(storage))
 {

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -23,6 +23,16 @@ bool World::isAlive(Entity entity) const
     return mEntityManager.isAlive(entity);
 }
 
+World::Components World::components(Entity entity)
+{
+    return Components{*this, entity};
+}
+
+World::ConstComponents World::components(Entity entity) const
+{
+    return ConstComponents{*this, entity};
+}
+
 data::old::Package World::pack(Entity entity, data::old::Context* context) const
 {
     CUBOS_ASSERT(this->isAlive(entity), "Entity is not alive");
@@ -90,4 +100,44 @@ World::Iterator World::begin() const
 World::Iterator World::end() const
 {
     return mEntityManager.end();
+}
+
+World::Components::Components(World& world, Entity entity)
+    : mWorld{world}
+    , mEntity{entity}
+{
+    CUBOS_ASSERT(world.isAlive(entity));
+}
+
+bool World::Components::has(const reflection::Type& type) const
+{
+    std::size_t componentId = mWorld.mComponentManager.getID(type);
+    return mWorld.mEntityManager.getMask(mEntity).test(componentId);
+}
+
+void* World::Components::get(const reflection::Type& type)
+{
+    CUBOS_ASSERT(this->has(type));
+    std::size_t componentId = mWorld.mComponentManager.getID(type);
+    return mWorld.mComponentManager.storage(componentId)->get(mEntity.index);
+}
+
+World::ConstComponents::ConstComponents(const World& world, Entity entity)
+    : mWorld{world}
+    , mEntity{entity}
+{
+    CUBOS_ASSERT(world.isAlive(entity));
+}
+
+bool World::ConstComponents::has(const reflection::Type& type) const
+{
+    std::size_t componentId = mWorld.mComponentManager.getID(type);
+    return mWorld.mEntityManager.getMask(mEntity).test(componentId);
+}
+
+const void* World::ConstComponents::get(const reflection::Type& type) const
+{
+    CUBOS_ASSERT(this->has(type));
+    std::size_t componentId = mWorld.mComponentManager.getID(type);
+    return mWorld.mComponentManager.storage(componentId)->get(mEntity.index);
 }

--- a/core/tests/ecs/blueprint.cpp
+++ b/core/tests/ecs/blueprint.cpp
@@ -70,19 +70,18 @@ TEST_CASE("ecs::Blueprint")
         auto spawnedBaz = spawned.entity("baz");
         cmdBuffer.commit();
 
-        // Package the entities to make sure they were properly spawned.
-        auto barPkg = world.pack(spawnedBar);
-        auto bazPkg = world.pack(spawnedBaz);
+        // Check if the spawned entities have the right components.
+        auto barComponents = world.components(spawnedBar);
+        auto bazComponents = world.components(spawnedBaz);
 
         // "bar" has no components.
-        CHECK(barPkg.type() == Package::Type::Object);
-        CHECK(barPkg.fields().size() == 0);
+        CHECK(barComponents.begin() == barComponents.end());
 
         // "baz" has a ParentComponent with parent = "bar" and an IntegerComponent with integer = 2.
-        CHECK(bazPkg.type() == Package::Type::Object);
-        CHECK(bazPkg.fields().size() == 2);
-        CHECK(bazPkg.field("parent").get<Entity>() == spawnedBar);
-        CHECK(bazPkg.field("integer").get<int>() == 2);
+        REQUIRE(bazComponents.has<ParentComponent>());
+        REQUIRE(bazComponents.has<IntegerComponent>());
+        CHECK(bazComponents.get<ParentComponent>().id == spawnedBar);
+        CHECK(bazComponents.get<IntegerComponent>().value == 2);
     }
 
     SUBCASE("merge one blueprint into another blueprint and then spawn it")
@@ -107,25 +106,23 @@ TEST_CASE("ecs::Blueprint")
         auto spawnedBaz = spawned.entity("sub.baz");
         cmdBuffer.commit();
 
-        // Package the entities to make sure they were properly spawned.
-        auto fooPkg = world.pack(spawnedFoo);
-        auto barPkg = world.pack(spawnedBar);
-        auto bazPkg = world.pack(spawnedBaz);
+        // Check if the spawned entities have the right components.
+        auto fooComponents = world.components(spawnedFoo);
+        auto barComponents = world.components(spawnedBar);
+        auto bazComponents = world.components(spawnedBaz);
 
         // "foo" has an IntegerComponent with value = 1.
-        CHECK(fooPkg.type() == Package::Type::Object);
-        CHECK(fooPkg.fields().size() == 1);
-        CHECK(fooPkg.field("integer").get<int>() == 1);
+        REQUIRE(fooComponents.has<IntegerComponent>());
+        CHECK(fooComponents.get<IntegerComponent>().value == 1);
 
         // "bar" has no components.
-        CHECK(barPkg.type() == Package::Type::Object);
-        CHECK(barPkg.fields().size() == 0);
+        CHECK(barComponents.begin() == barComponents.end());
 
         // "baz" has a ParentComponent with parent = "bar" and an IntegerComponent with value = 2.
-        CHECK(bazPkg.type() == Package::Type::Object);
-        CHECK(bazPkg.fields().size() == 2);
-        CHECK(bazPkg.field("parent").get<Entity>() == spawnedBar);
-        CHECK(bazPkg.field("integer").get<int>() == 2);
+        REQUIRE(bazComponents.has<ParentComponent>());
+        REQUIRE(bazComponents.has<IntegerComponent>());
+        CHECK(bazComponents.get<ParentComponent>().id == spawnedBar);
+        CHECK(bazComponents.get<IntegerComponent>().value == 2);
     }
 
     SUBCASE("check if arrays of entities are converted correctly when spawned")

--- a/core/tests/ecs/commands.cpp
+++ b/core/tests/ecs/commands.cpp
@@ -21,14 +21,14 @@ TEST_CASE("ecs::Commands")
     CHECK_FALSE(world.isAlive(foo)); // Still hasn't been committed.
     cmdBuffer.commit();
     CHECK(world.isAlive(foo)); // Now it has been committed.
-    CHECK(world.has<IntegerComponent>(foo));
+    CHECK(world.components(foo).has<IntegerComponent>());
 
     SUBCASE("destroy the entity")
     {
         // Destroy the entity.
         cmds.destroy(foo);
         CHECK(world.isAlive(foo));
-        CHECK(world.has<IntegerComponent>(foo));
+        CHECK(world.components(foo).has<IntegerComponent>());
         cmdBuffer.commit();
         CHECK_FALSE(world.isAlive(foo));
     }
@@ -36,18 +36,18 @@ TEST_CASE("ecs::Commands")
     SUBCASE("remove a component")
     {
         cmds.remove<IntegerComponent>(foo);
-        CHECK(world.has<IntegerComponent>(foo));
+        CHECK(world.components(foo).has<IntegerComponent>());
         cmdBuffer.commit();
-        CHECK_FALSE(world.has<IntegerComponent>(foo));
+        CHECK_FALSE(world.components(foo).has<IntegerComponent>());
     }
 
     SUBCASE("add a component")
     {
         auto parent = cmds.create().entity();
         cmds.add(foo, ParentComponent{parent});
-        CHECK_FALSE(world.has<ParentComponent>(foo));
+        CHECK_FALSE(world.components(foo).has<ParentComponent>());
         cmdBuffer.commit();
-        CHECK(world.has<ParentComponent>(foo));
+        CHECK(world.components(foo).has<ParentComponent>());
     }
 
     SUBCASE("abort creation of entities")

--- a/core/tests/ecs/query.cpp
+++ b/core/tests/ecs/query.cpp
@@ -46,11 +46,17 @@ TEST_CASE("ecs::Query")
 
     // Create a few entities.
     auto empty = world.create();
-    auto int0 = world.create(IntegerComponent{0});
-    auto int1 = world.create(IntegerComponent{1}, ParentComponent{});
-    world.create(ParentComponent{});
-    world.create(IntegerComponent{2});
-    world.create(IntegerComponent{3}, ParentComponent{});
+    auto int0 = world.create();
+    auto int1 = world.create();
+    auto int2 = world.create();
+    auto int3 = world.create();
+    auto foo = world.create();
+
+    world.components(int0).add(IntegerComponent{0});
+    world.components(int1).add(IntegerComponent{1}).add(ParentComponent{});
+    world.components(int2).add(IntegerComponent{2});
+    world.components(int3).add(IntegerComponent{3}).add(ParentComponent{});
+    world.components(foo).add(ParentComponent{});
 
     // Check if direct access to entities works.
     CHECK(Query<>(world)[empty].has_value());

--- a/core/tests/ecs/world.cpp
+++ b/core/tests/ecs/world.cpp
@@ -51,8 +51,9 @@ TEST_CASE("ecs::World")
     {
         bool destroyed = false;
 
-        // Create an entity with an detect destructor component.
-        auto foo = world.create(DetectDestructorComponent{{&destroyed}});
+        // Create an entity with a detect destructor component.
+        auto foo = world.create();
+        world.components(foo).add(DetectDestructorComponent{{&destroyed}});
         CHECK(world.components(foo).has<DetectDestructorComponent>());
         CHECK_FALSE(world.components(foo).has<ParentComponent>());
         CHECK_FALSE(destroyed);
@@ -69,13 +70,13 @@ TEST_CASE("ecs::World")
         CHECK(constComponents.begin()->type->is<DetectDestructorComponent>());
 
         // Add a parent component.
-        world.add(foo, ParentComponent{});
+        world.components(foo).add(ParentComponent{});
         CHECK(world.components(foo).has<DetectDestructorComponent>());
         CHECK(world.components(foo).has<ParentComponent>());
         CHECK_FALSE(destroyed);
 
         // Remove the detect destructor component.
-        world.remove<DetectDestructorComponent>(foo);
+        world.components(foo).remove<DetectDestructorComponent>();
         CHECK_FALSE(world.components(foo).has<DetectDestructorComponent>());
         CHECK(constWorld.components(foo).has<ParentComponent>());
         CHECK(destroyed);
@@ -115,7 +116,8 @@ TEST_CASE("ecs::World")
     {
         // Create an entity which has an integer component and a parent component.
         auto bar = world.create();
-        auto foo = world.create(IntegerComponent{0}, ParentComponent{bar});
+        auto foo = world.create();
+        world.components(foo).add(IntegerComponent{0}).add(ParentComponent{bar});
         CHECK(world.components(foo).has<IntegerComponent>());
         CHECK(world.components(foo).has<ParentComponent>());
 
@@ -139,7 +141,7 @@ TEST_CASE("ecs::World")
 
         // Create an entity and add a detect destructor component.
         auto foo = world.create();
-        world.add(foo, DetectDestructorComponent{{&destroyed}});
+        world.components(foo).add(DetectDestructorComponent{{&destroyed}});
         CHECK_FALSE(destroyed);
 
         // Destroy the entity.
@@ -155,7 +157,8 @@ TEST_CASE("ecs::World")
         {
             World world{};
             setupWorld(world);
-            world.create(DetectDestructorComponent{{&destroyed}});
+            auto foo = world.create();
+            world.components(foo).add(DetectDestructorComponent{{&destroyed}});
             CHECK_FALSE(destroyed);
         }
 

--- a/core/tests/ecs/world.cpp
+++ b/core/tests/ecs/world.cpp
@@ -44,20 +44,20 @@ TEST_CASE("ecs::World")
 
         // Create an entity with an detect destructor component.
         auto foo = world.create(DetectDestructorComponent{{&destroyed}});
-        CHECK(world.has<DetectDestructorComponent>(foo));
-        CHECK_FALSE(world.has<ParentComponent>(foo));
+        CHECK(world.components(foo).has<DetectDestructorComponent>());
+        CHECK_FALSE(world.components(foo).has<ParentComponent>());
         CHECK_FALSE(destroyed);
 
         // Add a parent component.
         world.add(foo, ParentComponent{});
-        CHECK(world.has<DetectDestructorComponent>(foo));
-        CHECK(world.has<ParentComponent>(foo));
+        CHECK(world.components(foo).has<DetectDestructorComponent>());
+        CHECK(world.components(foo).has<ParentComponent>());
         CHECK_FALSE(destroyed);
 
         // Remove the detect destructor component.
         world.remove<DetectDestructorComponent>(foo);
-        CHECK_FALSE(world.has<DetectDestructorComponent>(foo));
-        CHECK(world.has<ParentComponent>(foo));
+        CHECK_FALSE(world.components(foo).has<DetectDestructorComponent>());
+        CHECK(static_cast<const World&>(world).components(foo).has<ParentComponent>());
         CHECK(destroyed);
     }
 
@@ -70,8 +70,8 @@ TEST_CASE("ecs::World")
         auto pkg = world.pack(foo);
         pkg.fields().emplace_back("integer", Package::from(1));
         CHECK(world.unpack(foo, pkg));
-        CHECK(world.has<IntegerComponent>(foo));
-        CHECK_FALSE(world.has<ParentComponent>(foo));
+        CHECK(world.components(foo).has<IntegerComponent>());
+        CHECK_FALSE(world.components(foo).has<ParentComponent>());
 
         // Check if the component was added.
         pkg = world.pack(foo);
@@ -82,8 +82,8 @@ TEST_CASE("ecs::World")
         pkg.removeField("integer");
         pkg.fields().emplace_back("parent", Package::from(Entity{}));
         CHECK(world.unpack(foo, pkg));
-        CHECK_FALSE(world.has<IntegerComponent>(foo));
-        CHECK(world.has<ParentComponent>(foo));
+        CHECK_FALSE(world.components(foo).has<IntegerComponent>());
+        CHECK(world.components(foo).has<ParentComponent>());
 
         // Check if the component was added.
         pkg = world.pack(foo);
@@ -96,15 +96,15 @@ TEST_CASE("ecs::World")
         // Create an entity which has an integer component and a parent component.
         auto bar = world.create();
         auto foo = world.create(IntegerComponent{0}, ParentComponent{bar});
-        CHECK(world.has<IntegerComponent>(foo));
-        CHECK(world.has<ParentComponent>(foo));
+        CHECK(world.components(foo).has<IntegerComponent>());
+        CHECK(world.components(foo).has<ParentComponent>());
 
         // Change the value of the integer component.
         auto pkg = world.pack(foo);
         pkg.field("integer").set<int>(1);
         CHECK(world.unpack(foo, pkg));
-        CHECK(world.has<IntegerComponent>(foo));
-        CHECK(world.has<ParentComponent>(foo));
+        CHECK(world.components(foo).has<IntegerComponent>());
+        CHECK(world.components(foo).has<ParentComponent>());
 
         // Check if the value was changed.
         pkg = world.pack(foo);


### PR DESCRIPTION
# Description

Adds `Components` and `ConstComponents` to world, views which can be used to access the components in an entity directly through the `World`. Moved existing `.add`, `.remove` methods to `Components`. Example usage:

```cpp
world.components(myEntity).add(Position{...});
world.components(myEntity).get<Position>().x = 2;

for (auto [type, value] : world.components(myEntity)
{
    // type is a reflection type
    // value is a void* to the component
}
```

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
