### PR TITLE
Replace `typeid` by reflection on asset bridges

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -40,6 +40,7 @@ set(CUBOS_ENGINE_SOURCE
     "src/cubos/engine/gizmos/renderer.cpp"
 
     "src/cubos/engine/scene/plugin.cpp"
+    "src/cubos/engine/scene/scene.cpp"
     "src/cubos/engine/scene/bridge.cpp"
 
     "src/cubos/engine/voxels/plugin.cpp"

--- a/engine/include/cubos/engine/assets/bridge.hpp
+++ b/engine/include/cubos/engine/assets/bridge.hpp
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <typeindex>
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 #include <cubos/engine/assets/asset.hpp>
 
@@ -30,9 +31,9 @@ namespace cubos::engine
     public:
         /// @brief Constructs a bridge.
         ///
-        /// @param index Type of assets loaded by the bridge.
-        explicit AssetBridge(std::type_index index)
-            : mIndex(index)
+        /// @param type Type of assets loaded by the bridge.
+        explicit AssetBridge(const core::reflection::Type& type)
+            : mType(type)
         {
         }
 
@@ -58,12 +59,12 @@ namespace cubos::engine
 
         /// @brief Gets the type of the assets the bridge loads.
         /// @return Type of the asset.
-        inline std::type_index assetType() const
+        inline const core::reflection::Type& assetType() const
         {
-            return mIndex;
+            return mType;
         }
 
     private:
-        std::type_index mIndex; ///< Type of assets loaded by the bridge
+        const core::reflection::Type& mType; ///< Type of assets loaded by the bridge
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/assets/bridges/binary.hpp
+++ b/engine/include/cubos/engine/assets/bridges/binary.hpp
@@ -7,6 +7,7 @@
 #include <cubos/core/data/old/binary_deserializer.hpp>
 #include <cubos/core/data/old/binary_serializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/assets/bridges/file.hpp>
 
@@ -27,7 +28,7 @@ namespace cubos::engine
         /// @brief Constructs a bridge.
         /// @param littleEndian Whether to use little endian byte order.
         BinaryBridge(bool littleEndian = true)
-            : FileBridge(typeid(T))
+            : FileBridge(core::reflection::reflect<T>())
             , mLittleEndian{littleEndian}
         {
         }

--- a/engine/include/cubos/engine/assets/bridges/file.hpp
+++ b/engine/include/cubos/engine/assets/bridges/file.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cubos/core/memory/stream.hpp>
+#include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/assets/assets.hpp>
 
@@ -23,9 +24,9 @@ namespace cubos::engine
     public:
         /// @brief Constructs a bridge.
         ///
-        /// @param index Type of assets loaded by the bridge.
-        explicit FileBridge(std::type_index index)
-            : AssetBridge(index)
+        /// @param type Type of assets loaded by the bridge.
+        explicit FileBridge(const core::reflection::Type& type)
+            : AssetBridge(type)
         {
         }
 

--- a/engine/include/cubos/engine/assets/bridges/json.hpp
+++ b/engine/include/cubos/engine/assets/bridges/json.hpp
@@ -7,6 +7,7 @@
 #include <cubos/core/data/old/json_deserializer.hpp>
 #include <cubos/core/data/old/json_serializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/assets/bridges/file.hpp>
 
@@ -30,7 +31,7 @@ namespace cubos::engine
         ///
         /// @param indentation Indentation level to use when saving the JSON file.
         JSONBridge(int indentation = 4)
-            : FileBridge(typeid(T))
+            : FileBridge(core::reflection::reflect<T>())
             , mIndentation{indentation}
         {
         }

--- a/engine/include/cubos/engine/input/bindings.hpp
+++ b/engine/include/cubos/engine/input/bindings.hpp
@@ -6,6 +6,8 @@
 
 #include <unordered_map>
 
+#include <cubos/core/reflection/reflect.hpp>
+
 #include <cubos/engine/input/action.hpp>
 #include <cubos/engine/input/axis.hpp>
 
@@ -19,6 +21,8 @@ namespace cubos::engine
     class InputBindings final
     {
     public:
+        CUBOS_REFLECT;
+
         InputBindings() = default;
         ~InputBindings() = default;
 

--- a/engine/include/cubos/engine/scene/bridge.hpp
+++ b/engine/include/cubos/engine/scene/bridge.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cubos/core/reflection/reflect.hpp>
+
 #include <cubos/engine/assets/bridge.hpp>
 #include <cubos/engine/scene/scene.hpp>
 
@@ -49,7 +51,7 @@ namespace cubos::engine
         /// @brief Constructs a bridge.
         ///
         SceneBridge()
-            : AssetBridge(typeid(Scene))
+            : AssetBridge(core::reflection::reflect<Scene>())
         {
         }
 

--- a/engine/include/cubos/engine/scene/scene.hpp
+++ b/engine/include/cubos/engine/scene/scene.hpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include <cubos/core/ecs/blueprint.hpp>
+#include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/assets/asset.hpp>
 
@@ -21,6 +22,8 @@ namespace cubos::engine
     /// @ingroup scene-plugin
     struct Scene
     {
+        CUBOS_REFLECT;
+
         /// @brief Resulting blueprint which contains all the entities of the scene and its
         /// imported scenes. If you want to spawn the scene, use this blueprint.
         core::ecs::Blueprint blueprint;

--- a/engine/samples/assets/bridge/main.cpp
+++ b/engine/samples/assets/bridge/main.cpp
@@ -1,3 +1,6 @@
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
 #include <cubos/engine/assets/bridges/file.hpp>
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/settings/settings.hpp>
@@ -15,7 +18,7 @@ class TextBridge : public FileBridge
 {
 public:
     TextBridge()
-        : FileBridge(typeid(std::string))
+        : FileBridge(cubos::core::reflection::reflect<std::string>())
     {
     }
     /// [TextBridge]

--- a/engine/samples/assets/json/main.cpp
+++ b/engine/samples/assets/json/main.cpp
@@ -1,6 +1,11 @@
 #include <vector>
 
 #include <cubos/core/data/fs/file_system.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/vector.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 #include <cubos/engine/assets/bridges/json.hpp>
 #include <cubos/engine/assets/plugin.hpp>
@@ -12,6 +17,8 @@ using cubos::core::data::old::Serializer;
 using cubos::core::ecs::Read;
 using cubos::core::ecs::Write;
 using cubos::core::memory::Stream;
+using cubos::core::reflection::FieldsTrait;
+using cubos::core::reflection::Type;
 
 using namespace cubos::engine;
 
@@ -19,8 +26,14 @@ using namespace cubos::engine;
 /// A simple serializable type which we will be saving and loading.
 struct Strings
 {
+    CUBOS_REFLECT;
     std::vector<std::string> strings;
 };
+
+CUBOS_REFLECT_IMPL(Strings)
+{
+    return Type::create("Strings").with(FieldsTrait{}.withField("strings", &Strings::strings));
+}
 /// [Asset type]
 
 /// [Serialization definition]

--- a/engine/samples/assets/saving/main.cpp
+++ b/engine/samples/assets/saving/main.cpp
@@ -1,4 +1,8 @@
 #include <cubos/core/data/fs/file_system.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 #include <cubos/engine/assets/bridges/json.hpp>
 #include <cubos/engine/assets/plugin.hpp>
@@ -10,13 +14,22 @@ using cubos::core::data::old::Serializer;
 using cubos::core::ecs::Read;
 using cubos::core::ecs::Write;
 using cubos::core::memory::Stream;
+using cubos::core::reflection::FieldsTrait;
+using cubos::core::reflection::Type;
+
 using namespace cubos::engine;
 
 /// [Asset type]
 struct IntegerAsset
 {
+    CUBOS_REFLECT;
     int value;
 };
+
+CUBOS_REFLECT_IMPL(IntegerAsset)
+{
+    return Type::create("IntegerAsset").with(FieldsTrait{}.withField("value", &IntegerAsset::value));
+}
 /// [Asset type]
 
 template <>

--- a/engine/src/cubos/engine/input/bindings.cpp
+++ b/engine/src/cubos/engine/input/bindings.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/data/old/deserializer.hpp>
 #include <cubos/core/data/old/serializer.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 #include <cubos/engine/input/bindings.hpp>
 
@@ -10,6 +11,11 @@ using cubos::core::io::modifiersToString;
 using cubos::core::io::stringToKey;
 using cubos::core::io::stringToModifiers;
 using namespace cubos::engine;
+
+CUBOS_REFLECT_IMPL(cubos::engine::InputBindings)
+{
+    return core::reflection::Type::create("cubos::engine::InputBindings");
+}
 
 const std::unordered_map<std::string, InputAction>& InputBindings::actions() const
 {

--- a/engine/src/cubos/engine/scene/scene.cpp
+++ b/engine/src/cubos/engine/scene/scene.cpp
@@ -1,0 +1,8 @@
+#include <cubos/core/reflection/type.hpp>
+
+#include <cubos/engine/scene/scene.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::Scene)
+{
+    return core::reflection::Type::create("cubos::engine::Scene");
+}

--- a/tools/tesseratos/src/tesseratos/scene_editor/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/scene_editor/plugin.cpp
@@ -6,6 +6,8 @@
 
 #include <cubos/core/data/old/debug_serializer.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/imgui/plugin.hpp>
@@ -96,7 +98,7 @@ static void checkAssetEventSystem(cubos::core::ecs::EventReader<AssetSelectedEve
 {
     for (const auto& event : reader)
     {
-        if (assets->type(event.asset) == typeid(Scene))
+        if (assets->type(event.asset).is<Scene>())
         {
             CUBOS_INFO("Opening scene {}", Debug(event.asset));
             openScene(event.asset, commands, *assets, *scene);

--- a/tools/tesseratos/src/tesseratos/voxel_palette_editor/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/voxel_palette_editor/plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <cubos/core/data/old/debug_serializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 #include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/renderer/plugin.hpp>
@@ -92,7 +93,7 @@ static void checkAssetEventSystem(EventReader<AssetSelectedEvent> reader, Write<
 {
     for (const auto& event : reader)
     {
-        if (assets->type(event.asset) == typeid(VoxelPalette))
+        if (assets->type(event.asset).is<VoxelPalette>())
         {
             CUBOS_INFO("Opening palette asset {}", Debug(event.asset));
             if (!selectedPalette->asset.isNull() && selectedPalette->modified)


### PR DESCRIPTION
~~Blocked by #799~~ and uses commits from #775

# Description

- Replace `typeid` by reflection on asset bridges
- Fixed tesseratos plugins where asset types are compared
- Fixed assets samples to use this new system

## Checklist

- [X] Compiled and executed all assets samples
