### PR TITLE
Add a popup for selecting an asset of a given type

### DIFF
--- a/tools/tesseratos/CMakeLists.txt
+++ b/tools/tesseratos/CMakeLists.txt
@@ -6,6 +6,7 @@ option(BUILD_TESSERATOS_SAMPLES "Build tesseratos samples" OFF)
 set(TESSERATOS_SOURCE
     "src/tesseratos/plugin.cpp"
     "src/tesseratos/asset_explorer/plugin.cpp"
+    "src/tesseratos/asset_explorer/popup.cpp"
     "src/tesseratos/settings_inspector/plugin.cpp"
     "src/tesseratos/entity_selector/plugin.cpp"
     "src/tesseratos/world_inspector/plugin.cpp"

--- a/tools/tesseratos/include/tesseratos/asset_explorer/popup.hpp
+++ b/tools/tesseratos/include/tesseratos/asset_explorer/popup.hpp
@@ -1,0 +1,40 @@
+/// @dir
+/// @brief @ref Function @ref tesseratos::assetSelectionPopup.
+
+/// @file
+/// @brief Utility function to show up a popup containing assets with given type.
+/// @ingroup tesseratos-asset-explorer
+
+#pragma once
+
+#include <string>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/assets/asset.hpp>
+#include <cubos/engine/assets/assets.hpp>
+
+namespace tesseratos
+{
+    /// @brief Displays a modal popup to select an asset of a specified type.
+    /// @param title Popup title.
+    /// @param[out] selectedAsset Output asset.
+    /// @param type Asset type to filter by.
+    /// @param assets Assets database to query.
+    /// @return Whether an asset is selected.
+    bool assetSelectionPopup(const std::string& title, cubos::engine::AnyAsset& selectedAsset,
+                             const cubos::core::reflection::Type& type, const cubos::engine::Assets& assets);
+
+    /// @brief Displays a modal popup to select an asset of a specified type.
+    /// @tparam T Asset type to filter by.
+    /// @param title Popup title.
+    /// @param[out] selectedAsset Output asset.
+    /// @param assets Assets database to query.
+    /// @return Whether an asset is selected.
+    template <typename T>
+    bool assetSelectionPopup(const std::string& title, cubos::engine::AnyAsset& selectedAsset,
+                             const cubos::engine::Assets& assets)
+    {
+        return assetSelectionPopup(title, selectedAsset, cubos::core::reflection::reflect<T>(), assets);
+    }
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/asset_explorer/popup.cpp
+++ b/tools/tesseratos/src/tesseratos/asset_explorer/popup.cpp
@@ -1,0 +1,47 @@
+#include <imgui.h>
+
+#include <cubos/core/reflection/type.hpp>
+
+#include <tesseratos/asset_explorer/popup.hpp>
+
+using cubos::core::reflection::Type;
+
+using cubos::engine::AnyAsset;
+using cubos::engine::Asset;
+using cubos::engine::Assets;
+
+using namespace tesseratos;
+
+bool assetSelectionPopup(const std::string& title, AnyAsset& selectedAsset, const Type& type, const Assets& assets)
+{
+    bool returnValue = false;
+
+    ImGui::PushID(title.c_str());
+    ImGui::OpenPopup(title.c_str());
+    if (ImGui::BeginPopupModal(title.c_str(), nullptr))
+    {
+        for (auto const& asset : assets.listAll())
+        {
+            if (&assets.type(asset) == &type)
+            {
+                auto path = assets.readMeta(asset)->get("path");
+                ImGui::Text("- %s", path->c_str());
+                ImGui::SameLine();
+                if (ImGui::Button("Select"))
+                {
+                    selectedAsset = asset;
+                    returnValue = true;
+                }
+            }
+        }
+        ImGui::EndPopup();
+    }
+
+    if (returnValue)
+    {
+        ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::PopID();
+    return returnValue;
+}


### PR DESCRIPTION
~Blocked by #795~

# Description

Add a popup function for selecting an asset of a given type, via `popup.hpp & cpp` . This PR only implements the function, and not the usage in the plugins (like scene editor, etc)

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
