### PR TITLE
Add `RelationTable`

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -89,6 +89,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/ecs/system/dispatcher.cpp"
     "src/cubos/core/ecs/system/commands.cpp"
     "src/cubos/core/ecs/relation/reflection.cpp"
+    "src/cubos/core/ecs/relation/table.cpp"
     "src/cubos/core/ecs/blueprint.cpp"
     "src/cubos/core/ecs/world.cpp"
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -88,6 +88,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/ecs/system/system.cpp"
     "src/cubos/core/ecs/system/dispatcher.cpp"
     "src/cubos/core/ecs/system/commands.cpp"
+    "src/cubos/core/ecs/relation/reflection.cpp"
     "src/cubos/core/ecs/blueprint.cpp"
     "src/cubos/core/ecs/world.cpp"
 

--- a/core/include/cubos/core/ecs/relation/module.dox
+++ b/core/include/cubos/core/ecs/relation/module.dox
@@ -1,0 +1,9 @@
+/// @dir
+/// @brief @ref core-ecs-relation directory.
+
+namespace cubos::core::ecs
+{
+    /// @defgroup core-ecs-relation Relation
+    /// @ingroup core-ecs
+    /// @brief Relation part of the ECS.
+}

--- a/core/include/cubos/core/ecs/relation/reflection.hpp
+++ b/core/include/cubos/core/ecs/relation/reflection.hpp
@@ -1,0 +1,56 @@
+/// @file
+/// @brief Class @ref cubos::core::ecs::RelationTypeBuilder.
+/// @ingroup core-ecs-relation
+
+#pragma once
+
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+namespace cubos::core::ecs
+{
+    /// @brief Builder for @ref reflection::Type objects which represent relation types.
+    ///
+    /// Used to reduce the amount of boilerplate code required to define a relation type.
+    /// Automatically adds the @ref reflection::ConstructibleTrait and @ref reflection::FieldsTrait.
+    /// The type @p T must be default-constructible, copy-constructible and move-constructible.
+    ///
+    /// @tparam T Relation type.
+    template <typename T>
+    class RelationTypeBuilder
+    {
+    public:
+        /// @brief Constructs.
+        /// @param name Relation type name, including namespace.
+        RelationTypeBuilder(std::string name)
+            : mType(reflection::Type::create(std::move(name)))
+        {
+            mType.with(reflection::ConstructibleTrait::typed<T>().withBasicConstructors().build());
+        }
+
+        /// @brief Adds a field to the relation type.
+        /// @tparam F Field type.
+        /// @param name Field name.
+        /// @param pointer Field pointer.
+        /// @return Builder.
+        template <typename F>
+        RelationTypeBuilder&& withField(std::string name, F T::*pointer) &&
+        {
+            mFields.addField(std::move(name), pointer);
+            return std::move(*this);
+        }
+
+        /// @brief Builds the relation type.
+        /// @return Relation type.
+        reflection::Type& build() &&
+        {
+            mType.with(std::move(mFields));
+            return mType;
+        }
+
+    private:
+        reflection::Type& mType;
+        reflection::FieldsTrait mFields;
+    };
+} // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/relation/table.hpp
+++ b/core/include/cubos/core/ecs/relation/table.hpp
@@ -11,7 +11,26 @@
 
 namespace cubos::core::ecs
 {
-    /// @brief A table which stores relations.
+    /// @brief A table which stores relations. Allows for quick insertion, deletion and iteration.
+    ///
+    /// Internally, the table is stored simply as a vector of relations and their data. Each row in
+    /// this table stores:
+    /// - the 'from' entity index;
+    /// - the 'to' entity index;
+    /// - the previous and next rows with the same 'from' index;
+    /// - the previous and next rows with the same 'to' index;
+    /// - the relation data itself.
+    ///
+    /// To make random accesses more efficient, we also store an hashtable which maps entity index
+    /// pairs to rows. This way, we can quickly check if a relation exists or where it's stored.
+    ///
+    /// Additionally, we store two other hashtables, one which associate 'from' and 'to' indices to
+    /// rows in the table which represent the first and last nodes of linked lists, where each node
+    /// is a row with the same 'from' or 'to' index, depending on the list.
+    ///
+    /// These linked lists are essential to provide fast query times, as instead of having to
+    /// iterate over the entire table and filter for entity, we only need to follow the linked
+    /// list chain.
     class RelationTable final
     {
     public:

--- a/core/include/cubos/core/ecs/relation/table.hpp
+++ b/core/include/cubos/core/ecs/relation/table.hpp
@@ -1,0 +1,223 @@
+/// @file
+/// @brief Class @ref cubos::core::ecs::RelationTable.
+/// @ingroup core-ecs-relation
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <cubos/core/memory/any_vector.hpp>
+
+namespace cubos::core::ecs
+{
+    /// @brief A table which stores relations.
+    class RelationTable final
+    {
+    public:
+        /// @brief Used to iterate over the relations in a table.
+        class Iterator;
+
+        /// @brief Used to view part of a table.
+        class View;
+
+        /// @brief Constructs with the given relation type.
+        /// @note @p relationType must have @ref reflection::ConstructibleTrait and be move
+        /// constructible.
+        /// @param relationType Relation type.
+        RelationTable(const reflection::Type& relationType);
+
+        /// @brief Adds a relation between the given indices. If it already exists, overwrites it.
+        /// @param from From index.
+        /// @param to To index.
+        /// @param value Relation value to move from.
+        void insert(uint32_t from, uint32_t to, const void* value);
+
+        /// @brief Removes a relation between the given indices. If it didn't exist, does nothing.
+        /// @param from From index.
+        /// @param to To index.
+        /// @return Whether the relation existed.
+        bool erase(uint32_t from, uint32_t to);
+
+        /// @brief Removes all relations from the given index.
+        /// @param from From index.
+        void eraseFrom(uint32_t from);
+
+        /// @brief Removes all relations to the given index.
+        /// @param to To index.
+        void eraseTo(uint32_t to);
+
+        /// @brief Checks whether the given relation exists between the given indices.
+        /// @param from From index.
+        /// @param to To index.
+        /// @return Whether the relation exists.
+        bool contains(uint32_t from, uint32_t to) const;
+
+        /// @brief Gets a pointer to the data of the relation with the given indices.
+        /// @param from From index.
+        /// @param to To index.
+        /// @return Address of the data, or 0 if there's no such relation.
+        uintptr_t at(uint32_t from, uint32_t to) const;
+
+        /// @brief Gets an iterator to the first relation of the table.
+        /// @return Iterator.
+        Iterator begin() const;
+
+        /// @brief Gets an iterator which represents the end of the table.
+        /// @return Iterator.
+        Iterator end() const;
+
+        /// @brief Returns a view of the relations with the given from index.
+        /// @param from From index.
+        /// @return Relation view.
+        View viewFrom(uint32_t from) const;
+
+        /// @brief Returns a view of the relations with the given to index.
+        /// @param to To index.
+        /// @return Relation view.
+        View viewTo(uint32_t to) const;
+
+        /// @brief Returns the number of relations on the table.
+        /// @return Relation count.
+        std::size_t size() const;
+
+    private:
+        /// @brief Link for @ref List.
+        struct Link
+        {
+            uint32_t prev;
+            uint32_t next;
+        };
+
+        /// @brief List of rows with the same from/to index.
+        struct List
+        {
+            uint32_t first;
+            uint32_t last;
+        };
+
+        /// @brief Stores metadata for the relations.
+        struct Row
+        {
+            uint32_t from;
+            uint32_t to;
+            Link fromLink;
+            Link toLink;
+        };
+
+        memory::AnyVector mRelations;
+        std::vector<Row> mRows;
+        std::unordered_map<uint32_t, List> mFromRows;
+        std::unordered_map<uint32_t, List> mToRows;
+        std::unordered_map<uint64_t, uint32_t> mPairRows;
+    };
+
+    class RelationTable::Iterator final
+    {
+    public:
+        /// @brief Output structure for the iterator.
+        struct Output
+        {
+            uint32_t from;   ///< From index.
+            uint32_t to;     ///< To index.
+            uintptr_t value; ///< Address of the relation.
+        };
+
+        /// @brief Constructs.
+        /// @param table Table.
+        /// @param row Row.
+        Iterator(const RelationTable& table, uint32_t row);
+
+        /// @brief Copy constructs.
+        /// @param other Other iterator.
+        Iterator(const Iterator& other) = default;
+
+        /// @brief Compares two iterators.
+        /// @param other Other iterator.
+        /// @return Whether the iterators point to the same relation.
+        bool operator==(const Iterator& other) const;
+
+        /// @brief Accesses the relation referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Output.
+        const Output& operator*() const;
+
+        /// @brief Accesses the relation referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Output.
+        const Output* operator->() const;
+
+        /// @brief Advances the iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Reference to this.
+        Iterator& operator++();
+
+    private:
+        RelationTable& mTable;
+        uint32_t mRow;
+        mutable Output mOutput;
+    };
+
+    class RelationTable::View final
+    {
+    public:
+        /// @brief Used to iterate over the relations in a view.
+        class Iterator;
+
+        /// @brief Gets an iterator to the first relation of the view.
+        /// @return Iterator.
+        Iterator begin() const;
+
+        /// @brief Gets an iterator which represents the end of the view.
+        /// @return Iterator.
+        Iterator end() const;
+    };
+
+    class RelationTable::View::Iterator final
+    {
+    public:
+        /// @brief Output structure for the iterator.
+        struct Output
+        {
+            uint32_t from;   ///< From index.
+            uint32_t to;     ///< To index.
+            uintptr_t value; ///< Address of the relation.
+        };
+
+        /// @brief Constructs.
+        /// @param table Table.
+        /// @param row Row.
+        /// @param isFrom Are we iterating over the same from index? If false, iterates over to.
+        Iterator(const RelationTable& table, uint32_t row, bool isFrom);
+
+        /// @brief Copy constructs.
+        /// @param other Other iterator.
+        Iterator(const Iterator& other) = default;
+
+        /// @brief Compares two iterators.
+        /// @param other Other iterator.
+        /// @return Whether the iterators point to the same relation.
+        bool operator==(const Iterator& other) const;
+
+        /// @brief Accesses the relation referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Output.
+        const Output& operator*() const;
+
+        /// @brief Accesses the relation referenced by this iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Output.
+        const Output* operator->() const;
+
+        /// @brief Advances the iterator.
+        /// @note Aborts if out of bounds.
+        /// @return Reference to this.
+        Iterator& operator++();
+
+    private:
+        RelationTable& mTable;
+        uint32_t mRow;
+        bool mIsFrom;
+        mutable Output mOutput;
+    };
+} // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/relation/table.hpp
+++ b/core/include/cubos/core/ecs/relation/table.hpp
@@ -31,7 +31,8 @@ namespace cubos::core::ecs
         /// @param from From index.
         /// @param to To index.
         /// @param value Relation value to move from.
-        void insert(uint32_t from, uint32_t to, const void* value);
+        /// @return Whether the relation already existed.
+        bool insert(uint32_t from, uint32_t to, void* value);
 
         /// @brief Removes a relation between the given indices. If it didn't exist, does nothing.
         /// @param from From index.
@@ -41,11 +42,13 @@ namespace cubos::core::ecs
 
         /// @brief Removes all relations from the given index.
         /// @param from From index.
-        void eraseFrom(uint32_t from);
+        /// @return How many relations were erased.
+        std::size_t eraseFrom(uint32_t from);
 
         /// @brief Removes all relations to the given index.
         /// @param to To index.
-        void eraseTo(uint32_t to);
+        /// @return How many relations were erased.
+        std::size_t eraseTo(uint32_t to);
 
         /// @brief Checks whether the given relation exists between the given indices.
         /// @param from From index.
@@ -105,7 +108,20 @@ namespace cubos::core::ecs
             Link toLink;
         };
 
+        /// @brief Appends the row with the given index to the end of both linked lists.
+        /// @param index Row index.
+        void appendLink(uint32_t index);
+
+        /// @brief Removes references to the row with the given index in both linked lists.
+        /// @param index Row index.
+        void eraseLink(uint32_t index);
+
+        /// @brief Updates the links of the given row such that its neighbors point to it correctly.
+        /// @param index Row index.
+        void updateLink(uint32_t index);
+
         memory::AnyVector mRelations;
+        const reflection::ConstructibleTrait* mConstructibleTrait{nullptr};
         std::vector<Row> mRows;
         std::unordered_map<uint32_t, List> mFromRows;
         std::unordered_map<uint32_t, List> mToRows;
@@ -153,7 +169,7 @@ namespace cubos::core::ecs
         Iterator& operator++();
 
     private:
-        RelationTable& mTable;
+        const RelationTable& mTable;
         uint32_t mRow;
         mutable Output mOutput;
     };
