### PR TITLE
Add core aliases to `cubos::engine` namespace.

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -12,6 +12,7 @@ message("# Building engine tests: " ${BUILD_ENGINE_TESTS})
 # Set engine source files
 set(CUBOS_ENGINE_SOURCE
     "src/cubos/engine/cubos.cpp"
+    "src/cubos/engine/prelude.cpp"
 
     "src/cubos/engine/settings/plugin.cpp"
     "src/cubos/engine/settings/settings.cpp"

--- a/engine/include/cubos/engine/cubos.hpp
+++ b/engine/include/cubos/engine/cubos.hpp
@@ -12,6 +12,8 @@
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 
+#include <cubos/engine/prelude.hpp>
+
 namespace cubos::engine
 {
     /// @brief Resource which stores the time since the last iteration of the main loop started.

--- a/engine/include/cubos/engine/prelude.hpp
+++ b/engine/include/cubos/engine/prelude.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cubos/core/ecs/entity/entity.hpp>
+#include <cubos/core/ecs/system/accessors.hpp>
+#include <cubos/core/ecs/system/event/reader.hpp>
+#include <cubos/core/ecs/system/event/writer.hpp>
+#include <cubos/core/ecs/system/query.hpp>
+#include <cubos/core/ecs/system/system.hpp>
+
+namespace cubos::engine
+{
+    /// @copydoc cubos::core::ecs::Query
+    template <typename... ComponentTypes>
+    using Query = core::ecs::Query<ComponentTypes...>;
+
+    /// @copydoc cubos::core::ecs::Entity
+    using Entity = core::ecs::Entity;
+
+    /// @copydoc cubos::core::ecs::Commands
+    using Commands = core::ecs::Commands;
+
+    /// @copydoc cubos::core::ecs::Read
+    template <typename T>
+    using Read = core::ecs::Read<T>;
+
+    /// @copydoc cubos::core::ecs::Write
+    template <typename T>
+    using Write = core::ecs::Write<T>;
+
+    /// @copydoc cubos::core::ecs::OptRead
+    template <typename T>
+    using OptRead = core::ecs::OptRead<T>;
+
+    /// @copydoc cubos::core::ecs::OptWrite
+    template <typename T>
+    using OptWrite = core::ecs::OptWrite<T>;
+
+    /// @copydoc cubos::core::ecs::EventReader
+    template <typename T, unsigned int M = DEFAULT_FILTER_MASK>
+    using EventReader = core::ecs::EventReader<T, M>;
+
+    /// @copydoc cubos::core::ecs::EventWriter
+    template <typename T>
+    using EventWriter = core::ecs::EventWriter<T>;
+} // namespace cubos::engine

--- a/engine/samples/assets/bridge/main.cpp
+++ b/engine/samples/assets/bridge/main.cpp
@@ -5,8 +5,6 @@
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/settings/settings.hpp>
 
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::memory::Stream;
 
 using namespace cubos::engine;

--- a/engine/samples/assets/json/main.cpp
+++ b/engine/samples/assets/json/main.cpp
@@ -14,8 +14,6 @@
 using cubos::core::data::FileSystem;
 using cubos::core::data::old::Deserializer;
 using cubos::core::data::old::Serializer;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::memory::Stream;
 using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::Type;

--- a/engine/samples/assets/saving/main.cpp
+++ b/engine/samples/assets/saving/main.cpp
@@ -11,8 +11,6 @@
 using cubos::core::data::FileSystem;
 using cubos::core::data::old::Deserializer;
 using cubos::core::data::old::Serializer;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::memory::Stream;
 using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::Type;

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -14,11 +14,6 @@
 #include <cubos/engine/settings/settings.hpp>
 #include <cubos/engine/transform/plugin.hpp>
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Entity;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::geom::Box;
 using cubos::core::io::Key;
 using cubos::core::io::Modifiers;

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -3,12 +3,6 @@
 
 #include <cubos/engine/cubos.hpp>
 
-/// [Using type for aesthetic sake]
-using cubos::core::ecs::EventReader;
-using cubos::core::ecs::EventWriter;
-/// [Using type for aesthetic sake]
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 /// [Event struct]

--- a/engine/samples/events/page.md
+++ b/engine/samples/events/page.md
@@ -6,10 +6,6 @@
 
 This example shows how the @ref cubos::core::ecs::EventReader "EventReader" and the @ref cubos::core::ecs::EventWriter "EventWriter" system arguments can be used to communicate from one system to another.
 
-For convinience, we introduce these names in our scope with using-declarations.
-
-@snippet events/main.cpp Using type for aesthetic sake
-
 Firstly, we need to create and register the event we want to emit. Here, our event is a simple struct with a single field, however, you can use any type you want.
 
 @snippet events/main.cpp Event struct

--- a/engine/samples/gizmos/main.cpp
+++ b/engine/samples/gizmos/main.cpp
@@ -4,9 +4,6 @@
 #include <cubos/engine/settings/settings.hpp>
 #include <cubos/engine/transform/plugin.hpp>
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 static void settingsSystem(Write<Settings> settings)

--- a/engine/samples/hello-cubos/main.cpp
+++ b/engine/samples/hello-cubos/main.cpp
@@ -8,12 +8,7 @@
 using cubos::engine::Cubos;
 /// [Include]
 
-/// [Include Entity Stuff]
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
-/// [Include Entity Stuff]
+using namespace cubos::engine;
 
 /// [Component Refl]
 #include <cubos/core/ecs/component/reflection.hpp>

--- a/engine/samples/hello-cubos/page.md
+++ b/engine/samples/hello-cubos/page.md
@@ -56,8 +56,6 @@ Now let's see a bit about entities, components and resources.
 First we are going to need to use a few more things.
 We'll go over what each does as it comes up.
 
-@snippet hello-cubos/main.cpp Include Entity Stuff
-
 Entities have components, so let's create one to give our entities.
 Because of how the engine works, we cannot declare a component on our `main.cpp` file.
 We'll need to create a `components.hpp` for that.

--- a/engine/samples/imgui/main.cpp
+++ b/engine/samples/imgui/main.cpp
@@ -17,8 +17,6 @@
 
 /// [Including plugin headers]
 
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::reflect;
 using cubos::core::reflection::Type;

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -6,8 +6,6 @@
 #include <cubos/engine/settings/settings.hpp>
 
 using cubos::core::data::old::Debug;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::io::Window;
 
 using namespace cubos::engine;

--- a/engine/samples/physics/main.cpp
+++ b/engine/samples/physics/main.cpp
@@ -8,11 +8,6 @@
 #include <cubos/engine/transform/position.hpp>
 #include <cubos/engine/voxels/plugin.hpp>
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 static const Asset<VoxelGrid> CarAsset = AnyAsset("059c16e7-a439-44c7-9bdc-6e069dba0c80");

--- a/engine/samples/renderer/main.cpp
+++ b/engine/samples/renderer/main.cpp
@@ -4,10 +4,6 @@
 #include <cubos/engine/settings/settings.hpp>
 #include <cubos/engine/transform/plugin.hpp>
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Entity;
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 static void settingsSystem(Write<Settings> settings)

--- a/engine/samples/scene/main.cpp
+++ b/engine/samples/scene/main.cpp
@@ -7,11 +7,7 @@
 
 #include "components.hpp"
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Entity;
-using cubos::core::ecs::Read;
 using cubos::core::ecs::World;
-using cubos::core::ecs::Write;
 
 using namespace cubos::engine;
 

--- a/engine/samples/settings/main.cpp
+++ b/engine/samples/settings/main.cpp
@@ -1,8 +1,6 @@
 #include <cubos/engine/cubos.hpp>
 #include <cubos/engine/settings/plugin.hpp>
 
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 /// [System]

--- a/engine/samples/voxels/main.cpp
+++ b/engine/samples/voxels/main.cpp
@@ -4,10 +4,6 @@
 #include <cubos/engine/transform/plugin.hpp>
 #include <cubos/engine/voxels/plugin.hpp>
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 /// [Get handles to assets]

--- a/engine/src/cubos/engine/assets/bridges/file.cpp
+++ b/engine/src/cubos/engine/assets/bridges/file.cpp
@@ -3,9 +3,10 @@
 
 #include <cubos/engine/assets/bridges/file.hpp>
 
-using namespace cubos::engine;
 using cubos::core::data::File;
 using cubos::core::data::FileSystem;
+
+using namespace cubos::engine;
 
 bool FileBridge::load(Assets& assets, const AnyAsset& handle)
 {

--- a/engine/src/cubos/engine/assets/plugin.cpp
+++ b/engine/src/cubos/engine/assets/plugin.cpp
@@ -6,7 +6,6 @@
 
 using cubos::core::data::FileSystem;
 using cubos::core::data::StandardArchive;
-using cubos::core::ecs::Write;
 
 using namespace cubos::engine;
 

--- a/engine/src/cubos/engine/collisions/broad_phase/plugin.cpp
+++ b/engine/src/cubos/engine/collisions/broad_phase/plugin.cpp
@@ -9,10 +9,6 @@
 
 #include "sweep_and_prune.hpp"
 
-using cubos::core::ecs::OptRead;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using namespace cubos::engine;
 
 /// @brief Tracks all new colliders.

--- a/engine/src/cubos/engine/collisions/broad_phase/sweep_and_prune.cpp
+++ b/engine/src/cubos/engine/collisions/broad_phase/sweep_and_prune.cpp
@@ -2,7 +2,6 @@
 
 #include "sweep_and_prune.hpp"
 
-using cubos::core::ecs::Entity;
 using namespace cubos::engine;
 
 void BroadPhaseSweepAndPrune::addEntity(Entity entity)

--- a/engine/src/cubos/engine/collisions/broad_phase/sweep_and_prune.hpp
+++ b/engine/src/cubos/engine/collisions/broad_phase/sweep_and_prune.hpp
@@ -11,6 +11,8 @@
 #include <cubos/core/ecs/entity/hash.hpp>
 #include <cubos/core/ecs/entity/manager.hpp>
 
+#include <cubos/engine/prelude.hpp>
+
 namespace cubos::engine
 {
     /// @brief Resource which stores sweep and prune data.
@@ -20,8 +22,8 @@ namespace cubos::engine
         /// @brief Marker used for sweep and prune.
         struct SweepMarker
         {
-            core::ecs::Entity entity; ///< Entity referenced by the marker.
-            bool isMin;               ///< Whether the marker is a min or max marker.
+            Entity entity; ///< Entity referenced by the marker.
+            bool isMin;    ///< Whether the marker is a min or max marker.
         };
 
         /// @brief List of ordered sweep markers for each axis. Stores the index of the marker in mMarkers.
@@ -31,19 +33,18 @@ namespace cubos::engine
         ///
         /// For each each map, the key is an entity and the value is a list of entities that
         /// overlap with the key. Symmetrical pairs are not stored.
-        std::unordered_map<core::ecs::Entity, std::vector<core::ecs::Entity>, core::ecs::EntityHash>
-            sweepOverlapMaps[3];
+        std::unordered_map<Entity, std::vector<Entity>, cubos::core::ecs::EntityHash> sweepOverlapMaps[3];
 
         /// @brief Set of active entities during sweep for each axis.
-        std::unordered_set<core::ecs::Entity, core::ecs::EntityHash> activePerAxis[3];
+        std::unordered_set<Entity, cubos::core::ecs::EntityHash> activePerAxis[3];
 
         /// @brief Adds an entity to the list of entities tracked by sweep and prune.
         /// @param entity Entity to add.
-        void addEntity(core::ecs::Entity entity);
+        void addEntity(Entity entity);
 
         /// @brief Removes an entity from the list of entities tracked by sweep and prune.
         /// @param entity Entity to remove.
-        void removeEntity(core::ecs::Entity entity);
+        void removeEntity(Entity entity);
 
         /// @brief Clears the list of entities tracked by sweep and prune.
         void clearEntities();

--- a/engine/src/cubos/engine/collisions/plugin.cpp
+++ b/engine/src/cubos/engine/collisions/plugin.cpp
@@ -11,10 +11,6 @@
 #include <cubos/engine/collisions/shapes/capsule.hpp>
 #include <cubos/engine/transform/plugin.hpp>
 
-using cubos::core::ecs::EventWriter;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using namespace cubos::engine;
 
 /// @brief Setups new box colliders.

--- a/engine/src/cubos/engine/gizmos/plugin.cpp
+++ b/engine/src/cubos/engine/gizmos/plugin.cpp
@@ -12,12 +12,6 @@
 
 #include "renderer.hpp"
 
-using cubos::core::ecs::Entity;
-using cubos::core::ecs::EventReader;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
-
 using cubos::core::gl::Texture2D;
 
 using cubos::core::io::MouseButtonEvent;
@@ -26,13 +20,7 @@ using cubos::core::io::ResizeEvent;
 using cubos::core::io::Window;
 using cubos::core::io::WindowEvent;
 
-using cubos::engine::ActiveCameras;
-using cubos::engine::BaseRenderer;
-using cubos::engine::Camera;
-using cubos::engine::DeltaTime;
-using cubos::engine::Gizmos;
-using cubos::engine::GizmosRenderer;
-using cubos::engine::LocalToWorld;
+using namespace cubos::engine;
 
 static void iterateGizmos(std::vector<std::shared_ptr<Gizmos::Gizmo>>& gizmosVector,
                           const std::vector<std::pair<glm::mat4, BaseRenderer::Viewport>>& cameras,

--- a/engine/src/cubos/engine/imgui/plugin.cpp
+++ b/engine/src/cubos/engine/imgui/plugin.cpp
@@ -5,8 +5,6 @@
 
 #include "imgui.hpp"
 
-using cubos::core::ecs::EventReader;
-using cubos::core::ecs::Read;
 using cubos::core::io::Window;
 using cubos::core::io::WindowEvent;
 

--- a/engine/src/cubos/engine/input/plugin.cpp
+++ b/engine/src/cubos/engine/input/plugin.cpp
@@ -5,11 +5,9 @@
 #include <cubos/engine/input/plugin.hpp>
 #include <cubos/engine/window/plugin.hpp>
 
-using cubos::core::ecs::EventReader;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::io::Window;
 using cubos::core::io::WindowEvent;
+
 using namespace cubos::engine;
 
 static void bridge(Write<Assets> assets)

--- a/engine/src/cubos/engine/physics/gravity.cpp
+++ b/engine/src/cubos/engine/physics/gravity.cpp
@@ -4,10 +4,6 @@
 
 #include <cubos/engine/physics/plugins/gravity.hpp>
 
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 static void applyGravitySystem(Query<Write<PhysicsVelocity>, Read<PhysicsMass>> query, Read<Gravity> gravity)

--- a/engine/src/cubos/engine/physics/plugin.cpp
+++ b/engine/src/cubos/engine/physics/plugin.cpp
@@ -8,10 +8,6 @@
 
 #include "physics_accumulator.hpp"
 
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
-
 using namespace cubos::engine;
 
 CUBOS_REFLECT_IMPL(AccumulatedCorrection)

--- a/engine/src/cubos/engine/prelude.cpp
+++ b/engine/src/cubos/engine/prelude.cpp
@@ -1,0 +1,1 @@
+#include <cubos/engine/prelude.hpp>

--- a/engine/src/cubos/engine/renderer/plugin.cpp
+++ b/engine/src/cubos/engine/renderer/plugin.cpp
@@ -14,10 +14,6 @@
 #include <cubos/engine/transform/plugin.hpp>
 #include <cubos/engine/window/plugin.hpp>
 
-using cubos::core::ecs::EventReader;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::io::ResizeEvent;
 using cubos::core::io::Window;
 using cubos::core::io::WindowEvent;

--- a/engine/src/cubos/engine/scene/plugin.cpp
+++ b/engine/src/cubos/engine/scene/plugin.cpp
@@ -2,7 +2,6 @@
 #include <cubos/engine/scene/bridge.hpp>
 #include <cubos/engine/scene/plugin.hpp>
 
-using cubos::core::ecs::Write;
 using namespace cubos::engine;
 
 static void bridge(Write<Assets> assets)

--- a/engine/src/cubos/engine/settings/plugin.cpp
+++ b/engine/src/cubos/engine/settings/plugin.cpp
@@ -8,8 +8,6 @@ using cubos::core::data::File;
 using cubos::core::data::FileSystem;
 using cubos::core::data::StandardArchive;
 using cubos::core::data::old::JSONDeserializer;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 
 using namespace cubos::engine;
 

--- a/engine/src/cubos/engine/transform/plugin.cpp
+++ b/engine/src/cubos/engine/transform/plugin.cpp
@@ -1,9 +1,5 @@
 #include <cubos/engine/transform/plugin.hpp>
 
-using cubos::core::ecs::Commands;
-using cubos::core::ecs::OptRead;
-using cubos::core::ecs::Query;
-using cubos::core::ecs::Write;
 using namespace cubos::engine;
 
 static void autoLocalToWorld(Commands cmds,

--- a/engine/src/cubos/engine/voxels/plugin.cpp
+++ b/engine/src/cubos/engine/voxels/plugin.cpp
@@ -4,7 +4,6 @@
 #include <cubos/engine/voxels/palette.hpp>
 #include <cubos/engine/voxels/plugin.hpp>
 
-using cubos::core::ecs::Write;
 using namespace cubos::engine;
 
 static void bridges(Write<Assets> assets)

--- a/engine/src/cubos/engine/window/plugin.cpp
+++ b/engine/src/cubos/engine/window/plugin.cpp
@@ -1,9 +1,6 @@
 #include <cubos/engine/settings/plugin.hpp>
 #include <cubos/engine/window/plugin.hpp>
 
-using cubos::core::ecs::EventWriter;
-using cubos::core::ecs::Read;
-using cubos::core::ecs::Write;
 using cubos::core::io::openWindow;
 using cubos::core::io::Window;
 using cubos::core::io::WindowEvent;


### PR DESCRIPTION
# Description

- [X] Add core aliases to `cubos::engine` namespace.
- [X] Use them along the plugins

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [ ] ~Ensure test coverage.~
- [ ] ~Write new samples.~
