### PR TITLE
Add mouse button bindings

### DIFF
--- a/core/include/cubos/core/io/window.hpp
+++ b/core/include/cubos/core/io/window.hpp
@@ -139,6 +139,18 @@ namespace cubos::core::io
     /// @ingroup core-io
     Window openWindow(const std::string& title = "CUBOS.", const glm::ivec2& size = {800, 600});
 
+    /// @brief Converts a @ref MouseButton enum to a string.
+    /// @param button MouseButton to convert.
+    /// @return String representation.
+    /// @ingroup core-io
+    std::string mouseButtonToString(MouseButton button);
+
+    /// @brief Convert a string to a @ref MouseButton enum.
+    /// @param str The string to convert.
+    /// @return MouseButton.
+    /// @ingroup core-io
+    MouseButton stringToMouseButton(const std::string& str);
+
     /// @brief Interface used to wrap low-level window API implementations.
     ///
     /// Allows polling of input events and creates a @ref gl::RenderDevice for rendering to the

--- a/core/src/cubos/core/io/window.cpp
+++ b/core/src/cubos/core/io/window.cpp
@@ -1,6 +1,6 @@
-#include <cubos/core/io/window.hpp>
 #include <cubos/core/data/old/deserializer.hpp>
 #include <cubos/core/data/old/serializer.hpp>
+#include <cubos/core/io/window.hpp>
 
 #include "glfw_window.hpp"
 
