### PR TITLE
Remove old serialization code from `SceneBridge`

### DIFF
--- a/core/include/cubos/core/ecs/component/manager.hpp
+++ b/core/include/cubos/core/ecs/component/manager.hpp
@@ -17,25 +17,6 @@
 
 namespace cubos::core::ecs
 {
-    /// @brief Gets the registered name of a component type.
-    ///
-    /// If the component type is not registered, aborts the program.
-    ///
-    /// @tparam T Component type.
-    /// @return Registered name of the component type.
-    /// @ingroup core-ecs-component
-    template <typename T>
-    std::optional<std::string_view> getComponentName();
-
-    /// @brief Gets the registered name of a component type.
-    ///
-    /// If the component type is not registered, aborts the program.
-    ///
-    /// @param type Component type.
-    /// @return Registered name of the component type.
-    /// @ingroup core-ecs-component
-    std::optional<std::string_view> getComponentName(const reflection::Type& type);
-
     /// @brief Utility struct used to reference a storage of component type @p T for reading.
     /// @tparam T Component type.
     /// @ingroup core-ecs-component
@@ -207,12 +188,6 @@ namespace cubos::core::ecs
     };
 
     // Implementation.
-
-    template <typename T>
-    std::optional<std::string_view> getComponentName()
-    {
-        return getComponentName(reflection::reflect<T>());
-    }
 
     template <typename T>
     ReadStorage<T>::ReadStorage(ReadStorage&& other) noexcept

