### PR TITLE
Use `Function` for hooks on `Serializer`

### DIFF
--- a/core/samples/data/ser/custom/main.cpp
+++ b/core/samples/data/ser/custom/main.cpp
@@ -28,8 +28,8 @@ using cubos::core::reflection::reflect;
 
 MySerializer::MySerializer()
 {
-    this->hook<int32_t>([](Serializer&, const Type&, const void* value) {
-        Stream::stdOut.print(*static_cast<const int32_t*>(value));
+    this->hook<int32_t>([](const int32_t& value) {
+        Stream::stdOut.print(value);
         return true;
     });
 }

--- a/core/src/cubos/core/data/des/deserializer.cpp
+++ b/core/src/cubos/core/data/des/deserializer.cpp
@@ -28,6 +28,7 @@ void Deserializer::hook(const reflection::Type& type, Hook hook)
     if (auto it = mHooks.find(&type); it != mHooks.end())
     {
         CUBOS_WARN("Hook for type '{}' already exists, overwriting", type.name());
+        mHooks.erase(it);
     }
 
     mHooks.emplace(&type, memory::move(hook));

--- a/core/src/cubos/core/data/ser/debug.cpp
+++ b/core/src/cubos/core/data/ser/debug.cpp
@@ -16,9 +16,7 @@ using cubos::core::reflection::StringConversionTrait;
 using cubos::core::reflection::Type;
 
 #define AUTO_HOOK(type, ...)                                                                                           \
-    this->hook<type>([](Serializer& ser, const Type&, const void* value) {                                             \
-        auto& debug = static_cast<DebugSerializer&>(ser);                                                              \
-        const auto& typed = *static_cast<const type*>(value);                                                          \
+    this->hook<type>([this](const type& value) {                                                                       \
         __VA_ARGS__;                                                                                                   \
         return true;                                                                                                   \
     })
@@ -26,23 +24,23 @@ using cubos::core::reflection::Type;
 DebugSerializer::DebugSerializer(memory::Stream& stream)
     : mStream(stream)
 {
-    AUTO_HOOK(bool, debug.mStream.print(typed ? "true" : "false"));
+    AUTO_HOOK(bool, mStream.print(value ? "true" : "false"));
     AUTO_HOOK(char, {
-        debug.mStream.put('\'');
-        debug.mStream.put(typed);
-        debug.mStream.put('\'');
+        mStream.put('\'');
+        mStream.put(value);
+        mStream.put('\'');
     });
-    AUTO_HOOK(int8_t, debug.mStream.print(typed));
-    AUTO_HOOK(int16_t, debug.mStream.print(typed));
-    AUTO_HOOK(int32_t, debug.mStream.print(typed));
-    AUTO_HOOK(int64_t, debug.mStream.print(typed));
-    AUTO_HOOK(uint8_t, debug.mStream.print(typed));
-    AUTO_HOOK(uint16_t, debug.mStream.print(typed));
-    AUTO_HOOK(uint32_t, debug.mStream.print(typed));
-    AUTO_HOOK(uint64_t, debug.mStream.print(typed));
-    AUTO_HOOK(float, debug.mStream.print(typed));
-    AUTO_HOOK(double, debug.mStream.print(typed));
-    AUTO_HOOK(std::string, debug.mStream.printf("\"{}\"", typed));
+    AUTO_HOOK(int8_t, mStream.print(value));
+    AUTO_HOOK(int16_t, mStream.print(value));
+    AUTO_HOOK(int32_t, mStream.print(value));
+    AUTO_HOOK(int64_t, mStream.print(value));
+    AUTO_HOOK(uint8_t, mStream.print(value));
+    AUTO_HOOK(uint16_t, mStream.print(value));
+    AUTO_HOOK(uint32_t, mStream.print(value));
+    AUTO_HOOK(uint64_t, mStream.print(value));
+    AUTO_HOOK(float, mStream.print(value));
+    AUTO_HOOK(double, mStream.print(value));
+    AUTO_HOOK(std::string, mStream.printf("\"{}\"", value));
 }
 
 void DebugSerializer::pretty(bool pretty)

--- a/core/src/cubos/core/data/ser/serializer.cpp
+++ b/core/src/cubos/core/data/ser/serializer.cpp
@@ -8,7 +8,7 @@ bool Serializer::write(const reflection::Type& type, const void* value)
 {
     if (auto it = mHooks.find(&type); it != mHooks.end())
     {
-        if (!it->second(*this, type, value))
+        if (!it->second(value))
         {
             CUBOS_WARN("Serialization hook for type '{}' failed", type.name());
             return false;
@@ -28,7 +28,8 @@ void Serializer::hook(const reflection::Type& type, Hook hook)
     if (auto it = mHooks.find(&type); it != mHooks.end())
     {
         CUBOS_WARN("Hook for type '{}' already exists, overwriting", type.name());
+        mHooks.erase(it);
     }
 
-    mHooks.insert_or_assign(&type, hook);
+    mHooks.emplace(&type, memory::move(hook));
 }

--- a/core/tests/data/ser/debug.cpp
+++ b/core/tests/data/ser/debug.cpp
@@ -82,9 +82,9 @@ TEST_CASE("data::DebugSerializer")
     glm::tvec3<int> vec3{1, 2, 3};
     AUTO_TEST_SPLIT(decltype(vec3), vec3, "(x: 1, y: 2, z: 3)", "(\n  x: 1,\n  y: 2,\n  z: 3\n)", true);
 
-    ser.hook<std::string>([](Serializer&, const Type&, const void*) { return false; });
-    ser.hook<bool>([](Serializer&, const Type&, const void*) { return false; });
-    ser.hook<int>([](Serializer&, const Type&, const void*) { return false; });
+    ser.hook<std::string>([](auto) { return false; });
+    ser.hook<bool>([](auto) { return false; });
+    ser.hook<int>([](auto) { return false; });
     AUTO_TEST_SPLIT(decltype(map), map, "{?: ?, ?: ?}", "{\n  ?: ?,\n  ?: ?\n}", false);
     AUTO_TEST_SPLIT(decltype(vector), vector, "[?, ?, ?]", "[\n  ?,\n  ?,\n  ?\n]", false);
     AUTO_TEST_SPLIT(decltype(vec3), vec3, "(x: ?, y: ?, z: ?)", "(\n  x: ?,\n  y: ?,\n  z: ?\n)", false);


### PR DESCRIPTION
# Description

Use the new `Function` for hooks in the serializer, just like we do on `Deserializer`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Update samples.
