### PR TITLE
feat(ci): deploy docs to subdirs

### DIFF
--- a/.github/workflows/build-doxygen-docs.yml
+++ b/.github/workflows/build-doxygen-docs.yml
@@ -44,3 +44,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ${{github.workspace}}/build/docs/doxygen/html
+        destination_dir: docs

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -47,3 +47,4 @@ jobs:
       uses: rossjrw/pr-preview-action@v1
       with:
         source-dir: ${{github.workspace}}/build/docs/doxygen/html
+        umbrella-dir: docs-preview

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,6 +1,7 @@
 # Get project name and version from CMake
 PROJECT_NAME = @DOXYGEN_PROJECT_NAME@
 PROJECT_NUMBER = @DOXYGEN_PROJECT_VERSION@
+PROJECT_BRIEF = Docs
 
 # Add sources
 INPUT = @DOXYGEN_PROJECT_ROOT@/docs/pages \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 DOXYFILE = 'Doxyfile'
 
+MAIN_PROJECT_URL = 'https://gamedevtecnico.github.io/cubos/'
+
 LINKS_NAVBAR1 = [
     (None, 'pages', []),
     (None, 'modules', []),


### PR DESCRIPTION
Closes #563.

# Description

Since `cubos-blog` now deploys to the root of the `gh-pages` branch of this repo, this PR changes the path of the docs deploy to the `docs` subdirectory. 

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~
- [x] ~~Write new samples.~~