@@ -16,7 +16,7 @@ Window cubos::core::io::openWindow(const std::string& title, const glm::ivec2& s
 std::string cubos::core::io::mouseButtonToString(MouseButton button)
 {
 #define MAP_BUTTON_TO_STRING(button, string)                                                                           \
-    case MouseButton::button:                                                                                        \
+    case MouseButton::button:                                                                                          \
         return string;
     switch (button)
     {

--- a/core/src/cubos/core/io/window.cpp
+++ b/core/src/cubos/core/io/window.cpp
@@ -1,12 +1,63 @@
 #include <cubos/core/io/window.hpp>
+#include <cubos/core/data/old/deserializer.hpp>
+#include <cubos/core/data/old/serializer.hpp>
 
 #include "glfw_window.hpp"
 
 using namespace cubos::core::io;
+using cubos::core::data::old::Deserializer;
+using cubos::core::data::old::Serializer;
 
 Window cubos::core::io::openWindow(const std::string& title, const glm::ivec2& size)
 {
     return std::make_shared<GLFWWindow>(title, size);
+}
+
+std::string cubos::core::io::mouseButtonToString(MouseButton button)
+{
+#define MAP_BUTTON_TO_STRING(button, string)                                                                           \
+    case MouseButton::button:                                                                                        \
+        return string;
+    switch (button)
+    {
+        MAP_BUTTON_TO_STRING(Left, "Left")
+        MAP_BUTTON_TO_STRING(Right, "Right")
+        MAP_BUTTON_TO_STRING(Middle, "Middle")
+        MAP_BUTTON_TO_STRING(Extra1, "Extra1")
+        MAP_BUTTON_TO_STRING(Extra2, "Extra2")
+    default:
+        return "Invalid";
+    }
+#undef MAP_KEY_TO_STRING
+}
+
+template <>
+void cubos::core::data::old::serialize<MouseButton>(Serializer& ser, const MouseButton& obj, const char* name)
+{
+    ser.write(io::mouseButtonToString(obj), name);
+}
+
+MouseButton cubos::core::io::stringToMouseButton(const std::string& str)
+{
+#define MAP_STRING_TO_BUTTON(string, button)                                                                           \
+    if (str == (string))                                                                                               \
+        return MouseButton::button;
+    MAP_STRING_TO_BUTTON("Left", Left)
+    MAP_STRING_TO_BUTTON("Right", Right)
+    MAP_STRING_TO_BUTTON("Middle", Middle)
+    MAP_STRING_TO_BUTTON("Extra1", Extra1)
+    MAP_STRING_TO_BUTTON("Extra2", Extra2)
+    // else
+    return MouseButton::Invalid;
+#undef MAP_STRING_TO_BUTTON
+}
+
+template <>
+void cubos::core::data::old::deserialize<MouseButton>(Deserializer& des, MouseButton& obj)
+{
+    std::string axis;
+    des.read(axis);
+    obj = io::stringToMouseButton(axis);
 }
 
 BaseWindow::BaseWindow()

--- a/engine/include/cubos/engine/input/action.hpp
+++ b/engine/include/cubos/engine/input/action.hpp
@@ -8,6 +8,7 @@
 
 #include <cubos/core/io/gamepad.hpp>
 #include <cubos/core/io/keyboard.hpp>
+#include <cubos/core/io/window.hpp>
 
 namespace cubos::engine
 {
@@ -27,10 +28,13 @@ namespace cubos::engine
         /// @brief Constructs with existing bindings.
         /// @param keys Key bindings.
         /// @param gamepadButtons Gamepad button bindings.
+        /// @param mouseButtons Mouse button bindings.
         InputAction(std::vector<std::pair<core::io::Key, core::io::Modifiers>> keys,
-                    std::vector<core::io::GamepadButton> gamepadButtons)
+                    std::vector<core::io::GamepadButton> gamepadButtons,
+                    std::vector<core::io::MouseButton> mouseButtons)
             : mKeys(std::move(keys))
             , mGamepadButtons(std::move(gamepadButtons))
+            , mMouseButtons(std::move(mouseButtons))
         {
         }
 
@@ -50,6 +54,14 @@ namespace cubos::engine
         /// @return Vector of buttons.
         std::vector<core::io::GamepadButton>& gamepadButtons();
 
+        /// @brief Gets the mouse button bindings.
+        /// @return Vector of buttons.
+        const std::vector<core::io::MouseButton>& mouseButtons() const;
+
+        /// @brief Gets the mouse button bindings.
+        /// @return Vector of buttons.
+        std::vector<core::io::MouseButton>& mouseButtons();
+
         /// @brief Checks if this action is pressed.
         /// @return Whether this action is pressed.
         bool pressed() const;
@@ -61,6 +73,7 @@ namespace cubos::engine
     private:
         std::vector<std::pair<core::io::Key, core::io::Modifiers>> mKeys;
         std::vector<core::io::GamepadButton> mGamepadButtons;
+        std::vector<core::io::MouseButton> mMouseButtons;
 
         bool mPressed; ///< Not serialized.
     };

--- a/engine/include/cubos/engine/input/input.hpp
+++ b/engine/include/cubos/engine/input/input.hpp
@@ -30,6 +30,9 @@ namespace cubos::engine
         /// @brief Alias for @ref core::io::GamepadAxis.
         using GamepadAxis = core::io::GamepadAxis;
 
+        /// @brief Alias for @ref core::io::MouseButton.
+        using MouseButton = core::io::MouseButton;
+
         Input() = default;
         ~Input() = default;
 
@@ -77,6 +80,11 @@ namespace cubos::engine
         /// @param event Gamepad connection event.
         void handle(const core::io::Window& window, const core::io::GamepadConnectionEvent& event);
 
+        /// @brief Handle a mouse button event.
+        /// @param window Window that received the event.
+        /// @param event Mouse button event.
+        void handle(const core::io::Window& window, const core::io::MouseButtonEvent& event);
+
         /// @brief Handle all other events - discards them.
         ///
         /// This is method exists so that `std::visit` can be used with @ref core::io::WindowEvent
@@ -108,16 +116,19 @@ namespace cubos::engine
 
         static bool anyPressed(const core::io::Window& window, const std::vector<std::pair<Key, Modifiers>>& keys);
         bool anyPressed(int player, const std::vector<GamepadButton>& buttons) const;
+        bool anyPressed(const std::vector<MouseButton>& buttons);
         void handleActions(const core::io::Window& window, const std::vector<BindingIndex>& boundActions);
         void handleAxes(const core::io::Window& window, const std::vector<BindingIndex>& boundAxes);
 
         std::unordered_map<int, InputBindings> mPlayerBindings;
         std::unordered_map<int, int> mPlayerGamepads;
         std::unordered_map<int, core::io::GamepadState> mGamepadStates;
+        std::unordered_map<MouseButton, bool> mPressedMouseButtons;
 
         std::unordered_map<Key, std::vector<BindingIndex>> mBoundActions;
         std::unordered_map<Key, std::vector<BindingIndex>> mBoundAxes;
         std::unordered_map<GamepadButton, std::vector<BindingIndex>> mBoundGamepadActions;
         std::unordered_map<GamepadAxis, std::vector<BindingIndex>> mBoundGamepadAxes;
+        std::unordered_map<MouseButton, std::vector<BindingIndex>> mBoundMouseActions;
     };
 } // namespace cubos::engine