@@ -164,6 +180,11 @@ namespace cubos::core::ecs
         /// @brief Used to iterate over the relations in a view.
         class Iterator;
 
+        /// @brief Constructs.
+        /// @param index Index being iterated over.
+        /// @param isFrom Is the index a from index? If false, its a to index.
+        View(const RelationTable& table, uint32_t index, bool isFrom);
+
         /// @brief Gets an iterator to the first relation of the view.
         /// @return Iterator.
         Iterator begin() const;
@@ -171,6 +192,11 @@ namespace cubos::core::ecs
         /// @brief Gets an iterator which represents the end of the view.
         /// @return Iterator.
         Iterator end() const;
+
+    private:
+        const RelationTable& mTable;
+        uint32_t mIndex;
+        bool mIsFrom;
     };
 
     class RelationTable::View::Iterator final
@@ -215,7 +241,7 @@ namespace cubos::core::ecs
         Iterator& operator++();
 
     private:
-        RelationTable& mTable;
+        const RelationTable& mTable;
         uint32_t mRow;
         bool mIsFrom;
         mutable Output mOutput;

--- a/core/src/cubos/core/ecs/relation/reflection.cpp
+++ b/core/src/cubos/core/ecs/relation/reflection.cpp
@@ -1,0 +1,1 @@
+#include <cubos/core/ecs/relation/reflection.hpp>