--- a/core/include/cubos/core/ecs/component/registry.hpp
+++ b/core/include/cubos/core/ecs/component/registry.hpp
@@ -10,6 +10,7 @@
 #include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/component/storage.hpp>
 #include <cubos/core/memory/type_map.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 namespace cubos::core::ecs
 {
@@ -43,12 +44,7 @@ namespace cubos::core::ecs
         /// @tparam S Storage type to use for the component.
         /// @param name Name of the component.
         template <typename T, typename S>
-        static void add(std::string_view name);
-
-        /// @brief Gets the name of a component type.
-        /// @param type Type of the component.
-        /// @return Name of the component, or std::nullopt if the component type was not found.
-        static std::optional<std::string_view> name(const reflection::Type& type);
+        static void add();
 
         /// @brief Gets the type index of a component type.
         /// @param name Name of the component.
@@ -59,8 +55,7 @@ namespace cubos::core::ecs
         /// @brief Entry in the component registry.
         struct Entry
         {
-            const reflection::Type* type; ///< Type of the component.
-            std::string name;             ///< Name of the component.
+            const reflection::Type* type; ///< Component type.
 
             /// Function for creating the component from a deserializer.
             bool (*componentCreator)(data::old::Deserializer&, Blueprint&, Entity);
@@ -79,17 +74,15 @@ namespace cubos::core::ecs
     // Implementation.
 
     template <typename T, typename S>
-    inline void Registry::add(std::string_view name)
+    inline void Registry::add()
     {
         static_assert(std::is_base_of_v<Storage<T>, S>, "Component storage for T must be derived from Storage<T>");
 
         auto& byType = Registry::entriesByType();
         auto& byNames = Registry::entriesByName();
-        assert(byNames.find(std::string(name)) == byNames.end());
 
         auto entry = std::make_shared<Entry>(Entry{
             .type = &reflection::reflect<T>(),
-            .name = std::string(name),
             .componentCreator =
                 [](data::old::Deserializer& des, Blueprint& blueprint, Entity id) {
                     T comp;
@@ -110,7 +103,7 @@ namespace cubos::core::ecs
         });
 
         byType.insert<T>(entry);
-        byNames[std::string(name)] = entry;
+        byNames[entry->type->name()] = entry;
     }
 } // namespace cubos::core::ecs
 
@@ -120,7 +113,7 @@ namespace cubos::core::ecs
 /// unit (think of it as a .cpp file) in the executable, otherwise the component type may not be
 /// registered. E.g.: keeping it hidden in a .cpp file on a library may not work.
 /// @ingroup core-ecs-component
-#define CUBOS_REGISTER_COMPONENT(type, storageType, name)                                                              \
+#define CUBOS_REGISTER_COMPONENT(type, storageType)                                                                    \
     namespace cubos::core::ecs::impl                                                                                   \
     {                                                                                                                  \
         class ComponentRegister##type                                                                                  \
@@ -128,7 +121,7 @@ namespace cubos::core::ecs
         private:                                                                                                       \
             static inline bool registerType()                                                                          \
             {                                                                                                          \
-                ::cubos::core::ecs::Registry::add<type, storageType>(name);                                            \
+                ::cubos::core::ecs::Registry::add<type, storageType>();                                                \
                 return true;                                                                                           \
             }                                                                                                          \
                                                                                                                        \

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -12,7 +12,7 @@
 #include <cubos/core/ecs/entity/manager.hpp>
 #include <cubos/core/ecs/resource/manager.hpp>
 #include <cubos/core/log.hpp>
-#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 namespace cubos::core::ecs
 {
@@ -392,7 +392,7 @@ namespace cubos::core::ecs
     template <typename T>
     void World::registerComponent()
     {
-        CUBOS_TRACE("Registered component '{}'", getComponentName<T>().value());
+        CUBOS_TRACE("Registered component '{}'", reflection::reflect<T>().name());
         mComponentManager.registerComponent<T>();
     }
 

--- a/core/samples/ecs/general/main.cpp
+++ b/core/samples/ecs/general/main.cpp
@@ -122,10 +122,10 @@ namespace cubos::core::data::old
     }
 } // namespace cubos::core::data::old
 
-CUBOS_REGISTER_COMPONENT(Player, ecs::NullStorage<Player>, "Player")
-CUBOS_REGISTER_COMPONENT(Position, ecs::VecStorage<Position>, "Position")
-CUBOS_REGISTER_COMPONENT(Velocity, ecs::MapStorage<Velocity>, "Velocity")
-CUBOS_REGISTER_COMPONENT(Parent, ecs::VecStorage<Parent>, "Parent")
+CUBOS_REGISTER_COMPONENT(Player, ecs::NullStorage<Player>)
+CUBOS_REGISTER_COMPONENT(Position, ecs::VecStorage<Position>)
+CUBOS_REGISTER_COMPONENT(Velocity, ecs::MapStorage<Velocity>)
+CUBOS_REGISTER_COMPONENT(Parent, ecs::VecStorage<Parent>)
 
 void spawner(ecs::Commands cmds)
 {

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -5,11 +5,6 @@
 using namespace cubos::core;
 using namespace cubos::core::ecs;
 
-std::optional<std::string_view> cubos::core::ecs::getComponentName(const reflection::Type& type)
-{
-    return Registry::name(type);
-}
-
 void ComponentManager::registerComponent(const reflection::Type& type)
 {
     if (!mTypeToIds.contains(type))

--- a/core/src/cubos/core/ecs/component/registry.cpp
+++ b/core/src/cubos/core/ecs/component/registry.cpp
@@ -25,17 +25,6 @@ std::unique_ptr<IStorage> Registry::createStorage(const reflection::Type& type)
     return nullptr;
 }
 
-std::optional<std::string_view> Registry::name(const reflection::Type& type)
-{
-    auto& entries = Registry::entriesByType();
-    if (entries.contains(type))
-    {
-        return entries.at(type)->name;
-    }
-
-    return std::nullopt;
-}
-
 const reflection::Type* Registry::type(std::string_view name)
 {
     auto& entries = Registry::entriesByName();

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -55,8 +55,8 @@ data::old::Package World::pack(Entity entity, data::old::Context* context) const
     {
         if (mask.test(i))
         {
-            auto name = Registry::name(mComponentManager.getType(i));
-            pkg.fields().push_back({std::string(name.value()), mComponentManager.pack(entity.index, i, context)});
+            auto name = mComponentManager.getType(i).name();
+            pkg.fields().push_back({name, mComponentManager.pack(entity.index, i, context)});
         }
     }
 

--- a/core/tests/ecs/blueprint.cpp
+++ b/core/tests/ecs/blueprint.cpp
@@ -59,7 +59,7 @@ TEST_CASE("ecs::Blueprint")
 
         // Unpack the identifier of "bar" into a ParentComponent.
         Unpackager unpackager{barPkg};
-        Registry::create("parent", unpackager, blueprint, baz);
+        Registry::create("ParentComponent", unpackager, blueprint, baz);
     }
 
     SUBCASE("spawn the blueprint")

--- a/core/tests/ecs/registry.cpp
+++ b/core/tests/ecs/registry.cpp
@@ -26,33 +26,30 @@ TEST_CASE("ecs::Registry")
     Blueprint blueprint{};
     auto entity = blueprint.create("entity");
 
-    // Initially "foo" of type int isn't registered.
-    CHECK(Registry::type("foo") == nullptr);
-    CHECK_FALSE(Registry::name(reflect<int>()).has_value());
+    // Initially type int32_t isn't registered.
+    CHECK(Registry::type("int32_t") == nullptr);
 
     // After registering, it can now be found.
-    Registry::add<int, VecStorage<int>>("foo");
-    REQUIRE(Registry::type("foo") != nullptr);
-    CHECK(Registry::type("foo") == &reflect<int>());
-    REQUIRE(Registry::name(reflect<int>()).has_value());
-    CHECK(*Registry::name(reflect<int>()) == "foo");
+    Registry::add<int32_t, VecStorage<int32_t>>();
+    REQUIRE(Registry::type("int32_t") != nullptr);
+    CHECK(Registry::type("int32_t") == &reflect<int32_t>());
 
     // Create a storage for it and check if its of the correct type.
-    auto storage = Registry::createStorage(reflect<int>());
-    CHECK(dynamic_cast<VecStorage<int>*>(storage.get()) != nullptr);
+    auto storage = Registry::createStorage(reflect<int32_t>());
+    CHECK(dynamic_cast<VecStorage<int32_t>*>(storage.get()) != nullptr);
 
     // Instantiate the component into a blueprint, from a package.
-    auto pkg = Package::from<int>(42);
+    auto pkg = Package::from<int32_t>(42);
     Unpackager unpackager{pkg};
-    REQUIRE(Registry::create("foo", unpackager, blueprint, entity));
+    REQUIRE(Registry::create("int32_t", unpackager, blueprint, entity));
 
     // Spawn the blueprint into the world.
-    world.registerComponent<int>();
+    world.registerComponent<int32_t>();
     entity = cmds.spawn(blueprint).entity("entity");
     cmdBuffer.commit();
 
     // Package the entity and check if the component was correctly instantiated.
     pkg = world.pack(entity);
     REQUIRE(pkg.fields().size() == 1);
-    CHECK(pkg.field("foo").get<int>() == 42);
+    CHECK(pkg.field("int32_t").get<int32_t>() == 42);
 }

--- a/core/tests/ecs/world.cpp
+++ b/core/tests/ecs/world.cpp
@@ -89,7 +89,7 @@ TEST_CASE("ecs::World")
 
         // Add an integer component.
         auto pkg = world.pack(foo);
-        pkg.fields().emplace_back("integer", Package::from(1));
+        pkg.fields().emplace_back("IntegerComponent", Package::from(1));
         CHECK(world.unpack(foo, pkg));
         CHECK(world.components(foo).has<IntegerComponent>());
         CHECK_FALSE(world.components(foo).has<ParentComponent>());
@@ -97,11 +97,11 @@ TEST_CASE("ecs::World")
         // Check if the component was added.
         pkg = world.pack(foo);
         CHECK(pkg.fields().size() == 1);
-        CHECK(pkg.field("integer").get<int>() == 1);
+        CHECK(pkg.field("IntegerComponent").get<int>() == 1);
 
         // Remove the integer component and add a parent component.
-        pkg.removeField("integer");
-        pkg.fields().emplace_back("parent", Package::from(Entity{}));
+        pkg.removeField("IntegerComponent");
+        pkg.fields().emplace_back("ParentComponent", Package::from(Entity{}));
         CHECK(world.unpack(foo, pkg));
         CHECK_FALSE(world.components(foo).has<IntegerComponent>());
         CHECK(world.components(foo).has<ParentComponent>());
@@ -109,7 +109,7 @@ TEST_CASE("ecs::World")
         // Check if the component was added.
         pkg = world.pack(foo);
         CHECK(pkg.fields().size() == 1);
-        CHECK(pkg.field("parent").get<Entity>().isNull());
+        CHECK(pkg.field("ParentComponent").get<Entity>().isNull());
     }
 
     SUBCASE("change a component through pack and unpack")
@@ -123,7 +123,7 @@ TEST_CASE("ecs::World")
 
         // Change the value of the integer component.
         auto pkg = world.pack(foo);
-        pkg.field("integer").set<int>(1);
+        pkg.field("IntegerComponent").set<int>(1);
         CHECK(world.unpack(foo, pkg));
         CHECK(world.components(foo).has<IntegerComponent>());
         CHECK(world.components(foo).has<ParentComponent>());
@@ -131,8 +131,8 @@ TEST_CASE("ecs::World")
         // Check if the value was changed.
         pkg = world.pack(foo);
         CHECK(pkg.fields().size() == 2);
-        CHECK(pkg.field("integer").get<int>() == 1);
-        CHECK(pkg.field("parent").get<Entity>() == bar);
+        CHECK(pkg.field("IntegerComponent").get<int>() == 1);
+        CHECK(pkg.field("ParentComponent").get<Entity>() == bar);
     }
 
     SUBCASE("components are correctly destructed when their entity is destroyed")