--- a/engine/samples/input/assets/sample.bind
+++ b/engine/samples/input/assets/sample.bind
@@ -7,7 +7,9 @@
             "gamepad": [
                 "RBumper"
             ],
-            "mouse": []
+            "mouse": [
+                "Left"
+            ]
         },
         "x-or-z": {
             "keys": [
@@ -30,6 +32,35 @@
             ],
             "gamepad": [],
             "mouse": []
+        },
+        "left-mb": {
+            "keys": [],
+            "gamepad": [],
+            "mouse": [
+                "Left"
+            ]
+        },
+        "right-mb": {
+            "keys": [],
+            "gamepad": [],
+            "mouse": [
+                "Right"
+            ]
+        },
+        "middle-mb": {
+            "keys": [],
+            "gamepad": [],
+            "mouse": [
+                "Middle"
+            ]
+        },
+        "extra-mb": {
+            "keys": [],
+            "gamepad": [],
+            "mouse": [
+                "Extra1",
+                "Extra2"
+            ]
         }
     },
     "axes": {

--- a/engine/samples/input/assets/sample.bind
+++ b/engine/samples/input/assets/sample.bind
@@ -6,26 +6,30 @@
             ],
             "gamepad": [
                 "RBumper"
-            ]
+            ],
+            "mouse": []
         },
         "x-or-z": {
             "keys": [
                 "x",
                 "z"
             ],
-            "gamepad": []
+            "gamepad": [],
+            "mouse": []
         },
         "shift-space": {
             "keys": [
                 "S-Space"
             ],
-            "gamepad": []
+            "gamepad": [],
+            "mouse": []
         },
         "ctrl-shift-space": {
             "keys": [
                 "C-S-Space"
             ],
-            "gamepad": []
+            "gamepad": [],
+            "mouse": []
         }
     },
     "axes": {

--- a/engine/samples/input/assets/sample.bind
+++ b/engine/samples/input/assets/sample.bind
@@ -7,9 +7,7 @@
             "gamepad": [
                 "RBumper"
             ],
-            "mouse": [
-                "Left"
-            ]
+            "mouse": []
         },
         "x-or-z": {
             "keys": [

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -136,6 +136,35 @@ static void showcaseUnbound(const Window& window, bool& explained)
 }
 /// [Showcase Unbound]
 
+/// [Showcase Mouse Buttons]
+static void showcaseMouseButtons(const Input& input, bool& explained)
+{
+    if (!explained)
+    {
+        CUBOS_WARN("This showcase will print the name of a mouse button when it is pressed. Press Enter to advance to "
+                   "the next showcase.");
+        explained = true;
+    }
+
+    if (input.pressed("left-mb"))
+    {
+        CUBOS_INFO("Left");
+    }
+    if (input.pressed("right-mb"))
+    {
+        CUBOS_INFO("Right");
+    }
+    if (input.pressed("middle-mb"))
+    {
+        CUBOS_INFO("Middle");
+    }
+    if (input.pressed("extra-mb"))
+    {
+        CUBOS_INFO("Extra1 or Extra2");
+    }
+}
+/// [Showcase Mouse Buttons]
+
 /// [Checking Type of Press]
 static void update(Read<Input> input, Read<Window> window, Write<State> state, Write<ShouldQuit> shouldQuit)
 {
@@ -168,6 +197,8 @@ static void update(Read<Input> input, Read<Window> window, Write<State> state, W
         return showcaseModifierAxis(*input, state->explained);
     case 6:
         return showcaseUnbound(*window, state->explained);
+    case 7:
+        return showcaseMouseButtons(*input, state->explained);
     default:
         shouldQuit->value = true;
     }

--- a/engine/samples/input/page.md
+++ b/engine/samples/input/page.md
@@ -81,3 +81,7 @@ Modifier keys work with axis too.
 
 If, for any reason, you want to read an input that is not defined in the Bindings asset, you cannot use the Input plugin for it.
 Instead, you will have to call the @ref cubos::core::io::Window::pressed "Window::pressed" function.
+
+@snippet input/main.cpp Showcase Mouse Buttons
+
+Reading mouse buttons is also supported, just bind them to an action, and then call @ref cubos::engine::Input::pressed "Input::pressed" as usual. To check which strings map to which buttons, you check the `mouseButtonToString` function implementation on [this file](https://github.com/GameDevTecnico/cubos/blob/main/core/src/cubos/core/io/window.cpp).

--- a/engine/src/cubos/engine/input/action.cpp
+++ b/engine/src/cubos/engine/input/action.cpp
@@ -1,6 +1,7 @@
 #include <cubos/engine/input/action.hpp>
 
 using cubos::core::io::GamepadButton;
+using cubos::core::io::MouseButton;
 using cubos::core::io::Key;
 using cubos::core::io::Modifiers;
 using namespace cubos::engine;
@@ -15,6 +16,11 @@ const std::vector<GamepadButton>& InputAction::gamepadButtons() const
     return mGamepadButtons;
 }
 
+const std::vector<MouseButton>& InputAction::mouseButtons() const
+{
+    return mMouseButtons;
+}
+
 std::vector<std::pair<Key, Modifiers>>& InputAction::keys()
 {
     return mKeys;
@@ -23,6 +29,11 @@ std::vector<std::pair<Key, Modifiers>>& InputAction::keys()
 std::vector<GamepadButton>& InputAction::gamepadButtons()
 {
     return mGamepadButtons;
+}
+
+std::vector<MouseButton>& InputAction::mouseButtons()
+{
+    return mMouseButtons;
 }
 
 bool InputAction::pressed() const

--- a/engine/src/cubos/engine/input/action.cpp
+++ b/engine/src/cubos/engine/input/action.cpp
@@ -1,9 +1,9 @@
 #include <cubos/engine/input/action.hpp>
 
 using cubos::core::io::GamepadButton;
-using cubos::core::io::MouseButton;
 using cubos::core::io::Key;
 using cubos::core::io::Modifiers;
+using cubos::core::io::MouseButton;
 using namespace cubos::engine;
 
 const std::vector<std::pair<Key, Modifiers>>& InputAction::keys() const

--- a/engine/src/cubos/engine/input/bindings.cpp
+++ b/engine/src/cubos/engine/input/bindings.cpp
@@ -48,6 +48,7 @@ void cubos::core::data::old::serialize<InputBindings>(Serializer& ser, const Inp
         ser.beginObject(nullptr);
         ser.write(action.keys(), "keys");
         ser.write(action.gamepadButtons(), "gamepad");
+        ser.write(action.mouseButtons(), "mouse");
         ser.endObject();
     }
     ser.endDictionary();
@@ -78,6 +79,7 @@ void cubos::core::data::old::deserialize<InputBindings>(Deserializer& des, Input
         des.beginObject();
         des.read(obj.actions()[action].keys());
         des.read(obj.actions()[action].gamepadButtons());
+        des.read(obj.actions()[action].mouseButtons());
         des.endObject();
     }
     des.endDictionary();

--- a/engine/src/cubos/engine/input/input.cpp
+++ b/engine/src/cubos/engine/input/input.cpp
@@ -5,8 +5,8 @@
 using cubos::core::io::GamepadButton;
 using cubos::core::io::GamepadConnectionEvent;
 using cubos::core::io::GamepadState;
-using cubos::core::io::MouseButton;
 using cubos::core::io::KeyEvent;
+using cubos::core::io::MouseButton;
 using cubos::core::io::MouseButtonEvent;
 using cubos::core::io::Window;
 using namespace cubos::engine;
@@ -219,8 +219,8 @@ void Input::handleActions(const Window& window, const std::vector<BindingIndex>&
     for (const auto& boundAction : boundActions)
     {
         auto& action = mPlayerBindings[boundAction.player].actions()[boundAction.name];
-        auto pressed = anyPressed(window, action.keys()) || anyPressed(boundAction.player, action.gamepadButtons())
-                        || anyPressed(action.mouseButtons());
+        auto pressed = anyPressed(window, action.keys()) || anyPressed(boundAction.player, action.gamepadButtons()) ||
+                       anyPressed(action.mouseButtons());
 
         if (action.pressed() != pressed)
         {


### PR DESCRIPTION
# Description

Adds support for binding mouse buttons to input actions, similar to existing implementation of keyboard/gamepad. Serialization functions are also implemented in order to support adding bindings in an asset.
Adds a new showcase to the input sample to test the bindings.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