--- a/core/src/cubos/core/ecs/relation/table.cpp
+++ b/core/src/cubos/core/ecs/relation/table.cpp
@@ -1,1 +1,402 @@
 #include <cubos/core/ecs/relation/table.hpp>
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::ecs::RelationTable;
+
+/// @brief Creates a single integer which uniquely identifies the relation with the given indices.
+/// @param from From index.
+/// @param to To index.
+/// @return Identifier.
+static uint64_t pairId(uint32_t from, uint32_t to)
+{
+    return static_cast<uint64_t>(from) | (static_cast<uint64_t>(to) << 32);
+}
+
+RelationTable::RelationTable(const reflection::Type& relationType)
+    : mRelations{relationType}
+{
+    mConstructibleTrait = &relationType.get<reflection::ConstructibleTrait>();
+}
+
+std::size_t RelationTable::size() const
+{
+    return mRelations.size();
+}
+
+bool RelationTable::insert(uint32_t from, uint32_t to, void* value)
+{
+    // Single integer which contains both indices.
+    auto pair = pairId(from, to);
+    if (auto it = mPairRows.find(pair); it != mPairRows.end())
+    {
+        // Row already exists, simply overwrite it.
+        mConstructibleTrait->destruct(mRelations.at(it->second));
+        mConstructibleTrait->moveConstruct(mRelations.at(it->second), value);
+        return true;
+    }
+
+    // Push a new row.
+    auto index = static_cast<uint32_t>(mRows.size());
+    mRows.emplace_back(Row{
+        .from = from,
+        .to = to,
+        .fromLink = Link{.prev = UINT32_MAX, .next = UINT32_MAX},
+        .toLink = Link{.prev = UINT32_MAX, .next = UINT32_MAX},
+    });
+
+    // Push the actual data.
+    mRelations.pushMove(value);
+
+    // Update the indices.
+    mPairRows.emplace(pair, index);
+    this->appendLink(index);
+    return false;
+}
+
+bool RelationTable::erase(uint32_t from, uint32_t to)
+{
+    // Single integer which contains both indices.
+    auto it = mPairRows.find(pairId(from, to));
+    if (it == mPairRows.end())
+    {
+        return false;
+    }
+
+    // Update the indices.
+    auto index = it->second;
+    mPairRows.erase(it);
+    this->eraseLink(index);
+
+    // If this wasn't the last row, we first swap it with the last one.
+    auto last = static_cast<uint32_t>(mRows.size()) - 1;
+    if (index != last)
+    {
+        // Swap the erased row with the last row.
+        mRows[index] = mRows[last];
+        mPairRows[pairId(mRows[index].from, mRows[index].to)] = index;
+        this->updateLink(index); // Update indices.
+
+        // Do the same for the relation's data.
+        mConstructibleTrait->destruct(mRelations.at(index)); // Destruct the erased relation.
+        mConstructibleTrait->moveConstruct(mRelations.at(index),
+                                           mRelations.at(last)); // Move last into the erased slot.
+    }
+
+    // Pop last relation.
+    mRows.pop_back();
+    mRelations.pop();
+    return true;
+}
+
+std::size_t RelationTable::eraseFrom(uint32_t from)
+{
+    std::size_t count = 0;
+
+    while (mFromRows.contains(from))
+    {
+        auto& row = mRows[mFromRows.at(from).first];
+        this->erase(row.from, row.to);
+        count += 1;
+    }
+
+    return count;
+}
+
+std::size_t RelationTable::eraseTo(uint32_t to)
+{
+    std::size_t count = 0;
+
+    while (mToRows.contains(to))
+    {
+        auto& row = mRows[mToRows.at(to).first];
+        this->erase(row.from, row.to);
+        count += 1;
+    }
+
+    return count;
+}
+
+bool RelationTable::contains(uint32_t from, uint32_t to) const
+{
+    return mPairRows.contains(pairId(from, to));
+}
+
+uintptr_t RelationTable::at(uint32_t from, uint32_t to) const
+{
+    if (auto it = mPairRows.find(pairId(from, to)); it != mPairRows.end())
+    {
+        return reinterpret_cast<uintptr_t>(mRelations.at(it->second));
+    }
+
+    return 0;
+}
+
+auto RelationTable::begin() const -> Iterator
+{
+    return Iterator{*this, 0};
+}
+
+auto RelationTable::end() const -> Iterator
+{
+    return Iterator{*this, static_cast<uint32_t>(mRows.size())};
+}
+
+auto RelationTable::viewFrom(uint32_t from) const -> View
+{
+    return View{*this, from, true};
+}
+
+auto RelationTable::viewTo(uint32_t to) const -> View
+{
+    return View{*this, to, false};
+}
+
+void RelationTable::appendLink(uint32_t index)
+{
+    auto& row = mRows[index];
+
+    if (auto it = mFromRows.find(row.from); it != mFromRows.end())
+    {
+        // Append the row to the end of the existing list.
+        row.fromLink.prev = it->second.last;
+        mRows[it->second.last].fromLink.next = index;
+        it->second.last = index;
+    }
+    else
+    {
+        // There weren't any relations with the same from index before, we must initialize the list.
+        mFromRows.emplace(row.from, List{.first = index, .last = index});
+    }
+
+    if (auto it = mToRows.find(row.to); it != mToRows.end())
+    {
+        // Append the row to the end of the existing list.
+        row.toLink.prev = it->second.last;
+        mRows[it->second.last].toLink.next = index;
+        it->second.last = index;
+    }
+    else
+    {
+        // There weren't any relations with the same from index before, we must initialize the list.
+        mToRows.emplace(row.to, List{.first = index, .last = index});
+    }
+}
+
+void RelationTable::eraseLink(uint32_t index)
+{
+    auto& row = mRows[index];
+
+    // Handle 'from' links
+
+    if (row.fromLink.prev == UINT32_MAX)
+    {
+        // If we're the first, update the first index to be our next.
+        mFromRows[row.from].first = row.fromLink.next;
+    }
+    else
+    {
+        // Set the next index of the previous to our next.
+        mRows[row.fromLink.prev].fromLink.next = row.fromLink.next;
+    }
+
+    if (row.fromLink.next == UINT32_MAX)
+    {
+        // If we're the last, update the last index to be our previous.
+        mFromRows[row.from].last = row.fromLink.prev;
+    }
+    else
+    {
+        // Set the previous index of the next to our previous.
+        mRows[row.fromLink.next].fromLink.prev = row.fromLink.prev;
+    }
+
+    if (mFromRows[row.from].first == UINT32_MAX)
+    {
+        // There aren't any more relations with this from index.
+        mFromRows.erase(row.from);
+    }
+
+    // Handle 'to' links
+
+    if (row.toLink.prev == UINT32_MAX)
+    {
+        // If we're the first, update the first index to be our next.
+        mToRows[row.to].first = row.toLink.next;
+    }
+    else
+    {
+        // Set the next index of the previous to our next.
+        mRows[row.toLink.prev].toLink.next = row.toLink.next;
+    }
+
+    if (row.toLink.next == UINT32_MAX)
+    {
+        // If we're the last, update the last index to be our previous.
+        mToRows[row.to].last = row.toLink.prev;
+    }
+    else
+    {
+        // Set the previous index of the next to our previous.
+        mRows[row.toLink.next].toLink.prev = row.toLink.prev;
+    }
+
+    if (mToRows[row.to].first == UINT32_MAX)
+    {
+        // There aren't any more relations with this from index.
+        mToRows.erase(row.to);
+    }
+}
+
+void RelationTable::updateLink(uint32_t index)
+{
+    auto& row = mRows[index];
+
+    // Handle 'from' links
+
+    if (row.fromLink.prev == UINT32_MAX)
+    {
+        // If we're the first, we must update the list.
+        mFromRows[row.from].first = index;
+    }
+    else
+    {
+        // We must update our previous link.
+        mRows[row.fromLink.prev].fromLink.next = index;
+    }
+
+    if (row.fromLink.next == UINT32_MAX)
+    {
+        // If we're the last, we must update the list.
+        mFromRows[row.from].last = index;
+    }
+    else
+    {
+        // We must update our next link.
+        mRows[row.fromLink.next].fromLink.prev = index;
+    }
+
+    // Handle 'to' links
+
+    if (row.toLink.prev == UINT32_MAX)
+    {
+        // If we're the first, we must update the list.
+        mToRows[row.to].first = index;
+    }
+    else
+    {
+        // We must update our previous link.
+        mRows[row.toLink.prev].toLink.next = index;
+    }
+
+    if (row.toLink.next == UINT32_MAX)
+    {
+        // If we're the last, we must update the list.
+        mToRows[row.to].last = index;
+    }
+    else
+    {
+        // We must update our next link.
+        mRows[row.toLink.next].toLink.prev = index;
+    }
+}
+
+RelationTable::Iterator::Iterator(const RelationTable& table, uint32_t row)
+    : mTable{table}
+    , mRow{row}
+{
+}
+
+bool RelationTable::Iterator::operator==(const Iterator& other) const
+{
+    return &mTable == &other.mTable && mRow == other.mRow;
+}
+
+auto RelationTable::Iterator::operator*() const -> const Output&
+{
+    CUBOS_ASSERT(static_cast<std::size_t>(mRow) < mTable.mRows.size(), "Iterator out of bounds");
+    mOutput.from = mTable.mRows[mRow].from;
+    mOutput.to = mTable.mRows[mRow].to;
+    mOutput.value = reinterpret_cast<uintptr_t>(mTable.mRelations.at(mRow));
+    return mOutput;
+}
+
+auto RelationTable::Iterator::operator->() const -> const Output*
+{
+    return &this->operator*();
+}
+
+auto RelationTable::Iterator::operator++() -> Iterator&
+{
+    CUBOS_ASSERT(static_cast<std::size_t>(mRow) < mTable.mRows.size(), "Iterator out of bounds");
+    ++mRow;
+    return *this;
+}
+
+RelationTable::View::View(const RelationTable& table, uint32_t index, bool isFrom)
+    : mTable{table}
+    , mIndex{index}
+    , mIsFrom{isFrom}
+{
+}
+
+auto RelationTable::View::begin() const -> Iterator
+{
+    auto row = UINT32_MAX;
+
+    if (mIsFrom)
+    {
+        if (auto it = mTable.mFromRows.find(mIndex); it != mTable.mFromRows.end())
+        {
+            row = it->second.first;
+        }
+    }
+    else
+    {
+        if (auto it = mTable.mToRows.find(mIndex); it != mTable.mToRows.end())
+        {
+            row = it->second.first;
+        }
+    }
+
+    return Iterator{mTable, row, mIsFrom};
+}
+
+auto RelationTable::View::end() const -> Iterator
+{
+    return Iterator{mTable, UINT32_MAX, mIsFrom};
+}
+
+RelationTable::View::Iterator::Iterator(const RelationTable& table, uint32_t row, bool isFrom)
+    : mTable{table}
+    , mRow{row}
+    , mIsFrom{isFrom}
+{
+}
+
+bool RelationTable::View::Iterator::operator==(const Iterator& other) const
+{
+    return &mTable == &other.mTable && mRow == other.mRow && mIsFrom == other.mIsFrom;
+}
+
+auto RelationTable::View::Iterator::operator*() const -> const Output&
+{
+    CUBOS_ASSERT(static_cast<std::size_t>(mRow) < mTable.mRows.size(), "Iterator out of bounds");
+    mOutput.from = mTable.mRows[mRow].from;
+    mOutput.to = mTable.mRows[mRow].to;
+    mOutput.value = reinterpret_cast<uintptr_t>(mTable.mRelations.at(mRow));
+    return mOutput;
+}
+
+auto RelationTable::View::Iterator::operator->() const -> const Output*
+{
+    return &this->operator*();
+}
+
+auto RelationTable::View::Iterator::operator++() -> Iterator&
+{
+    CUBOS_ASSERT(static_cast<std::size_t>(mRow) < mTable.mRows.size(), "Iterator out of bounds");
+    mRow = mIsFrom ? mTable.mRows[mRow].fromLink.next : mTable.mRows[mRow].toLink.next;
+    return *this;
+}

