### PR TITLE
feat(ecs): add negative tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Log the system order on the dispatcher (#414, **@RiscadoA**).
+- Negative tags to the dispatcher (#390, **@RiscadoA**).
 - Support for queries with multiple relation terms (#929, **@RiscadoA**).
 - Support for queries with more than one unrelated targets (#930, **@RiscadoA**).
 - Fixed Time Step plugin (#989, **@joaomanita**).

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -148,15 +148,25 @@ namespace cubos::core::ecs
         template <typename E>
         Cubos& addEvent();
 
-        /// @brief Returns a @ref TagBuilder to configure the given tag.
-        /// @param tag Tag to configure.
-        /// @return @ref TagBuilder used to configure the tag.
+        /// @brief Returns a @ref TagBuilder to configure the systems with the given tag.
+        /// @param tag Tag.
+        /// @return @ref TagBuilder.
         TagBuilder tag(const std::string& tag);
 
-        /// @brief Returns a @ref TagBuilder to configure the given startup tag.
-        /// @param tag Tag to configure.
-        /// @return @ref TagBuilder used to configure the tag.
+        /// @brief Returns a @ref TagBuilder to configure the systems with the given startup tag.
+        /// @param tag Tag.
+        /// @return @ref TagBuilder.
         TagBuilder startupTag(const std::string& tag);
+
+        /// @brief Returns a @ref TagBuilder to configure the systems without the given tag.
+        /// @param tag Tag.
+        /// @return @ref TagBuilder.
+        TagBuilder noTag(const std::string& tag);
+
+        /// @brief Returns a @ref TagBuilder to configure the systems without the given startup tag.
+        /// @param tag Tag.
+        /// @return @ref TagBuilder.
+        TagBuilder noStartupTag(const std::string& tag);
 
         /// @brief Returns a new builder used to add a system to the engine.
         /// @param name System debug name.

--- a/core/include/cubos/core/ecs/system/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/system/dispatcher.hpp
@@ -61,6 +61,10 @@ namespace cubos::core::ecs
         /// @param tag Tag to add.
         void addTag(const std::string& tag);
 
+        /// @brief Adds a tag, and sets it as the current negative tag for further settings.
+        /// @param tag Tag to add.
+        void addNegativeTag(const std::string& tag);
+
         /// @brief Makes the current tag inherit the settings of another tag.
         /// @param tag Tag to inherit from.
         void tagInheritTag(const std::string& tag);

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -55,17 +55,25 @@ Cubos& Cubos::addPlugin(void (*func)(Cubos&))
 TagBuilder Cubos::tag(const std::string& tag)
 {
     mMainDispatcher.addTag(tag);
-    TagBuilder builder(mWorld, mMainDispatcher, mMainTags);
-
-    return builder;
+    return TagBuilder{mWorld, mMainDispatcher, mMainTags};
 }
 
 TagBuilder Cubos::startupTag(const std::string& tag)
 {
     mStartupDispatcher.addTag(tag);
-    TagBuilder builder(mWorld, mStartupDispatcher, mStartupTags);
+    return TagBuilder{mWorld, mStartupDispatcher, mStartupTags};
+}
 
-    return builder;
+TagBuilder Cubos::noTag(const std::string& tag)
+{
+    mMainDispatcher.addNegativeTag(tag);
+    return TagBuilder{mWorld, mMainDispatcher, mMainTags};
+}
+
+TagBuilder Cubos::noStartupTag(const std::string& tag)
+{
+    mStartupDispatcher.addNegativeTag(tag);
+    return TagBuilder{mWorld, mStartupDispatcher, mStartupTags};
 }
 
 auto Cubos::system(std::string name) -> SystemBuilder

--- a/core/src/ecs/system/dispatcher.cpp
+++ b/core/src/ecs/system/dispatcher.cpp
@@ -26,9 +26,17 @@ Dispatcher::~Dispatcher()
 
 void Dispatcher::addTag(const std::string& tag)
 {
+    CUBOS_ASSERT(!tag.starts_with('!'), "Tags starting with '!' are reserved for internal use");
     ENSURE_TAG_SETTINGS(tag);
     mCurrTag = tag;
     mCurrGroup = mMainStep;
+}
+
+void Dispatcher::addNegativeTag(const std::string& tag)
+{
+    CUBOS_ASSERT(!tag.starts_with('!'), "Tags starting with '!' are reserved for internal use");
+    ENSURE_TAG_SETTINGS('!' + tag);
+    mCurrTag = '!' + tag;
 }
 
 void Dispatcher::tagInheritTag(const std::string& tag)
@@ -138,6 +146,15 @@ void Dispatcher::compileChain()
     // Implement system tag settings with custom settings
     for (System* system : mPendingSystems)
     {
+        // Add negative tags when the system doesn't have the respective positive tags
+        for (auto& [tag, settings] : mTagSettings)
+        {
+            if (tag.starts_with('!') && !system->tags.contains(tag.substr(1)))
+            {
+                system->tags.insert(tag);
+            }
+        }
+
         for (const auto& tag : system->tags)
         {
             if (!system->settings)

--- a/core/tests/ecs/dispatcher.cpp
+++ b/core/tests/ecs/dispatcher.cpp
@@ -119,6 +119,21 @@ TEST_CASE("ecs::Dispatcher")
             dispatcher.tagSetBeforeTag("2"); // "3" runs before "2"
         }
 
+        SUBCASE("with constraints on negative tags")
+        {
+            dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
+            dispatcher.systemAddTag("1");
+            dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
+            dispatcher.systemAddTag("2");
+            dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
+            dispatcher.systemAddTag("3");
+
+            dispatcher.addNegativeTag("1");
+            dispatcher.tagSetBeforeTag("1"); // anything without "1" runs before "1"
+            dispatcher.addNegativeTag("3");
+            dispatcher.tagSetAfterTag("3"); // anything without "3" runs after "3"
+        }
+
         singleDispatch(dispatcher, cmdBuffer);
         assertOrder(world, {3, 2, 1});
     }
@@ -154,6 +169,14 @@ TEST_CASE("ecs::Dispatcher")
             dispatcher.tagSetAfterTag("1");  // "3" runs after "1" - redundant
             dispatcher.tagSetAfterTag("1");  // Repeat
             dispatcher.tagSetBeforeTag("2"); // "3" runs before "2" - redundant
+            dispatcher.tagSetBeforeTag("2"); // Repeat
+
+            dispatcher.addNegativeTag("1");
+            dispatcher.tagSetAfterTag("1"); // "2" and "3" run after "1" - redundant
+            dispatcher.tagSetAfterTag("1"); // Repeat
+
+            dispatcher.addNegativeTag("2");
+            dispatcher.tagSetBeforeTag("2"); // "1" and "3" run before "2" - redundant
             dispatcher.tagSetBeforeTag("2"); // Repeat
         }
 


### PR DESCRIPTION
# Description

Adds the `.noTag` and `.noStartupTag` methods to `Cubos`, analogs to `.tag` and `.startupTag` but which can be used to apply configuration to all systems except the ones with the given tag. This was implemented by simply storing the negative tag settings on the same tag name prefixed with '!'. Then, when we apply the tag settings to the systems, we first add the tags `!x` to the system if they're not tagged with `x`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~ (I don't think this deserves a sample of its own)
