### PR TITLE
Add `JSONDeserializer`

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/data/ser/serializer.cpp"
     "src/cubos/core/data/ser/debug.cpp"
     "src/cubos/core/data/des/deserializer.cpp"
+    "src/cubos/core/data/des/json.cpp"
 
     "src/cubos/core/io/window.cpp"
     "src/cubos/core/io/cursor.cpp"

--- a/core/include/cubos/core/data/des/json.hpp
+++ b/core/include/cubos/core/data/des/json.hpp
@@ -1,0 +1,36 @@
+/// @file
+/// @brief Class @ref cubos::core::data::JSONDeserializer.
+/// @ingroup core-data-des
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <cubos/core/data/des/deserializer.hpp>
+
+namespace cubos::core::data
+{
+    /// @brief Deserializer implementation which allows reading data from a JSON object.
+    ///
+    /// Before deserializing any data, a JSON object must be fed to the deserializer.
+    ///
+    /// @ingroup core-data-des
+    class JSONDeserializer : public Deserializer
+    {
+    public:
+        /// @brief Constructs.
+        JSONDeserializer();
+
+        /// @brief Feeds a JSON object to be deserialized.
+        /// @param json JSON object.
+        void feed(nlohmann::json json);
+
+    protected:
+        bool decompose(const reflection::Type& type, void* value) override;
+
+    private:
+        nlohmann::json mJSON;
+        nlohmann::json::iterator mIterator;
+        bool mIsKey;
+    };
+} // namespace cubos::core::data

--- a/core/include/cubos/core/reflection/traits/array.hpp
+++ b/core/include/cubos/core/reflection/traits/array.hpp
@@ -92,6 +92,10 @@ namespace cubos::core::reflection
         /// @return Whether the operation is supported.
         bool hasErase() const;
 
+        /// @brief Checks if resize is supported.
+        /// @return Whether the operation is supported.
+        bool hasResize() const;
+
         /// @brief Returns the element type of the array.
         /// @return Element type.
         const Type& elementType() const;
@@ -158,6 +162,16 @@ namespace cubos::core::reflection
         /// @note Aborts if @ref ArrayTrait::hasErase() returns false.
         /// @param index Element index.
         void erase(std::size_t index) const;
+
+        /// @brief Clears the array.
+        /// @note Aborts if @ref ArrayTrait::hasErase() returns false.
+        void clear() const;
+
+        /// @brief Resizes the array. If this increases the size of the array, @ref insertDefault
+        /// is used to insert the remaining elements.
+        /// @note Aborts if @ref ArrayTrait::hasResize() returns false.
+        /// @param size Array size.
+        void resize(std::size_t size) const;
 
         /// @brief Gets an iterator to the first element.
         /// @return Iterator.

--- a/core/include/cubos/core/reflection/traits/dictionary.hpp
+++ b/core/include/cubos/core/reflection/traits/dictionary.hpp
@@ -227,6 +227,13 @@ namespace cubos::core::reflection
         /// @param iterator Iterator.
         void erase(Iterator& iterator) const;
 
+        /// @copydoc erase(Iterator&) const
+        void erase(Iterator&& iterator) const;
+
+        /// @brief Clears the dictionary.
+        /// @note Aborts if @ref DictionaryTrait::hasErase() returns false.
+        void clear() const;
+
     private:
         const DictionaryTrait& mTrait;
         void* mInstance;

--- a/core/include/cubos/core/reflection/traits/fields.hpp
+++ b/core/include/cubos/core/reflection/traits/fields.hpp
@@ -94,6 +94,10 @@ namespace cubos::core::reflection
         /// @return Iterator.
         static Iterator end();
 
+        /// @brief Returns how many fields there are in the trait.
+        /// @return Field count.
+        std::size_t size() const;
+
         /// @brief Returns a view of the given object instance.
         /// @param instance Object instance.
         /// @return Object view.