--- a/engine/include/cubos/engine/scene/bridge.hpp
+++ b/engine/include/cubos/engine/scene/bridge.hpp
@@ -6,7 +6,7 @@
 
 #include <cubos/core/reflection/reflect.hpp>
 
-#include <cubos/engine/assets/bridge.hpp>
+#include <cubos/engine/assets/bridges/file.hpp>
 #include <cubos/engine/scene/scene.hpp>
 
 namespace cubos::engine
@@ -27,35 +27,34 @@ namespace cubos::engine
     ///     },
     ///     "entities": {
     ///         "baz": {
-    ///             "cubos/position": {
-    ///                 "x": 1,
-    ///                 "y": 2,
-    ///                 "z": 3
+    ///             "cubos::engine::Position": {
+    ///                 "x": 10
     ///             }
     ///         },
     ///         "foo.bar": {
-    ///             "cubos/parent": "baz",
+    ///             "Parent": "baz",
     ///         }
     ///     }
     /// }
     /// @endcode
     ///
-    /// This scene will import the subscene with ID `6f42ae5a-59d1-5df3-8720-83b8df6dd536`, and
+    /// This scene will import the sub-scene with ID `6f42ae5a-59d1-5df3-8720-83b8df6dd536`, and
     /// prefix all of its entities with `foo.`. The entity `foo.bar` will override the entity `bar`
     /// from the imported scene, while the entity `baz` will be added to the scene.
     ///
     /// @ingroup scene-plugin