--- a/core/src/cubos/core/ecs/relation/table.cpp
+++ b/core/src/cubos/core/ecs/relation/table.cpp
@@ -1,0 +1,1 @@
+#include <cubos/core/ecs/relation/table.hpp>

--- a/core/src/cubos/core/memory/any_vector.cpp
+++ b/core/src/cubos/core/memory/any_vector.cpp
@@ -11,6 +11,7 @@ using cubos::core::reflection::Type;
 
 AnyVector::~AnyVector()
 {
+    this->clear();
     operator delete(mData, static_cast<std::align_val_t>(mConstructibleTrait->alignment()));
 }
 

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(
     ecs/commands.cpp
     ecs/system.cpp
     ecs/dispatcher.cpp
+    ecs/relation/utils.cpp
+    ecs/relation/table.cpp
 
     geom/box.cpp
     geom/capsule.cpp

--- a/core/tests/ecs/relation/table.cpp
+++ b/core/tests/ecs/relation/table.cpp
@@ -1,0 +1,270 @@
+#include <algorithm>
+#include <map>
+#include <set>
+
+#include <doctest/doctest.h>
+
+#include <cubos/core/ecs/relation/table.hpp>
+
+#include "utils.hpp"
+
+using cubos::core::ecs::RelationTable;
+using cubos::core::reflection::reflect;
+
+template <typename V>
+static std::map<std::pair<uint32_t, uint32_t>, uintptr_t> collectRelations(const V& view)
+{
+    std::map<std::pair<uint32_t, uint32_t>, uintptr_t> map{};
+    for (const auto& [from, to, value] : view)
+    {
+        auto pair = std::make_pair(from, to);
+        REQUIRE_FALSE(map.contains(pair));
+        map.emplace(pair, value);
+    }
+    return map;
+}
+
+TEST_CASE("ecs::RelationTable")
+{
+    SUBCASE("zero-sized relation type")
+    {
+        EmptyRelation empty{}; // Doesn't store anything, thus can be reused.
+        RelationTable table{reflect<EmptyRelation>()};
+        REQUIRE(table.size() == 0);
+
+        REQUIRE_FALSE(table.insert(0, 1, &empty));
+        REQUIRE(table.size() == 1);
+        REQUIRE_FALSE(table.insert(1, 0, &empty));
+        REQUIRE(table.size() == 2);
+        REQUIRE(table.insert(0, 1, &empty)); // Overwrites existing relation
+        REQUIRE(table.size() == 2);
+        REQUIRE_FALSE(table.insert(0, 2, &empty));
+        REQUIRE(table.size() == 3);
+        REQUIRE_FALSE(table.insert(0, 0, &empty));
+        REQUIRE(table.size() == 4);
+
+        REQUIRE(table.contains(0, 1));
+        REQUIRE(table.contains(1, 0));
+        REQUIRE(table.contains(0, 2));
+        REQUIRE(table.contains(0, 0));
+        REQUIRE_FALSE(table.contains(2, 0));
+        REQUIRE_FALSE(table.contains(1, 1));
+
+        REQUIRE(table.at(0, 0) != 0);
+        REQUIRE(table.at(2, 0) == 0);
+
+        REQUIRE(table.erase(0, 0));
+        REQUIRE_FALSE(table.contains(0, 0));
+        REQUIRE(table.size() == 3);
+        REQUIRE_FALSE(table.erase(0, 0));
+        REQUIRE_FALSE(table.erase(2, 0));
+
+        auto map = collectRelations(table);
+        CHECK(map.size() == 3);
+        CHECK(map.contains({0, 1}));
+        CHECK(map.contains({0, 2}));
+        CHECK(map.contains({1, 0}));
+
+        map = collectRelations(table.viewFrom(0));
+        CHECK(map.size() == 2);
+        CHECK(map.contains({0, 1}));
+        CHECK(map.contains({0, 2}));
+
+        map = collectRelations(table.viewFrom(1));
+        CHECK(map.size() == 1);
+        CHECK(map.contains({1, 0}));
+
+        map = collectRelations(table.viewFrom(2));
+        CHECK(map.empty());
+
+        map = collectRelations(table.viewTo(1));
+        CHECK(map.size() == 1);
+        CHECK(map.contains({0, 1}));
+
+        map = collectRelations(table.viewTo(3));
+        CHECK(map.empty());
+    }
+
+    SUBCASE("relation with destructor detection")
+    {
+        bool flag1 = false;
+        bool flag2 = false;
+        bool flag3 = false;
+
+        DetectDestructorRelation detector1{{&flag1}};
+        DetectDestructorRelation detector2{{&flag2}};
+        DetectDestructorRelation detector3{{&flag3}};
+
+        {
+            RelationTable table{reflect<DetectDestructorRelation>()};
+            REQUIRE(table.size() == 0);
+
+            table.insert(1000, 2000, &detector1);
+            table.insert(2000, 4000, &detector2);
+            table.insert(4000, 8000, &detector3);
+
+            REQUIRE_FALSE(flag1);
+            REQUIRE_FALSE(flag2);
+            REQUIRE_FALSE(flag3);
+
+            SUBCASE("no erases")
+            {
+            }
+
+            SUBCASE("erase first")
+            {
+                REQUIRE(table.erase(1000, 2000));
+                REQUIRE(flag1);
+                REQUIRE_FALSE(flag2);
+                REQUIRE_FALSE(flag3);
+            }
+
+            SUBCASE("erase middle")
+            {
+                REQUIRE(table.erase(2000, 4000));
+                REQUIRE_FALSE(flag1);
+                REQUIRE(flag2);
+                REQUIRE_FALSE(flag3);
+            }
+
+            SUBCASE("erase last")
+            {
+                REQUIRE(table.erase(4000, 8000));
+                REQUIRE_FALSE(flag1);
+                REQUIRE_FALSE(flag2);
+                REQUIRE(flag3);
+            }
+
+            SUBCASE("erase all")
+            {
+                REQUIRE(table.erase(1000, 2000));
+                REQUIRE(table.erase(2000, 4000));
+                REQUIRE(table.erase(4000, 8000));
+                REQUIRE(flag1);
+                REQUIRE(flag2);
+                REQUIRE(flag3);
+            }
+        }
+
+        // Table has been deconstructed, all of the relations should also have been deconstructed.
+        CHECK(flag1);
+        CHECK(flag2);
+        CHECK(flag3);
+    }
+
+    SUBCASE("stress")
+    {
+        bool useEraseFromTo = false;
+        PARAMETRIZE_TRUE_OR_FALSE("with eraseFrom and eraseTo", useEraseFromTo);
+
+        constexpr std::size_t ListSize = 100;
+        constexpr std::size_t ListCount = 10;
+
+        RelationTable table{reflect<IntegerRelation>()};
+        REQUIRE(table.size() == 0);
+
+        for (uint32_t i = 1; i <= static_cast<uint32_t>(ListCount); ++i)
+        {
+            for (uint32_t j = 1; j <= static_cast<uint32_t>(ListSize); ++j)
+            {
+                IntegerRelation rel{.value = static_cast<int>(i * ListCount + j)};
+                REQUIRE_FALSE(table.insert(i, j, &rel));
+            }
+        }
+
+        REQUIRE(table.size() == ListSize * ListCount);
+
+        // Remove relations with odd 'to' index.
+        for (uint32_t j = 1; j <= static_cast<uint32_t>(ListSize); j += 2)
+        {
+            if (useEraseFromTo)
+            {
+                REQUIRE(table.eraseTo(j) == ListCount);
+                REQUIRE(table.eraseTo(j) == 0);
+            }
+            else
+            {
+                for (uint32_t i = 1; i <= static_cast<uint32_t>(ListCount); ++i)
+                {
+                    REQUIRE(table.erase(i, j));
+                }
+            }
+        }
+
+        // Check if the number of relations with each 'from' is correct.
+        for (uint32_t i = 1; i <= static_cast<uint32_t>(ListCount); ++i)
+        {
+            auto map = collectRelations(table.viewFrom(i));
+            REQUIRE(map.size() == ListSize / 2); // Removed the odd elements.
+        }
+
+        // Check if the number of relations with each 'to' is correct.
+        for (uint32_t j = 1; j <= static_cast<uint32_t>(ListSize); ++j)
+        {
+            auto map = collectRelations(table.viewTo(j));
+            if (j % 2 == 0)
+            {
+                REQUIRE(map.size() == ListCount);
+            }
+            else
+            {
+                // We deleted all relations with odd 'to's.
+                REQUIRE(map.empty());
+            }
+        }
+
+        // Remove relations with even 'from' index.
+        for (uint32_t i = 2; i <= static_cast<uint32_t>(ListCount); i += 2)
+        {
+            if (useEraseFromTo)
+            {
+                REQUIRE(table.eraseFrom(i) == ListSize / 2);
+                REQUIRE(table.eraseFrom(i) == 0);
+            }
+            else
+            {
+                for (uint32_t j = 1; j <= static_cast<uint32_t>(ListSize); ++j)
+                {
+                    if (j % 2 == 0)
+                    {
+                        REQUIRE(table.erase(i, j));
+                    }
+                    else
+                    {
+                        // Was already deleted due to 'to' being odd.
+                        REQUIRE_FALSE(table.erase(i, j));
+                    }
+                }
+            }
+        }
+
+        // Check if the number of relations with each 'from' is correct.
+        for (uint32_t i = 1; i <= static_cast<uint32_t>(ListCount); ++i)
+        {
+            auto map = collectRelations(table.viewFrom(i));
+            if (i % 2 == 0)
+            {
+                REQUIRE(map.empty()); // Removed the even 'from's.
+            }
+            else
+            {
+                REQUIRE(map.size() == ListSize / 2); // Removed the odd elements.
+            }
+        }
+
+        // Check if the number of relations with each 'to' is correct.
+        for (uint32_t j = 1; j <= static_cast<uint32_t>(ListSize); ++j)
+        {
+            auto map = collectRelations(table.viewTo(j));
+            if (j % 2 == 0)
+            {
+                REQUIRE(map.size() == ListCount / 2); // Removed the even elements.
+            }
+            else
+            {
+                // We deleted all relations with odd 'to's.
+                REQUIRE(map.empty());
+            }
+        }
+    }
+}

--- a/core/tests/ecs/relation/table.cpp
+++ b/core/tests/ecs/relation/table.cpp
@@ -24,7 +24,7 @@ static std::map<std::pair<uint32_t, uint32_t>, uintptr_t> collectRelations(const
     return map;
 }
 
-TEST_CASE("ecs::RelationTable")
+TEST_CASE("ecs::RelationTable") // NOLINT(readability-function-size)
 {
     SUBCASE("zero-sized relation type")
     {

--- a/core/tests/ecs/relation/utils.cpp
+++ b/core/tests/ecs/relation/utils.cpp
@@ -1,0 +1,30 @@
+#include "utils.hpp"
+
+#include <cubos/core/ecs/relation/reflection.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+using cubos::core::reflection::ConstructibleTrait;
+using cubos::core::reflection::FieldsTrait;
+using cubos::core::reflection::Type;
+
+CUBOS_REFLECT_IMPL(EmptyRelation)
+{
+    return cubos::core::ecs::RelationTypeBuilder<EmptyRelation>("EmptyRelation").build();
+}
+
+CUBOS_REFLECT_IMPL(IntegerRelation)
+{
+    return cubos::core::ecs::RelationTypeBuilder<IntegerRelation>("IntegerRelation")
+        .withField("value", &IntegerRelation::value)
+        .build();
+}
+
+CUBOS_REFLECT_IMPL(DetectDestructorRelation)
+{
+    return Type::create("DetectDestructorRelation")
+        .with(ConstructibleTrait::typed<DetectDestructorRelation>()
+                  .withDefaultConstructor()
+                  .withMoveConstructor()
+                  .build())
+        .with(FieldsTrait().withField("detect", &DetectDestructorRelation::detect));
+}

--- a/core/tests/ecs/relation/utils.hpp
+++ b/core/tests/ecs/relation/utils.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include "../utils.hpp"
+
+// A relation which doesn't store anything.
+struct EmptyRelation
+{
+    CUBOS_REFLECT;
+};
+
+// A relation which stores a single integer.
+struct IntegerRelation
+{
+    CUBOS_REFLECT;
+
+    int value;
+};
+
+// A relation which can be used to test if destructors are called correctly.
+struct DetectDestructorRelation
+{
+    CUBOS_REFLECT;
+
+    DetectDestructor detect;
+};


### PR DESCRIPTION
# Description

Adds `RelationTypeBuilder`, used to make relation type reflection easier.
Adds `RelationTable`. For now, this isn't used anywhere but it will be used in future PRs the store relations which are frequently inserted and removed, such as collision pairs. Read the class documentation for details on how its implemented.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