--- a/core/src/cubos/core/data/des/json.cpp
+++ b/core/src/cubos/core/data/des/json.cpp
@@ -1,0 +1,250 @@
+#include <cubos/core/data/des/json.hpp>
+#include <cubos/core/log.hpp>
+#include <cubos/core/memory/any_value.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/traits/array.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/traits/dictionary.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::data::JSONDeserializer;
+using cubos::core::memory::AnyValue;
+using cubos::core::reflection::ArrayTrait;
+using cubos::core::reflection::ConstructibleTrait;
+using cubos::core::reflection::DictionaryTrait;
+using cubos::core::reflection::FieldsTrait;
+using cubos::core::reflection::StringConversionTrait;
+using cubos::core::reflection::Type;
+
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define AUTO_HOOK(T, fromString)                                                                                       \
+    this->hook<T>([this](T& value) {                                                                                   \
+        if (mIsKey)                                                                                                    \
+        {                                                                                                              \
+            try                                                                                                        \
+            {                                                                                                          \
+                value = static_cast<T>(fromString(mIterator.key()));                                                   \
+            }                                                                                                          \
+            catch (std::invalid_argument&)                                                                             \
+            {                                                                                                          \
+                CUBOS_WARN("Cannot deserialize '{}' from JSON key {}: invalid string", #T, mIterator.key());           \
+                return false;                                                                                          \
+            }                                                                                                          \
+            catch (std::out_of_range&)                                                                                 \
+            {                                                                                                          \
+                CUBOS_WARN("Cannot deserialize '{}' from JSON key {}: out of range", #T, mIterator.key());             \
+                return false;                                                                                          \
+            }                                                                                                          \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            try                                                                                                        \
+            {                                                                                                          \
+                value = mIterator.value();                                                                             \
+            }                                                                                                          \
+            catch (nlohmann::json::exception&)                                                                         \
+            {                                                                                                          \
+                CUBOS_WARN("Cannot deserialize '{}' from a JSON {}", #T, mIterator->type_name());                      \
+                return false;                                                                                          \
+            }                                                                                                          \
+        }                                                                                                              \
+        return true;                                                                                                   \
+    })
+// NOLINTEND(bugprone-macro-parentheses)
+
+JSONDeserializer::JSONDeserializer()
+{
+    AUTO_HOOK(bool, [](const std::string& s) {
+        if (s == "true")
+        {
+            return true;
+        }
+
+        if (s == "false")
+        {
+            return false;
+        }
+
+        throw std::invalid_argument{s};
+    });
+    AUTO_HOOK(int8_t, std::stol);
+    AUTO_HOOK(int16_t, std::stol);
+    AUTO_HOOK(int32_t, std::stol);
+    AUTO_HOOK(int64_t, std::stoll);
+    AUTO_HOOK(uint8_t, std::stoul);
+    AUTO_HOOK(uint16_t, std::stoul);
+    AUTO_HOOK(uint32_t, std::stoul);
+    AUTO_HOOK(uint64_t, std::stoull);
+    AUTO_HOOK(float, std::stoull);
+    AUTO_HOOK(double, std::stoull);
+    AUTO_HOOK(std::string, [](const std::string& s) { return s; });
+}
+
+void JSONDeserializer::feed(nlohmann::json json)
+{
+    mJSON = nlohmann::json::array({std::move(json)});
+    mIterator = mJSON.begin();
+    mIsKey = false;
+}
+
+bool JSONDeserializer::decompose(const Type& type, void* value)
+{
+    if (mIsKey)
+    {
+        if (!type.has<StringConversionTrait>())
+        {
+            // JSON doesn't support structured keys, as JSON keys are just strings
+            CUBOS_WARN("Type '{}' cannot be deserialized from a dictionary key - try defining a hook", type.name());
+            return false;
+        }
+
+        const auto& trait = type.get<StringConversionTrait>();
+        if (!trait.from(value, mIterator.key()))
+        {
+            CUBOS_WARN("Key '{}' is not a valid string representation of '{}'", mIterator.key(), type.name());
+            return false;
+        }
+
+        return true;
+    }
+
+    if (mIterator->is_string() && type.has<StringConversionTrait>())
+    {
+        const auto& trait = type.get<StringConversionTrait>();
+        if (!trait.from(value, mIterator.value()))
+        {
+            CUBOS_WARN("String '{}' is not a valid string representation of '{}'", mIterator.value(), type.name());
+            return false;
+        }
+
+        return true;
+    }
+
+    if (mIterator->is_object() && type.has<DictionaryTrait>())
+    {
+        const auto& trait = type.get<DictionaryTrait>();
+        auto view = trait.view(value);
+
+        if (view.length() > 0)
+        {
+            if (!trait.hasErase())
+            {
+                CUBOS_WARN("Dictionary type '{}' must be empty to be deserialized as it doesn't support erase",
+                           type.name());
+                return false;
+            }
+
+            view.clear();
+        }
+
+        if (!trait.keyType().has<ConstructibleTrait>())
+        {
+            CUBOS_WARN("Dictionary type '{}' cannot be deserialized because its key type '{}' isn't constructible",
+                       type.name(), trait.keyType().name());
+            return false;
+        }
+
+        auto key = AnyValue::defaultConstruct(trait.keyType());
+        for (auto it = mIterator->begin(), end = mIterator->end(); it != end; ++it)
+        {
+            mIterator = it;
+            mIsKey = true;
+            if (!this->read(key.type(), key.get()))
+            {
+                CUBOS_WARN("Couldn't deserialize dictionary key '{}'", it.key());
+                return false;
+            }
+
+            view.insertDefault(key.get());
+            auto entry = view.find(key.get());
+            CUBOS_ASSERT(entry != view.end()); // We just inserted the key...
+
+            mIterator = it;
+            mIsKey = false;
+            if (!this->read(trait.valueType(), entry->value))
+            {
+                CUBOS_WARN("Couldn't deserialize dictionary value with key '{}'", it.key());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (mIterator->is_array() && type.has<ArrayTrait>())
+    {
+        const auto& trait = type.get<ArrayTrait>();
+        auto view = trait.view(value);
+
+        if (mIterator->size() != view.length())
+        {
+            if (!trait.hasResize())
+            {
+                CUBOS_WARN(
+                    "Array type '{}' isn't resizable and the JSON array size ({}) doesn't match the its size ({})",
+                    type.name(), mIterator->size(), view.length());
+                return false;
+            }
+
+            view.resize(mIterator->size());
+        }
+
+        auto it = mIterator->begin();
+        for (std::size_t i = 0; i < view.length(); ++i, ++it)
+        {
+            mIterator = it;
+            mIsKey = false;
+            if (!this->read(trait.elementType(), view.get(i)))
+            {
+                CUBOS_WARN("Couldn't deserialize array element {}", i);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (type.has<FieldsTrait>())
+    {
+        const auto& trait = type.get<FieldsTrait>();
+        auto view = trait.view(value);
+
+        if (trait.size() == 1)
+        {
+            // If there's a single field, read it directly.
+            if (!this->read(trait.begin()->type(), view.begin()->value))
+            {
+                CUBOS_WARN("Couldn't deserialize wrapped field '{}'", trait.begin()->name());
+                return false;
+            }
+
+            return true;
+        }
+
+        for (auto it = mIterator->begin(), end = mIterator->end(); it != end; ++it)
+        {
+            const auto* field = trait.field(it.key());
+            if (field == nullptr)
+            {
+                CUBOS_WARN("Type '{}' has no such field '{}'", type.name(), it.key());
+                return false;
+            }
+
+            mIterator = it;
+            mIsKey = false;
+            if (!this->read(field->type(), view.get(*field)))
+            {
+                CUBOS_WARN("Couldn't deserialize field '{}'", it.key());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    CUBOS_WARN("Cannot deserialize type '{}' from a JSON {}", type.name(), mIterator->type_name());
+    return false;
+}

--- a/core/src/cubos/core/reflection/traits/array.cpp
+++ b/core/src/cubos/core/reflection/traits/array.cpp
@@ -55,6 +55,11 @@ bool ArrayTrait::hasErase() const
     return mErase != nullptr;
 }
 
+bool ArrayTrait::hasResize() const
+{
+    return this->hasErase() && this->hasInsertDefault();
+}
+
 const Type& ArrayTrait::elementType() const
 {
     return mElementType;
@@ -109,6 +114,35 @@ void ArrayTrait::View::erase(std::size_t index) const
 {
     CUBOS_ASSERT(mTrait.hasErase(), "Erase not supported");
     mTrait.mErase(mInstance, index);
+}
+
+void ArrayTrait::View::clear() const
+{
+    CUBOS_ASSERT(mTrait.hasErase(), "Clear not supported");
+
+    // This really inefficient, but if it ever becomes a problem its easy to improve, we could just
+    // add yet another function pointer to the trait, which each array type sets.
+    while (this->length() > 0)
+    {
+        this->erase(this->length() - 1);
+    }
+}
+
+void ArrayTrait::View::resize(std::size_t size) const
+{
+    CUBOS_ASSERT(mTrait.hasResize(), "Resize not supported");
+
+    // This really inefficient, but if it ever becomes a problem its easy to improve, we could just
+    // add yet another function pointer to the trait, which each array type sets.
+    while (this->length() > size)
+    {
+        this->erase(this->length() - 1);
+    }
+
+    while (this->length() < size)
+    {
+        this->insertDefault(this->length());
+    }
 }
 
 ArrayTrait::View::Iterator ArrayTrait::View::begin() const

--- a/core/src/cubos/core/reflection/traits/dictionary.cpp
+++ b/core/src/cubos/core/reflection/traits/dictionary.cpp
@@ -134,6 +134,21 @@ void DictionaryTrait::View::erase(Iterator& iterator) const
     iterator.mInner = nullptr;
 }
 
+void DictionaryTrait::View::erase(Iterator&& iterator) const
+{
+    this->erase(iterator);
+}
+
+void DictionaryTrait::View::clear() const
+{
+    // This really inefficient, but if it ever becomes a problem its easy to improve, we could just
+    // add yet another function pointer to the trait, which each dictionary type sets.
+    while (this->length() > 0)
+    {
+        this->erase(this->begin());
+    }
+}
+
 DictionaryTrait::ConstView::ConstView(const DictionaryTrait& trait, const void* instance)
     : mTrait(trait)
     , mInstance(instance)

--- a/core/src/cubos/core/reflection/traits/fields.cpp
+++ b/core/src/cubos/core/reflection/traits/fields.cpp
@@ -124,7 +124,7 @@ const FieldsTrait::Field* FieldsTrait::field(const std::string& name) const
         }
     }
 
-    CUBOS_ERROR("No such field '{}'", name);
+    CUBOS_DEBUG("No such field '{}'", name);
     return nullptr;
 }
 

--- a/core/src/cubos/core/reflection/traits/fields.cpp
+++ b/core/src/cubos/core/reflection/traits/fields.cpp
@@ -138,6 +138,17 @@ FieldsTrait::Iterator FieldsTrait::end()
     return Iterator{nullptr};
 }
 
+std::size_t FieldsTrait::size() const
+{
+    std::size_t i = 0;
+    for (const auto& field : *this)
+    {
+        (void)field;
+        i += 1;
+    }
+    return i;
+}
+
 FieldsTrait::View FieldsTrait::view(void* instance) const
 {
     return View{*this, instance};

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
     data/fs/standard_archive.cpp
     data/fs/file_system.cpp
     data/ser/debug.cpp
+    data/des/json.cpp
     data/context.cpp
 
     memory/any_value.cpp

--- a/core/tests/data/des/json.cpp
+++ b/core/tests/data/des/json.cpp
@@ -1,0 +1,146 @@
+#include <doctest/doctest.h>
+#include <glm/vec3.hpp>
+
+#include <cubos/core/data/des/json.hpp>
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/map.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/uuid.hpp>
+#include <cubos/core/reflection/external/vector.hpp>
+#include <cubos/core/reflection/traits/constructible_utils.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+
+#include "../utils.hpp"
+
+using cubos::core::data::JSONDeserializer;
+using cubos::core::reflection::autoConstructibleTrait;
+using cubos::core::reflection::FieldsTrait;
+using cubos::core::reflection::Type;
+
+namespace
+{
+    struct NonConstructible
+    {
+        CUBOS_REFLECT
+        {
+            return Type::create("NonConstructible");
+        }
+
+        int operator<=>(const NonConstructible& /*unused*/) const
+        {
+            return 0;
+        }
+    };
+
+    struct Empty
+    {
+        CUBOS_REFLECT
+        {
+            return Type::create("Empty").with(autoConstructibleTrait<Empty>());
+        }
+
+        int operator<=>(const Empty& /*unused*/) const
+        {
+            return 0;
+        }
+    };
+
+    struct Wrapper
+    {
+        CUBOS_REFLECT
+        {
+            return Type::create("Wrapper").with(FieldsTrait{}.withField("inner", &Wrapper::inner));
+        }
+
+        bool operator==(const Wrapper& /*unused*/) const = default;
+
+        bool inner;
+    };
+} // namespace
+
+#define AUTO_EXISTING(json, initial, expected)                                                                         \
+    {                                                                                                                  \
+        des.feed(json);                                                                                                \
+        decltype(expected) value = (initial);                                                                          \
+        CHECK(des.read(value));                                                                                        \
+        CHECK(value == (expected));                                                                                    \
+    }
+
+#define AUTO_SUCCESS(json, expected)                                                                                   \
+    {                                                                                                                  \
+        des.feed(json);                                                                                                \
+        decltype(expected) value{};                                                                                    \
+        CHECK(des.read(value));                                                                                        \
+        CHECK(value == (expected));                                                                                    \
+    }
+
+#define AUTO_FAILURE(json, ...)                                                                                        \
+    {                                                                                                                  \
+        des.feed(json);                                                                                                \
+        __VA_ARGS__ value{};                                                                                           \
+        CHECK_FALSE(des.read(value));                                                                                  \
+    }
+
+// NOLINTBEGIN(readability-function-size)
+TEST_CASE("data::JSONDeserializer")
+{
+    using Json = nlohmann::json;
+
+    cubos::core::disableLogging();
+
+    JSONDeserializer des{};
+
+    AUTO_SUCCESS(true, true);
+    AUTO_SUCCESS(false, false);
+    AUTO_SUCCESS(-120, static_cast<int8_t>(-120));
+    AUTO_SUCCESS(30000, static_cast<int16_t>(30000));
+    AUTO_SUCCESS(-2000000000, static_cast<int32_t>(-2000000000));
+    AUTO_SUCCESS(9000000000000000000, static_cast<int64_t>(9000000000000000000));
+    AUTO_SUCCESS(240, static_cast<uint8_t>(240));
+    AUTO_SUCCESS(60000, static_cast<uint16_t>(60000));
+    AUTO_SUCCESS(4000000000, static_cast<uint32_t>(4000000000));
+    AUTO_SUCCESS(18000000000000000000ULL, static_cast<uint64_t>(18000000000000000000ULL));
+    AUTO_SUCCESS(1.5F, 1.5F);
+    AUTO_SUCCESS(1.5, 1.5);
+    AUTO_SUCCESS("Hello, world!", std::string{"Hello, world!"});
+    AUTO_SUCCESS("f7063cd4-de44-47b5-b0a9-f0e7a558c9e5",
+                 *uuids::uuid::from_string("f7063cd4-de44-47b5-b0a9-f0e7a558c9e5"));
+
+    AUTO_FAILURE("true", bool);
+    AUTO_FAILURE("-120", int8_t);
+    AUTO_FAILURE(1.5F, std::string);
+    AUTO_FAILURE("?", uuids::uuid);
+    AUTO_FAILURE("?", Empty);
+
+    AUTO_EXISTING((Json::object({})), (std::map<std::string, bool>{{"true", true}}), (std::map<std::string, bool>{}));
+    AUTO_SUCCESS((Json::object({})), (std::map<std::string, bool>{}));
+    AUTO_SUCCESS((Json::object({{"false", false}, {"true", true}})),
+                 (std::map<std::string, bool>{{"false", false}, {"true", true}}));
+    AUTO_SUCCESS((Json::object({{"false", true}, {"true", false}})),
+                 (std::map<bool, bool>{{false, true}, {true, false}}));
+    AUTO_SUCCESS(
+        (Json::object({{"f7063cd4-de44-47b5-b0a9-f0e7a558c9e5", true}})),
+        (std::map<uuids::uuid, bool>{{*uuids::uuid::from_string("f7063cd4-de44-47b5-b0a9-f0e7a558c9e5"), true}}));
+    AUTO_FAILURE((Json::object({{"yes", true}})), std::map<bool, bool>);
+    AUTO_FAILURE((Json::object({{"true", "yes"}})), std::map<bool, bool>);
+    AUTO_FAILURE((Json::object({})), std::map<NonConstructible, bool>);
+    AUTO_FAILURE((Json::object({{"?", true}})), std::map<Empty, bool>);
+    AUTO_FAILURE((Json::object({{"?", true}})), std::map<uuids::uuid, bool>);
+
+    AUTO_EXISTING(true, Wrapper{false}, Wrapper{true});
+    AUTO_SUCCESS(false, Wrapper{false});
+    AUTO_FAILURE((Json::object({{"inner", "true"}})), Wrapper);
+
+    AUTO_EXISTING((Json::object({{"x", 4}, {"z", 0}})), (glm::ivec3{3, 2, 1}), (glm::ivec3{4, 2, 0}));
+    AUTO_SUCCESS((Json::object({{"x", 1}, {"y", 2}})), (glm::ivec3{1, 2, 0}));
+    AUTO_FAILURE((Json::object({{"w", 0}})), glm::ivec3);
+    AUTO_FAILURE((Json::object({{"x", "0"}})), glm::ivec3);
+
+    AUTO_EXISTING((Json::array({1, 2, 3})), (std::vector<int>{3, 2}), (std::vector<int>{1, 2, 3}));
+    AUTO_EXISTING((Json::array({1, 2, 3})), (std::vector<int>{4, 3, 2, 1}), (std::vector<int>{1, 2, 3}));
+    AUTO_SUCCESS((Json::array({1, 2, 3})), (std::vector<int>{1, 2, 3}));
+    AUTO_FAILURE((Json::array({1, 2, "3"})), std::vector<int>);
+}
+// NOLINTEND(readability-function-size)

--- a/core/tests/reflection/traits/fields.cpp
+++ b/core/tests/reflection/traits/fields.cpp
@@ -28,6 +28,7 @@ TEST_CASE("reflection::FieldsTrait")
         auto fields = FieldsTrait();
         CHECK(fields.field("foo") == nullptr);
         CHECK(fields.begin() == fields.end());
+        CHECK(fields.size() == 0);
     }
 
     SUBCASE("single field")
@@ -39,6 +40,7 @@ TEST_CASE("reflection::FieldsTrait")
         CHECK(field == &*fields.begin());
         CHECK(fields.begin() != fields.end());
         CHECK(++fields.begin() == fields.end());
+        CHECK(fields.size() == 1);
 
         ObjectType object{};
         CHECK(field->name() == "foo");
@@ -69,6 +71,7 @@ TEST_CASE("reflection::FieldsTrait")
         REQUIRE(barField != nullptr);
         CHECK(barField == &*(++fields.begin()));
         CHECK(++(++fields.begin()) == fields.end());
+        CHECK(fields.size() == 2);
 
         ObjectType object{};
         CHECK(fooField->name() == "foo");


### PR DESCRIPTION
# Description

Adds `JSONDeserializer`, which implements the new reflection based `Deserializer` by reading data from `nlohmann::json` objects.
Adds `clear` to `DictionaryTrait` and `ArrayTrait`, and `resize` to the latter.
Adds `size` to `FieldsTrait`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