-    class SceneBridge : public AssetBridge
+    class SceneBridge : public FileBridge
     {
     public:
         /// @brief Constructs a bridge.
         ///
         SceneBridge()
-            : AssetBridge(core::reflection::reflect<Scene>())
+            : FileBridge(core::reflection::reflect<Scene>())
         {
         }
 
-        bool load(Assets& assets, const AnyAsset& handle) override;
-        bool save(const Assets& assets, const AnyAsset& handle) override;
+    protected:
+        bool loadFromFile(Assets& assets, const AnyAsset& handle, core::memory::Stream& stream) override;
+        bool saveToFile(const Assets& assets, const AnyAsset& handle, core::memory::Stream& stream) override;
     };
 } // namespace cubos::engine

--- a/engine/samples/scene/assets/main.cubos
+++ b/engine/samples/scene/assets/main.cubos
@@ -5,13 +5,13 @@
   },
   "entities": {
     "main": {
-      "num": 0
+      "Num": 0
     },
     "sub1.root": {
-      "parent": "main"
+      "Parent": "main"
     },
     "sub2.root": {
-      "parent": "main"
+      "Parent": "main"
     }
   }
 }

--- a/engine/samples/scene/assets/sub.cubos
+++ b/engine/samples/scene/assets/sub.cubos
@@ -2,11 +2,11 @@
   "imports": {},
   "entities": {
     "root": {
-      "num": 1
+      "Num": 1
     },
     "child": {
-      "num": 2,
-      "parent": "root"
+      "Num": 2,
+      "Parent": "root"
     }
   }
 }

--- a/tools/quadrados-gen/src/main.cpp
+++ b/tools/quadrados-gen/src/main.cpp
@@ -881,8 +881,7 @@ static bool generate(const GenerateOptions& options)
             file << "{" << std::endl;
             file << "    ";
         }
-        file << "CUBOS_REGISTER_COMPONENT(" << component.typeStr << ", " << storageId << ", \"" << component.name
-             << "\")" << std::endl;
+        file << "CUBOS_REGISTER_COMPONENT(" << component.typeStr << ", " << storageId << ")" << std::endl;
         if (!component.namespaceStr.empty())
         {
             file << "} // namespace " << component.namespaceStr << std::endl;


### PR DESCRIPTION
# Description

Makes the ECS use the actual type name to identify components instead of the attribute name - still haven't removed it from quadrados, but the whole attribute will soon go away anyway. 
Changes the `SceneBridge` to use the new `JSONDeserializer` instead of the old one.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~
- [x] Update samples.