### PR TITLE
Implement `Logger` and remove `spdlog`/`fmt`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "core/lib/glm"]
 	path = core/lib/glm
 	url = https://github.com/g-truc/glm.git
-[submodule "core/lib/spdlog"]
-	path = core/lib/spdlog
-	url = https://github.com/gabime/spdlog
 [submodule "core/lib/fmt"]
 	path = core/lib/fmt
 	url = https://github.com/fmtlib/fmt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "core/lib/glm"]
 	path = core/lib/glm
 	url = https://github.com/g-truc/glm.git
-[submodule "core/lib/fmt"]
-	path = core/lib/fmt
-	url = https://github.com/fmtlib/fmt.git
 [submodule "core/lib/openal-soft"]
 	path = core/lib/openal-soft
 	url = https://github.com/kcat/openal-soft

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,7 +9,6 @@ endif ()
 option(WITH_OPENAL "With OpenAL?" ON)
 option(GLM_USE_SUBMODULE "Compile GLM from source?" ON)
 option(DOCTEST_USE_SUBMODULE "Compile doctest from source?" ON)
-option(SPDLOG_USE_SUBMODULE "Compile SPDLOG from source?" ON)
 option(FMT_USE_SUBMODULE "Compile FMT from source?" ON)
 
 set(CUBOS_CORE_ECS_MAX_COMPONENTS "63" CACHE STRING "The maximum number of components registered in an ECS world.")
@@ -161,13 +160,6 @@ else ()
     find_package(fmt REQUIRED)
 endif ()
 
-if (SPDLOG_USE_SUBMODULE)
-    add_subdirectory(lib/spdlog SYSTEM)
-else ()
-    set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
-    find_package(spdlog REQUIRED)
-endif ()
-
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 add_subdirectory(lib/json)
 
@@ -178,7 +170,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 target_compile_definitions(cubos-core PUBLIC GLM_FORCE_SILENT_WARNINGS) # Needed for compilation to succeed on MSVC
-target_link_libraries(cubos-core PUBLIC glm::glm spdlog nlohmann_json::nlohmann_json fmt::fmt ${CMAKE_DL_LIBS})
+target_link_libraries(cubos-core PUBLIC glm::glm nlohmann_json::nlohmann_json fmt::fmt ${CMAKE_DL_LIBS})
 target_link_libraries(cubos-core PRIVATE Threads::Threads)
 
 # Add core tests

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,7 +42,9 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/reflection/traits/nullable.cpp"
     "src/cubos/core/reflection/traits/enum.cpp"
     "src/cubos/core/reflection/external/primitives.cpp"
+    "src/cubos/core/reflection/external/cstring.cpp"
     "src/cubos/core/reflection/external/string.cpp"
+    "src/cubos/core/reflection/external/string_view.cpp"
     "src/cubos/core/reflection/external/uuid.cpp"
     "src/cubos/core/reflection/external/glm.cpp"
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,7 +9,6 @@ endif ()
 option(WITH_OPENAL "With OpenAL?" ON)
 option(GLM_USE_SUBMODULE "Compile GLM from source?" ON)
 option(DOCTEST_USE_SUBMODULE "Compile doctest from source?" ON)
-option(FMT_USE_SUBMODULE "Compile FMT from source?" ON)
 
 set(CUBOS_CORE_ECS_MAX_COMPONENTS "63" CACHE STRING "The maximum number of components registered in an ECS world.")
 set(CUBOS_CORE_DISPATCHER_MAX_CONDITIONS "64" CACHE STRING "The maximum number of conditions available for the dispatcher.")
@@ -154,12 +153,6 @@ else ()
     find_package(doctest REQUIRED)
 endif ()
 
-if (FMT_USE_SUBMODULE)
-    add_subdirectory(lib/fmt SYSTEM)
-else ()
-    find_package(fmt REQUIRED)
-endif ()
-
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 add_subdirectory(lib/json)
 
@@ -170,7 +163,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 target_compile_definitions(cubos-core PUBLIC GLM_FORCE_SILENT_WARNINGS) # Needed for compilation to succeed on MSVC
-target_link_libraries(cubos-core PUBLIC glm::glm nlohmann_json::nlohmann_json fmt::fmt ${CMAKE_DL_LIBS})
+target_link_libraries(cubos-core PUBLIC glm::glm nlohmann_json::nlohmann_json ${CMAKE_DL_LIBS})
 target_link_libraries(cubos-core PRIVATE Threads::Threads)
 
 # Add core tests

--- a/core/include/cubos/core/data/old/debug_serializer.hpp
+++ b/core/include/cubos/core/data/old/debug_serializer.hpp
@@ -2,35 +2,11 @@
 
 #include <stack>
 
-#include <fmt/format.h>
-
 #include <cubos/core/data/old/serializer.hpp>
 #include <cubos/core/memory/buffer_stream.hpp>
 
 namespace cubos::core::data::old
 {
-    /// Used to wrap a value to be printed using the debug serializer.
-    /// Can be pretty-printed using the `p` option. Types can be printed using the `t` option.
-    ///
-    /// @details Example usage:
-    ///
-    ///    CUBOS_ERROR("Cool debug serialized object: {}", Debug(mySerializableObj));
-    ///    CUBOS_INFO("Pretty printed: {:p}", Debug(mySerializableObj));
-    ///    CUBOS_INFO("With types too: {:pt}", Debug(mySerializableObj));
-    ///
-    /// @tparam T The type of the value to wrap.
-    template <typename T>
-    struct Debug
-    {
-        /// @param value The value to debug.
-        inline Debug(const T& value)
-            : value(value)
-        {
-        }
-
-        const T& value;
-    };
-
     /// Implementation of the abstract Serializer class for debugging purposes.
     /// This class is used internally by the logging functions.
     class DebugSerializer : public Serializer
@@ -90,53 +66,3 @@ namespace cubos::core::data::old
         bool mTypeNames;          ///< Whether to print the type names.
     };
 } // namespace cubos::core::data::old
-
-// Add a formatter for Debug<T>.
-
-/// @cond
-template <typename T>
-struct fmt::formatter<cubos::core::data::old::Debug<T>> : formatter<string_view>
-{
-    bool pretty = false; ///< Whether to pretty print the data.
-    bool types = false;  ///< Whether to print the type name.
-
-    inline constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin())
-    {
-        const auto* it = ctx.begin();
-        const auto* end = ctx.end();
-        while (it != end)
-        {
-            if (*it == 'p')
-            {
-                this->pretty = true;
-            }
-            else if (*it == 't')
-            {
-                this->types = true;
-            }
-            else if (*it != '}')
-            {
-                throw format_error("invalid format");
-            }
-            else
-            {
-                break;
-            }
-            ++it;
-        }
-        return it;
-    }
-
-    template <typename FormatContext>
-    inline auto format(const cubos::core::data::old::Debug<T>& dbg, FormatContext& ctx) -> decltype(ctx.out())
-    {
-        auto stream = cubos::core::memory::BufferStream(32);
-        cubos::core::data::old::DebugSerializer serializer(stream, this->pretty, this->types);
-        serializer.write(dbg.value, nullptr);
-        stream.put('\0');
-        // Skip the '?: ' prefix.
-        auto result = std::string(static_cast<const char*>(stream.getBuffer()) + 3);
-        return formatter<string_view>::format(string_view(result), ctx);
-    }
-};
-/// @endcond

--- a/core/include/cubos/core/data/old/package.hpp
+++ b/core/include/cubos/core/data/old/package.hpp
@@ -7,6 +7,7 @@
 #include <cubos/core/data/old/deserializer.hpp>
 #include <cubos/core/data/old/serializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 
 namespace cubos::core::data::old
 {

--- a/core/include/cubos/core/ecs/component/registry.hpp
+++ b/core/include/cubos/core/ecs/component/registry.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include <cubos/core/data/old/deserializer.hpp>

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -12,6 +12,8 @@
 #include <cubos/core/ecs/entity/manager.hpp>
 #include <cubos/core/ecs/resource/manager.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/string_view.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 namespace cubos::core::ecs

--- a/core/include/cubos/core/io/gamepad.hpp
+++ b/core/include/cubos/core/io/gamepad.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @brief Struct Gref cubos::core::io::GamepadState and related enums.
+/// @brief Struct @ref cubos::core::io::GamepadState and related enums.
 /// @ingroup core-io
 
 #pragma once

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -6,8 +6,41 @@
 
 #include <cstdlib>
 
+#include <cubos/core/memory/buffer_stream.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
 /// @addtogroup core
 /// @{
+
+/// @brief Trace log level, lowest log level. Very verbose.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_TRACE 0
+
+/// @brief Debug log level. Contains messages useful for debugging, but which are not necessary in
+/// release builds.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_DEBUG 1
+
+/// @brief Information log level. Contains important events that are not errors.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_INFO 2
+
+/// @brief Warn log level. Contains events that are not errors, but which are unexpected and may be
+/// problematic.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_WARN 3
+
+/// @brief Error log level. Contains errors which are recoverable from.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_ERROR 4
+
+/// @brief Critical log level, highest log level. Contains errors which are unrecoverable from.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_CRITICAL 5
+
+/// @brief Off log level, disables all logging.
+/// @sa CUBOS_LOG_LEVEL
+#define CUBOS_LOG_LEVEL_OFF 6
 
 /// @def CUBOS_LOG_LEVEL
 /// @brief Log level to compile in.
@@ -30,76 +63,105 @@
 
 #ifndef CUBOS_LOG_LEVEL
 #ifndef NDEBUG
-#define CUBOS_LOG_LEVEL 0
+#define CUBOS_LOG_LEVEL CUBOS_LOG_LEVEL_TRACE
 #else
-#define CUBOS_LOG_LEVEL 2
+#define CUBOS_LOG_LEVEL CUBOS_LOG_LEVEL_INFO
 #endif
 #endif
 
-#undef SPDLOG_ACTIVE_LEVEL
-#define SPDLOG_ACTIVE_LEVEL CUBOS_LOG_LEVEL
-#include <spdlog/spdlog.h>
-
-/// @brief Trace log level, lowest log level. Very verbose.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_TRACE SPDLOG_LEVEL_TRACE
-
-/// @brief Debug log level. Contains messages useful for debugging, but which are not necessary in
-/// release builds.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_DEBUG SPDLOG_LEVEL_DEBUG
-
-/// @brief Information log level. Contains important events that are not errors.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_INFO SPDLOG_LEVEL_INFO
-
-/// @brief Warn log level. Contains events that are not errors, but which are unexpected and may be
-/// problematic.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_WARN SPDLOG_LEVEL_WARN
-
-/// @brief Error log level. Contains errors which are recoverable from.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_ERROR SPDLOG_LEVEL_ERROR
-
-/// @brief Critical log level, highest log level. Contains errors which are unrecoverable from.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_CRITICAL SPDLOG_LEVEL_CRITICAL
-
-/// @brief Off log level, disables all logging.
-/// @sa CUBOS_LOG_LEVEL
-#define CUBOS_LOG_LEVEL_OFF SPDLOG_LEVEL_OFF
-
+/// @def CUBOS_TRACE
 /// @brief Used for logging very verbose information.
 /// @param ... Format string and arguments.
 /// @see CUBOS_LOG_LEVEL_TRACE
-#define CUBOS_TRACE(...) SPDLOG_TRACE(__VA_ARGS__)
 
+#if CUBOS_LOG_LEVEL <= CUBOS_LOG_LEVEL_TRACE
+#define CUBOS_TRACE(...) CUBOS_LOG(Trace, __VA_ARGS__)
+#else
+#define CUBOS_TRACE(...)                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
+
+/// @def CUBOS_DEBUG
 /// @brief Used for logging information which is useful for debugging but not necessary in release
 /// builds.
 /// @param ... Format string and arguments.
 /// @see CUBOS_LOG_LEVEL_DEBUG
-#define CUBOS_DEBUG(...) SPDLOG_DEBUG(__VA_ARGS__)
 
+#if CUBOS_LOG_LEVEL <= CUBOS_LOG_LEVEL_DEBUG
+#define CUBOS_DEBUG(...) CUBOS_LOG(Debug, __VA_ARGS__)
+#else
+#define CUBOS_DEBUG(...)                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
+
+/// @def CUBOS_INFO
 /// @brief Used for logging information which is useful in release builds.
 /// @param ... Format string and arguments.
 /// @see CUBOS_LOG_LEVEL_INFO
-#define CUBOS_INFO(...) SPDLOG_INFO(__VA_ARGS__)
 
+#if CUBOS_LOG_LEVEL <= CUBOS_LOG_LEVEL_INFO
+#define CUBOS_INFO(...) CUBOS_LOG(Info, __VA_ARGS__)
+#else
+#define CUBOS_INFO(...)                                                                                                \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
+
+/// @def CUBOS_WARN
 /// @brief Used for logging unexpected events.
 /// @param ... Format string and arguments.
 /// @see CUBOS_LOG_LEVEL_WARN
-#define CUBOS_WARN(...) SPDLOG_WARN(__VA_ARGS__)
 
+#if CUBOS_LOG_LEVEL <= CUBOS_LOG_LEVEL_WARN
+#define CUBOS_WARN(...) CUBOS_LOG(Warn, __VA_ARGS__)
+#else
+#define CUBOS_WARN(...)                                                                                                \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
+
+/// @def CUBOS_ERROR
 /// @brief Used for logging recoverable errors.
 /// @param ... Format string and arguments.
 /// @see CUBOS_LOG_LEVEL_ERROR
-#define CUBOS_ERROR(...) SPDLOG_ERROR(__VA_ARGS__)
 
+#if CUBOS_LOG_LEVEL <= CUBOS_LOG_LEVEL_ERROR
+#define CUBOS_ERROR(...) CUBOS_LOG(Error, __VA_ARGS__)
+#else
+#define CUBOS_ERROR(...)                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
+
+/// @def CUBOS_CRITICAL
 /// @brief Used for logging unrecoverable errors.
 /// @param ... Format string and arguments.
 /// @see CUBOS_LOG_LEVEL_CRITICAL
-#define CUBOS_CRITICAL(...) SPDLOG_CRITICAL(__VA_ARGS__)
+
+#if CUBOS_LOG_LEVEL <= CUBOS_LOG_LEVEL_CRITICAL
+#define CUBOS_CRITICAL(...) CUBOS_LOG(Critical, __VA_ARGS__)
+#else
+#define CUBOS_CRITICAL(...)                                                                                            \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
+
+/// @brief Used for logging messages.
+/// @param level Log level.
+/// @param ... Format string and arguments.
+/// @see CUBOS_LOG_LEVEL_CRITICAL
+#define CUBOS_LOG(level, ...)                                                                                          \
+    ::cubos::core::Logger::writeFormat(                                                                                \
+        ::cubos::core::Logger::Level::level,                                                                           \
+        ::cubos::core::Logger::Location{.function = __func__, .file = __FILE__, .line = __LINE__}, __VA_ARGS__)
 
 /// @brief Aborts a program, optionally printing a critical error message.
 /// @param ... Optional format string and arguments.
@@ -122,6 +184,15 @@
         CUBOS_FAIL(__VA_ARGS__);                                                                                       \
     } while (false)
 
+/// @brief Marks a code path as unfinished. Aborts the program when reached.
+/// @param ... Optional format string and arguments.
+#define CUBOS_TODO(...)                                                                                                \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        CUBOS_CRITICAL("Reached unfinished code");                                                                     \
+        CUBOS_FAIL(__VA_ARGS__);                                                                                       \
+    } while (false)
+
 /// @brief Asserts that a condition is true, aborting the program if it is not.
 /// @param cond Condition to assert.
 /// @param ... Optional format string and arguments.
@@ -130,26 +201,152 @@
     {                                                                                                                  \
         if (!(cond))                                                                                                   \
         {                                                                                                              \
-            CUBOS_CRITICAL("Assertion {} failed", #cond);                                                              \
+            CUBOS_CRITICAL("Assertion " #cond " failed");                                                              \
             CUBOS_FAIL(__VA_ARGS__);                                                                                   \
         }                                                                                                              \
     } while (false)
 
+/// @def CUBOS_DEBUG_ASSERT
 /// @brief In debug builds asserts that a condition is true, aborting the program if it is not.
 /// @param cond Condition to assert.
 /// @param ... Optional format string and arguments.
-/// @todo This should be compiled out when some option is set to false.
+
+#ifndef NDEBUG
 #define CUBOS_DEBUG_ASSERT(cond, ...) CUBOS_ASSERT(cond)
+#else
+#define CUBOS_DEBUG_ASSERT(cond, ...)                                                                                  \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (false)
+#endif
 
 /// @}
 
 namespace cubos::core
 {
-    /// @brief Must be called before any logging is done.
+    /// @brief Singleton which holds the logging state.
     /// @ingroup core
-    void initializeLogger();
+    class Logger final
+    {
+    public:
+        /// @brief Represents a logging level.
+        enum class Level
+        {
+            /// @copybrief CUBOS_LOG_LEVEL_TRACE
+            Trace = CUBOS_LOG_LEVEL_TRACE,
 
-    /// @brief Disables all logging except for critical errors.
-    /// @ingroup core
-    void disableLogging();
+            /// @copybrief CUBOS_LOG_LEVEL_DEBUG
+            Debug = CUBOS_LOG_LEVEL_DEBUG,
+
+            /// @copybrief CUBOS_LOG_LEVEL_INFO
+            Info = CUBOS_LOG_LEVEL_INFO,
+
+            /// @copybrief CUBOS_LOG_LEVEL_WARN
+            Warn = CUBOS_LOG_LEVEL_WARN,
+
+            /// @copybrief CUBOS_LOG_LEVEL_ERROR
+            Error = CUBOS_LOG_LEVEL_ERROR,
+
+            /// @copybrief CUBOS_LOG_LEVEL_CRITICAL
+            Critical = CUBOS_LOG_LEVEL_CRITICAL,
+
+            /// @copybrief CUBOS_LOG_LEVEL_OFF
+            Off = CUBOS_LOG_LEVEL_OFF,
+        };
+
+        /// @brief Identifies a location in the code.
+        struct Location
+        {
+            std::string function; ///< Function name.
+            std::string file;     ///< File name.
+            int line;             ///< Line number.
+
+            /// @brief Returns a string representation for the location.
+            /// @return String representation.
+            std::string string() const;
+        };
+
+        /// @brief A timestamp used to identify when a logging message was written.
+        struct Timestamp
+        {
+            int64_t timestamp; ///< Milliseconds since the UNIX epoch.
+
+            /// @brief Returns a timestamp with the current time.
+            /// @return Timestamp.
+            static Timestamp now();
+
+            /// @brief Returns a string representation for the timestamp, containing hours,
+            /// minutes, seconds and milliseconds.
+            /// @return String representation.
+            std::string string() const;
+        };
+
+        /// @brief Data created by a call to @ref log.
+        struct Entry
+        {
+            Level level;         ///< Level.
+            Timestamp timestamp; ///< Timestamp;
+            Location location;   ///< Code location which originated the log message.
+            std::string message; ///< Message.
+        };
+
+        /// @brief Deleted constructor.
+        Logger() = delete;
+
+        /// @brief Sets the log level.
+        ///
+        /// If @ref CUBOS_LOG_LEVEL is higher than the set level, entries below it are still not
+        /// registered.
+        ///
+        /// @param level New logging level.
+        static void level(Level level);
+
+        /// @brief Gets the current log level.
+        /// @return Log level.
+        static Level level();
+
+        /// @brief Creates a new entry in the logs, as long as the log level is high enough.
+        /// @param level Log level.
+        /// @param location Code location.
+        /// @param message Log message.
+        static void write(Level level, Location location, std::string message);
+
+        /// @brief Wrapper for @ref write() with message formatting.
+        /// @tparam TArgs Message format argument types.
+        /// @param level Log level.
+        /// @param location Code location.
+        /// @param format Message format string.
+        /// @param args Message format arguments.
+        template <reflection::Reflectable... TArgs>
+        static void writeFormat(Level level, Location location, const char* format, TArgs... args)
+        {
+            memory::BufferStream stream{};
+            if constexpr (sizeof...(TArgs) == 0)
+            {
+                stream.print(format);
+            }
+            else
+            {
+                ([&]() { format = Logger::streamFormat(stream, format, reflection::reflect<TArgs>(), &args); }(), ...);
+            }
+            Logger::write(level, location, stream.string());
+        }
+
+        /// @brief Reads a log entry, if there's a new one.
+        /// @param[out] cursor Index of the entry to be read. Automatically increased.
+        /// @param[out] entry Entry to read into.
+        /// @return Whether an entry was red.
+        static bool read(std::size_t& cursor, Entry& entry);
+
+    private:
+        /// @brief Writes the given format string to the given stream, with a single argument type.
+        /// Stops if a second argument is found, and returns a pointer to its location.
+        /// @param stream Stream to write to.
+        /// @param format Format string.
+        /// @param type Argument type.
+        /// @param value Argument value.
+        /// @return Pointer to second argument location, or to null terminating character, if over.
+        static const char* streamFormat(memory::Stream& stream, const char* format, const reflection::Type& type,
+                                        const void* value);
+    };
 } // namespace cubos::core

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -350,3 +350,5 @@ namespace cubos::core
                                         const void* value);
     };
 } // namespace cubos::core
+
+CUBOS_REFLECT_EXTERNAL_DECL(cubos::core::Logger::Level);

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -329,7 +329,7 @@ namespace cubos::core
             {
                 ([&]() { format = Logger::streamFormat(stream, format, reflection::reflect<TArgs>(), &args); }(), ...);
             }
-            Logger::write(level, location, stream.string());
+            Logger::write(level, std::move(location), stream.string());
         }
 
         /// @brief Reads a log entry, if there's a new one.

--- a/core/include/cubos/core/memory/buffer_stream.hpp
+++ b/core/include/cubos/core/memory/buffer_stream.hpp
@@ -44,6 +44,10 @@ namespace cubos::core::memory
         /// @return Buffer.
         const void* getBuffer() const;
 
+        /// @brief Creates a string from the buffer of this stream.
+        /// @return String.
+        std::string string() const;
+
         // Method implementations.
 
         std::size_t read(void* data, std::size_t size) override;

--- a/core/include/cubos/core/reflection/external/cstring.hpp
+++ b/core/include/cubos/core/reflection/external/cstring.hpp
@@ -1,0 +1,10 @@
+/// @file
+/// @brief Reflection declaration for C-strings.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+CUBOS_REFLECT_EXTERNAL_DECL(const char*);
+CUBOS_REFLECT_EXTERNAL_DECL(char*);

--- a/core/include/cubos/core/reflection/external/primitives.hpp
+++ b/core/include/cubos/core/reflection/external/primitives.hpp
@@ -4,19 +4,28 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include <cubos/core/reflection/reflect.hpp>
 
+// Boolean type.
 CUBOS_REFLECT_EXTERNAL_DECL(bool);
+
+// Char type (distinct from `signed char` and `unsigned char`).
 CUBOS_REFLECT_EXTERNAL_DECL(char);
-CUBOS_REFLECT_EXTERNAL_DECL(int8_t);
-CUBOS_REFLECT_EXTERNAL_DECL(int16_t);
-CUBOS_REFLECT_EXTERNAL_DECL(int32_t);
-CUBOS_REFLECT_EXTERNAL_DECL(int64_t);
-CUBOS_REFLECT_EXTERNAL_DECL(uint8_t);
-CUBOS_REFLECT_EXTERNAL_DECL(uint16_t);
-CUBOS_REFLECT_EXTERNAL_DECL(uint32_t);
-CUBOS_REFLECT_EXTERNAL_DECL(uint64_t);
+
+// Signed integer types.
+CUBOS_REFLECT_EXTERNAL_DECL(signed char);
+CUBOS_REFLECT_EXTERNAL_DECL(short);
+CUBOS_REFLECT_EXTERNAL_DECL(int);
+CUBOS_REFLECT_EXTERNAL_DECL(long);
+CUBOS_REFLECT_EXTERNAL_DECL(long long);
+
+// Unsigned integer types.
+CUBOS_REFLECT_EXTERNAL_DECL(unsigned char);
+CUBOS_REFLECT_EXTERNAL_DECL(unsigned short);
+CUBOS_REFLECT_EXTERNAL_DECL(unsigned int);
+CUBOS_REFLECT_EXTERNAL_DECL(unsigned long);
+CUBOS_REFLECT_EXTERNAL_DECL(unsigned long long);
+
+// Floating point types.
 CUBOS_REFLECT_EXTERNAL_DECL(float);
 CUBOS_REFLECT_EXTERNAL_DECL(double);

--- a/core/include/cubos/core/reflection/external/string_view.hpp
+++ b/core/include/cubos/core/reflection/external/string_view.hpp
@@ -1,0 +1,11 @@
+/// @file
+/// @brief Reflection declaration for `std::string_view`.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <string_view>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+CUBOS_REFLECT_EXTERNAL_DECL(std::string_view);

--- a/core/include/cubos/core/reflection/traits/dictionary.hpp
+++ b/core/include/cubos/core/reflection/traits/dictionary.hpp
@@ -246,8 +246,8 @@ namespace cubos::core::reflection
         /// @brief Output structure for the iterator.
         struct Entry
         {
-            const void* key; ///< Key.
-            void* value;     ///< Value.
+            const void* key{nullptr}; ///< Key.
+            void* value{nullptr};     ///< Value.
         };
 
         ~Iterator();
@@ -309,8 +309,8 @@ namespace cubos::core::reflection
         /// @brief Output structure for the iterator.
         struct Entry
         {
-            const void* key;   ///< Key.
-            const void* value; ///< Value.
+            const void* key{nullptr};   ///< Key.
+            const void* value{nullptr}; ///< Value.
         };
 
         ~Iterator();

--- a/core/samples/data/des/custom/main.cpp
+++ b/core/samples/data/des/custom/main.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/stream.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using cubos::core::memory::Stream;
 

--- a/core/samples/data/ser/custom/main.cpp
+++ b/core/samples/data/ser/custom/main.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/stream.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using cubos::core::memory::Stream;
 

--- a/core/samples/ecs/events/main.cpp
+++ b/core/samples/ecs/events/main.cpp
@@ -9,8 +9,6 @@ using namespace cubos::core::memory;
 
 int main()
 {
-    cubos::core::initializeLogger();
-
     struct MyEvent
     {
         enum Mask
@@ -40,8 +38,8 @@ int main()
     while (true)
     {
         auto mouseReader = EventReader<MyEvent, MyEvent::Mask::MouseEvent>(pipe, index);
-        auto it = mouseReader.read();
-        if (it == std::nullopt)
+        const auto* it = mouseReader.read();
+        if (it == nullptr)
         {
             break;
         }
@@ -53,8 +51,8 @@ int main()
     index = 0;
     auto mouseReader = EventReader<MyEvent, MyEvent::Mask::MouseEvent>(pipe, index);
     Stream::stdOut.printf("\n\n### mouse events:");
-    auto x = mouseReader.read(); // already read one event, the loop will only loop once
-    Stream::stdOut.printf("{} , ", x->get().data);
+    const auto* x = mouseReader.read(); // already read one event, the loop will only loop once
+    Stream::stdOut.printf("{} , ", x->data);
     for (const auto& it : mouseReader)
     {
         Stream::stdOut.printf(" {} , ", it.data); // 6

--- a/core/samples/ecs/events/main.cpp
+++ b/core/samples/ecs/events/main.cpp
@@ -43,7 +43,7 @@ int main()
         {
             break;
         }
-        Stream::stdOut.printf(" {} , ", it->get().data);
+        Stream::stdOut.printf(" {} , ", it->data);
     }
 
     // range based

--- a/core/samples/ecs/general/main.cpp
+++ b/core/samples/ecs/general/main.cpp
@@ -181,7 +181,7 @@ void mySystem(ecs::Write<DeltaTime> dt, ecs::Read<MyResource> res)
 
 int main()
 {
-    initializeLogger();
+    Logger::level(Logger::Level::Critical);
     ecs::World world;
     world.registerResource<DeltaTime>(DeltaTime{1.0F});
     world.registerResource<MyResource>(MyResource{0});

--- a/core/samples/gl/compute/main.cpp
+++ b/core/samples/gl/compute/main.cpp
@@ -9,7 +9,6 @@ using namespace cubos::core;
 
 int main()
 {
-    initializeLogger();
     auto window = io::openWindow();
     auto& renderDevice = window->renderDevice();
 

--- a/core/samples/gl/debug_renderer/main.cpp
+++ b/core/samples/gl/debug_renderer/main.cpp
@@ -9,7 +9,6 @@ using namespace cubos::core;
 
 int main()
 {
-    initializeLogger();
     auto window = io::openWindow();
     auto& renderDevice = window->renderDevice();
     gl::Debug::init(renderDevice);

--- a/core/samples/gl/quad/main.cpp
+++ b/core/samples/gl/quad/main.cpp
@@ -10,7 +10,6 @@ using namespace cubos::core;
 
 int main()
 {
-    initializeLogger();
     auto window = io::openWindow();
     auto& renderDevice = window->renderDevice();
 

--- a/core/samples/logging/main.cpp
+++ b/core/samples/logging/main.cpp
@@ -4,17 +4,18 @@
 #include <cubos/core/log.hpp>
 /// [Logging include]
 
-/// [Debug wrapper include]
-#include <cubos/core/data/old/debug_serializer.hpp>
+/// [External reflection includes]
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/unordered_map.hpp>
+/// [External reflection includes]
 
-using cubos::core::data::old::Debug;
-/// [Debug wrapper include]
-
-/// [Logger initialization]
 int main()
 {
-    cubos::core::initializeLogger();
-    /// [Logger initialization]
+    /// [Set logging level]
+    cubos::core::Logger::level(cubos::core::Logger::Level::Trace);
+    /// [Set logging level]
 
     /// [Logging macros]
     CUBOS_TRACE("Trace message");
@@ -26,13 +27,8 @@ int main()
     /// [Logging macros]
 
     /// [Logging macros with arguments]
-    CUBOS_ERROR("Error message with {} argument", 1);
-    /// [Logging macros with arguments]
-
-    /// [Debug wrapper usage]
-    CUBOS_INFO("Serializable type: {}", Debug(glm::vec3(0.0F, 1.0F, 2.0F)));
-    CUBOS_INFO("Again, but with type information: {:t}", Debug(glm::vec3(0.0F, 1.0F, 2.0F)));
-    CUBOS_INFO("Since unordered maps are serializable, we can do this: {}",
-               Debug((std::unordered_map<int, const char*>{{1, "one"}, {2, "two"}})));
+    CUBOS_INFO("An integer: {}", 1);
+    CUBOS_INFO("A glm::vec3: {}", glm::vec3(0.0F, 1.0F, 2.0F));
+    CUBOS_INFO("An std::unordered_map: {}", std::unordered_map<int, const char*>{{1, "one"}, {2, "two"}});
 }
-/// [Debug wrapper usage]
+/// [Logging macros with arguments]

--- a/core/samples/logging/page.md
+++ b/core/samples/logging/page.md
@@ -8,29 +8,28 @@ Logging in **CUBOS.** is done through the logging macros defined in @ref core/lo
 
 @snippet logging/main.cpp Logging include
 
-Before any logging is done, the logger must be initialized.
-This usually happens right at the beginning of the program.
-
-@snippet logging/main.cpp Logger initialization
-
 There are six logging levels, each with its own macro.
 In order of increasing severity, they are:
 
 @snippet logging/main.cpp Logging macros
 
-These macros can also take arguments:
+The minimum registered log level is set with @ref cubos::core::Logger::level "Logger::level". On
+this sample, to demonstrate @ref CUBOS_TRACE, we set it to @ref cubos::core::Logger::Level::Trace
+"Trace":
+
+@snippet logging/main.cpp Set logging level
+
+@note By default, on debug builds all logging calls are compiled, while on release builds only
+messages with severity level @ref CUBOS_LOG_LEVEL_INFO or higher are compiled. This can be changed
+by defining @ref CUBOS_LOG_LEVEL to the desired level.
+
+These macros can also take arguments, which can be of any reflectable type.
 
 @snippet logging/main.cpp Logging macros with arguments
 
-@note By default, on debug builds all messages are logged, while on release builds only messages with
-severity level @ref CUBOS_LOG_LEVEL_INFO or higher are logged. This can be changed by defining
-@ref CUBOS_LOG_LEVEL to the desired level.
+To print external types, such as `glm` math types, `STL` types (`std::string`, ...) or primitives
+(`int`, ...), you'll have to include their respective headers in the @ref core/reflection/external
+directory. Notice that although we aren't printing C-strings directly, we must still include them
+as our `std::unordered_map` contains `const char*`s.
 
-Serializable types can also be logged, using @ref cubos::core::data::old::Debug.
-
-@snippet logging/main.cpp Debug wrapper include
-
-By wrapping the value in @ref cubos::core::data::old::Debug, the type is serialized using the
-@ref cubos::core::data::old::DebugSerializer, and the result is logged.
-
-@snippet logging/main.cpp Debug wrapper usage
+@snippet logging/main.cpp External reflection includes

--- a/core/samples/reflection/traits/array/main.cpp
+++ b/core/samples/reflection/traits/array/main.cpp
@@ -1,4 +1,6 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 /// [Printing any array]
 #include <cubos/core/reflection/traits/array.hpp>
@@ -42,7 +44,7 @@ void printArray(const T& array)
 /// [Typed wrapper]
 
 /// [Usage]
-#include <cubos/core/reflection/external/primitives.hpp>
+// You must also include <cubos/core/reflection/external/primitives.hpp> :)
 #include <cubos/core/reflection/external/vector.hpp>
 
 int main()

--- a/core/samples/reflection/traits/dictionary/main.cpp
+++ b/core/samples/reflection/traits/dictionary/main.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 /// [Printing any dictionary]
 #include <cubos/core/reflection/traits/dictionary.hpp>

--- a/core/samples/reflection/traits/enum/main.cpp
+++ b/core/samples/reflection/traits/enum/main.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 /// [Enum declaration]
 #include <cubos/core/reflection/reflect.hpp>

--- a/core/samples/reflection/traits/fields/main.cpp
+++ b/core/samples/reflection/traits/fields/main.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 /// [Person declaration]
 #include <cubos/core/reflection/reflect.hpp>

--- a/core/src/cubos/core/data/des/deserializer.cpp
+++ b/core/src/cubos/core/data/des/deserializer.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/data/des/deserializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 using cubos::core::data::Deserializer;

--- a/core/src/cubos/core/data/des/json.cpp
+++ b/core/src/cubos/core/data/des/json.cpp
@@ -71,17 +71,21 @@ JSONDeserializer::JSONDeserializer()
 
         throw std::invalid_argument{s};
     });
-    AUTO_HOOK(int8_t, std::stol);
-    AUTO_HOOK(int16_t, std::stol);
-    AUTO_HOOK(int32_t, std::stol);
-    AUTO_HOOK(int64_t, std::stoll);
-    AUTO_HOOK(uint8_t, std::stoul);
-    AUTO_HOOK(uint16_t, std::stoul);
-    AUTO_HOOK(uint32_t, std::stoul);
-    AUTO_HOOK(uint64_t, std::stoull);
-    AUTO_HOOK(float, std::stoull);
-    AUTO_HOOK(double, std::stoull);
-    AUTO_HOOK(std::string, [](const std::string& s) { return s; });
+
+    AUTO_HOOK(signed char, std::stol);
+    AUTO_HOOK(short, std::stol);
+    AUTO_HOOK(int, std::stol);
+    AUTO_HOOK(long, std::stol);
+    AUTO_HOOK(long long, std::stoll);
+
+    AUTO_HOOK(unsigned char, std::stoul);
+    AUTO_HOOK(unsigned short, std::stoul);
+    AUTO_HOOK(unsigned int, std::stoul);
+    AUTO_HOOK(unsigned long, std::stoul);
+    AUTO_HOOK(unsigned long long, std::stoull);
+
+    AUTO_HOOK(float, std::stof);
+    AUTO_HOOK(double, std::stod);
 }
 
 void JSONDeserializer::feed(nlohmann::json json)

--- a/core/src/cubos/core/data/des/json.cpp
+++ b/core/src/cubos/core/data/des/json.cpp
@@ -1,6 +1,7 @@
 #include <cubos/core/data/des/json.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/any_value.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/array.hpp>
@@ -116,7 +117,8 @@ bool JSONDeserializer::decompose(const Type& type, void* value)
         const auto& trait = type.get<StringConversionTrait>();
         if (!trait.from(value, mIterator.value()))
         {
-            CUBOS_WARN("String '{}' is not a valid string representation of '{}'", mIterator.value(), type.name());
+            CUBOS_WARN("String '{}' is not a valid string representation of '{}'",
+                       static_cast<std::string>(mIterator.value()), type.name());
             return false;
         }
 

--- a/core/src/cubos/core/data/fs/embedded_archive.cpp
+++ b/core/src/cubos/core/data/fs/embedded_archive.cpp
@@ -2,6 +2,7 @@
 #include <cubos/core/data/fs/file_stream.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/buffer_stream.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using namespace cubos::core;
 using namespace cubos::core::data;

--- a/core/src/cubos/core/data/fs/file.cpp
+++ b/core/src/cubos/core/data/fs/file.cpp
@@ -3,6 +3,9 @@
 #include <cubos/core/data/fs/archive.hpp>
 #include <cubos/core/data/fs/file.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/string_view.hpp>
 
 using namespace cubos::core;
 using namespace cubos::core::data;

--- a/core/src/cubos/core/data/fs/file_system.cpp
+++ b/core/src/cubos/core/data/fs/file_system.cpp
@@ -3,6 +3,7 @@
 #include <cubos/core/data/fs/archive.hpp>
 #include <cubos/core/data/fs/file_system.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string_view.hpp>
 
 using namespace cubos::core;
 using namespace cubos::core::data;

--- a/core/src/cubos/core/data/fs/standard_archive.cpp
+++ b/core/src/cubos/core/data/fs/standard_archive.cpp
@@ -1,7 +1,11 @@
+#include <cstring>
+
 #include <cubos/core/data/fs/file_stream.hpp>
 #include <cubos/core/data/fs/standard_archive.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/standard_stream.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using cubos::core::data::StandardArchive;
 using cubos::core::memory::Stream;

--- a/core/src/cubos/core/data/old/context.cpp
+++ b/core/src/cubos/core/data/old/context.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/data/old/context.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 
 using namespace cubos::core::data::old;
 

--- a/core/src/cubos/core/data/old/json_deserializer.cpp
+++ b/core/src/cubos/core/data/old/json_deserializer.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/data/old/json_deserializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 
 using namespace cubos::core;
 using namespace cubos::core::data::old;

--- a/core/src/cubos/core/data/old/package.cpp
+++ b/core/src/cubos/core/data/old/package.cpp
@@ -1,6 +1,8 @@
 #include <iterator>
 
 #include <cubos/core/data/old/package.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using namespace cubos::core::data::old;
 
@@ -502,7 +504,7 @@ void impl::Packager::beginObject(const char* name)
 
 void impl::Packager::endObject()
 {
-    assert(!mStack.empty());
+    CUBOS_ASSERT(!mStack.empty());
     mStack.pop();
 }
 
@@ -513,7 +515,7 @@ void impl::Packager::beginArray(std::size_t /*length*/, const char* name)
 
 void impl::Packager::endArray()
 {
-    assert(!mStack.empty());
+    CUBOS_ASSERT(!mStack.empty());
     mStack.pop();
 }
 
@@ -524,7 +526,7 @@ void impl::Packager::beginDictionary(std::size_t /*length*/, const char* name)
 
 void impl::Packager::endDictionary()
 {
-    assert(!mStack.empty());
+    CUBOS_ASSERT(!mStack.empty());
     mStack.pop();
 }
 
@@ -540,7 +542,7 @@ Package* impl::Packager::push(Package::Data&& data, const char* name)
     switch (pkg->type())
     {
     case Package::Type::Object:
-        assert(name != nullptr);
+        CUBOS_ASSERT(name != nullptr);
         pkg->fields().emplace_back(name, Package());
         pkg->fields().back().second.mData = std::move(data);
         return &pkg->fields().back().second;
@@ -753,7 +755,7 @@ void Unpackager::beginObject()
 
 void Unpackager::endObject()
 {
-    assert(!mStack.empty());
+    CUBOS_ASSERT(!mStack.empty());
     mStack.pop();
 }
 
@@ -772,7 +774,7 @@ std::size_t Unpackager::beginArray()
 
 void Unpackager::endArray()
 {
-    assert(!mStack.empty());
+    CUBOS_ASSERT(!mStack.empty());
     mStack.pop();
 }
 
@@ -791,7 +793,7 @@ std::size_t Unpackager::beginDictionary()
 
 void Unpackager::endDictionary()
 {
-    assert(!mStack.empty());
+    CUBOS_ASSERT(!mStack.empty());
     mStack.pop();
 }
 

--- a/core/src/cubos/core/data/ser/debug.cpp
+++ b/core/src/cubos/core/data/ser/debug.cpp
@@ -25,22 +25,27 @@ DebugSerializer::DebugSerializer(memory::Stream& stream)
     : mStream(stream)
 {
     AUTO_HOOK(bool, mStream.print(value ? "true" : "false"));
+
     AUTO_HOOK(char, {
         mStream.put('\'');
         mStream.put(value);
         mStream.put('\'');
     });
-    AUTO_HOOK(int8_t, mStream.print(value));
-    AUTO_HOOK(int16_t, mStream.print(value));
-    AUTO_HOOK(int32_t, mStream.print(value));
-    AUTO_HOOK(int64_t, mStream.print(value));
-    AUTO_HOOK(uint8_t, mStream.print(value));
-    AUTO_HOOK(uint16_t, mStream.print(value));
-    AUTO_HOOK(uint32_t, mStream.print(value));
-    AUTO_HOOK(uint64_t, mStream.print(value));
+
+    AUTO_HOOK(signed char, mStream.print(value));
+    AUTO_HOOK(short, mStream.print(value));
+    AUTO_HOOK(int, mStream.print(value));
+    AUTO_HOOK(long, mStream.print(value));
+    AUTO_HOOK(long long, mStream.print(value));
+
+    AUTO_HOOK(unsigned char, mStream.print(value));
+    AUTO_HOOK(unsigned short, mStream.print(value));
+    AUTO_HOOK(unsigned int, mStream.print(value));
+    AUTO_HOOK(unsigned long, mStream.print(value));
+    AUTO_HOOK(unsigned long long, mStream.print(value));
+
     AUTO_HOOK(float, mStream.print(value));
     AUTO_HOOK(double, mStream.print(value));
-    AUTO_HOOK(std::string, mStream.printf("\"{}\"", value));
 }
 
 void DebugSerializer::pretty(bool pretty)

--- a/core/src/cubos/core/data/ser/debug.cpp
+++ b/core/src/cubos/core/data/ser/debug.cpp
@@ -160,7 +160,9 @@ bool DebugSerializer::decompose(const Type& type, const void* value)
     else if (type.has<StringConversionTrait>())
     {
         const auto& trait = type.get<StringConversionTrait>();
+        mStream.put('"');
         mStream.print(trait.into(value));
+        mStream.put('"');
     }
     else
     {

--- a/core/src/cubos/core/data/ser/serializer.cpp
+++ b/core/src/cubos/core/data/ser/serializer.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/data/ser/serializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 using cubos::core::data::Serializer;

--- a/core/src/cubos/core/ecs/blueprint.cpp
+++ b/core/src/cubos/core/ecs/blueprint.cpp
@@ -1,6 +1,7 @@
 #include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/array.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/traits/dictionary.hpp>

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -1,5 +1,7 @@
 #include <cubos/core/ecs/component/manager.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 using namespace cubos::core;

--- a/core/src/cubos/core/ecs/entity/entity.cpp
+++ b/core/src/cubos/core/ecs/entity/entity.cpp
@@ -4,6 +4,7 @@
 #include <cubos/core/ecs/entity/entity.hpp>
 #include <cubos/core/ecs/entity/hash.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/type.hpp>

--- a/core/src/cubos/core/ecs/system/commands.cpp
+++ b/core/src/cubos/core/ecs/system/commands.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using namespace cubos::core::ecs;
 

--- a/core/src/cubos/core/ecs/system/dispatcher.cpp
+++ b/core/src/cubos/core/ecs/system/dispatcher.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
+#include <iterator>
 
 #include <cubos/core/ecs/system/dispatcher.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 using namespace cubos::core::ecs;
 

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -1,6 +1,7 @@
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/world.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 using namespace cubos::core;
@@ -18,7 +19,7 @@ Entity World::create()
     Entity::Mask mask{};
     mask.set(0);
     auto entity = mEntityManager.create(mask);
-    CUBOS_DEBUG("Created entity {}#{}", entity.index, entity.generation);
+    CUBOS_DEBUG("Created entity {}", entity);
     return entity;
 }
 
@@ -26,7 +27,7 @@ void World::destroy(Entity entity)
 {
     mEntityManager.destroy(entity);
     mComponentManager.removeAll(entity.index);
-    CUBOS_DEBUG("Destroyed entity {}#{}", entity.index, entity.generation);
+    CUBOS_DEBUG("Destroyed entity {}", entity);
 }
 
 bool World::isAlive(Entity entity) const
@@ -151,7 +152,7 @@ auto World::Components::add(const reflection::Type& type, void* value) -> Compon
     mWorld.mEntityManager.setMask(mEntity, mask);
     mWorld.mComponentManager.add(mEntity.index, type, value);
 
-    CUBOS_DEBUG("Added component {} to entity {}#{}", type.name(), mEntity.index, mEntity.generation);
+    CUBOS_DEBUG("Added component {} to entity {}", type.name(), mEntity, mEntity);
     return *this;
 }
 
@@ -163,7 +164,7 @@ auto World::Components::remove(const reflection::Type& type) -> Components&
     mWorld.mEntityManager.setMask(mEntity, mask);
     mWorld.mComponentManager.remove(mEntity.index, componentId);
 
-    CUBOS_DEBUG("Removed component {} from entity {}#{}", type.name(), mEntity.index, mEntity.generation);
+    CUBOS_DEBUG("Removed component {} from entity {}", type.name(), mEntity);
     return *this;
 }
 

--- a/core/src/cubos/core/gl/ogl_render_device.cpp
+++ b/core/src/cubos/core/gl/ogl_render_device.cpp
@@ -3,10 +3,13 @@
 #include <list>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <glad/gl.h>
 
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include "ogl_render_device.hpp"
 
@@ -1697,7 +1700,7 @@ Texture1D OGLRenderDevice::createTexture1D(const Texture1DDesc& desc)
 
     if (!textureFormatToGL(desc.format, internalFormat, format, type))
     {
-        CUBOS_ERROR("Unsupported texture format {}", desc.format);
+        CUBOS_ERROR("Unsupported texture format {}", static_cast<int>(desc.format));
         return nullptr;
     }
 
@@ -1738,7 +1741,7 @@ Texture2D OGLRenderDevice::createTexture2D(const Texture2DDesc& desc)
 
     if (!textureFormatToGL(desc.format, internalFormat, format, type))
     {
-        CUBOS_ERROR("Unsupported texture format {}", desc.format);
+        CUBOS_ERROR("Unsupported texture format {}", static_cast<int>(desc.format));
         return nullptr;
     }
 
@@ -1782,7 +1785,7 @@ Texture2DArray OGLRenderDevice::createTexture2DArray(const Texture2DArrayDesc& d
 
     if (!textureFormatToGL(desc.format, internalFormat, format, type))
     {
-        CUBOS_ERROR("Unsupported texture format {}", desc.format);
+        CUBOS_ERROR("Unsupported texture format {}", static_cast<int>(desc.format));
         return nullptr;
     }
 
@@ -1841,7 +1844,7 @@ Texture3D OGLRenderDevice::createTexture3D(const Texture3DDesc& desc)
 
     if (!textureFormatToGL(desc.format, internalFormat, format, type))
     {
-        CUBOS_ERROR("Unsupported texture format {}", desc.format);
+        CUBOS_ERROR("Unsupported texture format {}", static_cast<int>(desc.format));
         return nullptr;
     }
 
@@ -1885,7 +1888,7 @@ CubeMap OGLRenderDevice::createCubeMap(const CubeMapDesc& desc)
 
     if (!textureFormatToGL(desc.format, internalFormat, format, type))
     {
-        CUBOS_ERROR("Unsupported texture format {}", desc.format);
+        CUBOS_ERROR("Unsupported texture format {}", static_cast<int>(desc.format));
         return nullptr;
     }
 
@@ -1943,7 +1946,7 @@ CubeMapArray OGLRenderDevice::createCubeMapArray(const CubeMapArrayDesc& desc)
 
     if (!textureFormatToGL(desc.format, internalFormat, format, type))
     {
-        CUBOS_ERROR("Unsupported texture format {}", desc.format);
+        CUBOS_ERROR("Unsupported texture format {}", static_cast<int>(desc.format));
         return nullptr;
     }
 

--- a/core/src/cubos/core/io/glfw_window.cpp
+++ b/core/src/cubos/core/io/glfw_window.cpp
@@ -3,6 +3,8 @@
 #include <glad/gl.h>
 
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include "../gl/ogl_render_device.hpp"
 

--- a/core/src/cubos/core/log.cpp
+++ b/core/src/cubos/core/log.cpp
@@ -1,26 +1,204 @@
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
+#include <chrono>
+#include <ctime>
+#include <mutex>
+#include <vector>
 
+#include <cubos/core/data/ser/debug.hpp>
 #include <cubos/core/log.hpp>
 
-void cubos::core::initializeLogger()
+using cubos::core::Logger;
+
+namespace
 {
-    auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    consoleSink->set_level(spdlog::level::trace);
-    consoleSink->set_pattern("%^[cubos] [%s:%# %!] %l: %v%$");
+    /// @brief Private type which stores the state of the logger.
+    struct State
+    {
+        std::mutex mutex;
+        Logger::Level level = Logger::Level::Debug;
+        std::vector<Logger::Entry> entries;
+    };
+} // namespace
 
-    // Only print to the file warnings, errors and critical logs
-    auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("log/cubos.txt", true);
-    fileSink->set_level(spdlog::level::warn);
-    fileSink->set_pattern("[cubos] [%s:%# %!] %l: %v");
-
-    auto logger = std::make_shared<spdlog::logger>("cubos", spdlog::sinks_init_list({consoleSink, fileSink}));
-    logger->set_level(spdlog::level::trace);
-    logger->flush_on(spdlog::level::trace);
-    spdlog::set_default_logger(logger);
+/// @brief Logger state singleton. Guarantees it is initialized exactly once, when needed.
+/// @return Logger state.
+static State& state()
+{
+    static State state{};
+    return state;
 }
 
-void cubos::core::disableLogging()
+/// @brief Returns a string representing the given log level.
+/// @param level Log level.
+/// @return String representation.
+static const char* levelString(Logger::Level level)
 {
-    spdlog::set_level(spdlog::level::critical);
+    switch (level)
+    {
+    case Logger::Level::Trace:
+        return "trace";
+    case Logger::Level::Debug:
+        return "debug";
+    case Logger::Level::Info:
+        return "info";
+    case Logger::Level::Warn:
+        return "warn";
+    case Logger::Level::Error:
+        return "error";
+    case Logger::Level::Critical:
+        return "critical";
+    default:
+        return "unknown";
+    }
+}
+
+static constexpr const char* ColorResetCode = "\033[m";
+
+/// @brief Returns an ASCII color code for the given log level.
+/// @param level Log level.
+/// @return ASCII color code.
+static const char* levelColor(Logger::Level level)
+{
+    switch (level)
+    {
+    case Logger::Level::Trace:
+        return "\033[37m"; // White
+    case Logger::Level::Debug:
+        return "\033[36m"; // Cyan
+    case Logger::Level::Info:
+        return "\033[32m"; // Green
+    case Logger::Level::Warn:
+        return "\033[33m\033[1m"; // Yellow bold
+    case Logger::Level::Error:
+        return "\033[31m\033[1m"; // Red bold
+    case Logger::Level::Critical:
+        return "\033[1m\033[41m"; // Bold on red
+    default:
+        return ColorResetCode;
+    }
+}
+
+std::string Logger::Location::string() const
+{
+    // Extract the file name.
+    auto name = this->file;
+    if (name.find('/') != std::string::npos)
+    {
+        name = name.substr(name.find_last_of('/') + 1);
+    }
+    else if (name.find('\\') != std::string::npos)
+    {
+        name = name.substr(name.find_last_of('\\') + 1);
+    }
+
+    return name + ':' + std::to_string(this->line) + ' ' + this->function;
+}
+
+auto Logger::Timestamp::now() -> Timestamp
+{
+    const auto now = std::chrono::system_clock::now();
+    const auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+    return Timestamp{.timestamp = timestamp};
+}
+
+std::string Logger::Timestamp::string() const
+{
+    const auto time = std::chrono::system_clock::from_time_t(0) + std::chrono::milliseconds{this->timestamp};
+    const auto cTime = std::chrono::system_clock::to_time_t(time);
+
+    std::string hoursMinsSecs{};
+    hoursMinsSecs.resize(8, ' ');
+    std::strftime(hoursMinsSecs.data(), hoursMinsSecs.size() + 1, "%H:%M:%S", std::localtime(&cTime));
+
+    // Get the number of milliseconds since the time_t timestamp (that format only stores up to seconds).
+    auto ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(time - std::chrono::system_clock::from_time_t(cTime))
+            .count();
+    std::string msStr = std::to_string(ms);
+
+    // Pad milliseconds string to 3 digits
+    if (msStr.size() < 3)
+    {
+        msStr.insert(msStr.begin(), 3 - msStr.size(), '0');
+    }
+
+    return hoursMinsSecs + '.' + msStr;
+}
+
+void Logger::level(Level level)
+{
+    std::lock_guard<std::mutex> guard{state().mutex};
+    state().level = level;
+}
+
+auto Logger::level() -> Logger::Level
+{
+    std::lock_guard<std::mutex> guard{state().mutex};
+    return state().level;
+}
+
+void Logger::write(Level level, Location location, std::string message)
+{
+    auto timestamp = Timestamp::now();
+
+    std::lock_guard<std::mutex> guard{state().mutex};
+
+    if (static_cast<int>(state().level) > static_cast<int>(level))
+    {
+        // If the log level is higher than the message level, then just ignore it.
+        return;
+    }
+
+    // Print the message to stderr.
+    memory::Stream::stdErr.printf("{}[{}] [{}] {}: {}{}\n", levelColor(level), timestamp.string(), location.string(),
+                                  levelString(level), message, ColorResetCode);
+
+    // Store the log entry.
+    state().entries.emplace_back(Entry{
+        .level = level,
+        .timestamp = timestamp,
+        .location = std::move(location),
+        .message = std::move(message),
+    });
+}
+
+bool Logger::read(std::size_t& cursor, Entry& entry)
+{
+    std::lock_guard<std::mutex> guard{state().mutex};
+
+    if (cursor >= state().entries.size())
+    {
+        return false;
+    }
+
+    entry = state().entries[cursor];
+    cursor += 1;
+    return true;
+}
+
+const char* Logger::streamFormat(memory::Stream& stream, const char* format, const reflection::Type& type,
+                                 const void* value)
+{
+    bool foundArgument = false;
+
+    for (; format[0] != '\0'; ++format)
+    {
+        if (format[0] == '{' && format[1] == '}')
+        {
+            if (foundArgument)
+            {
+                // This is the second argument, just return a pointer to it.
+                break;
+            }
+
+            foundArgument = true;
+            data::DebugSerializer{stream}.write(type, value);
+            ++format;
+        }
+        else
+        {
+            stream.put(format[0]);
+        }
+    }
+
+    return format;
 }

--- a/core/src/cubos/core/log.cpp
+++ b/core/src/cubos/core/log.cpp
@@ -5,8 +5,22 @@
 
 #include <cubos/core/data/ser/debug.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/traits/enum.hpp>
 
 using cubos::core::Logger;
+using cubos::core::reflection::EnumTrait;
+
+CUBOS_REFLECT_EXTERNAL_IMPL(Logger::Level)
+{
+    return Type::create("cubos::core::Logger::Level")
+        .with(EnumTrait{}
+                  .withVariant<Logger::Level::Trace>("Trace")
+                  .withVariant<Logger::Level::Debug>("Debug")
+                  .withVariant<Logger::Level::Info>("Info")
+                  .withVariant<Logger::Level::Warn>("Warn")
+                  .withVariant<Logger::Level::Error>("Error")
+                  .withVariant<Logger::Level::Critical>("Critical"));
+}
 
 namespace
 {
@@ -27,28 +41,16 @@ static State& state()
     return state;
 }
 
-/// @brief Returns a string representing the given log level.
-/// @param level Log level.
-/// @return String representation.
-static const char* levelString(Logger::Level level)
+/// @brief Converts the given string to lower case.
+/// @param string String.
+/// @return Lower case string.
+static std::string toLower(std::string string)
 {
-    switch (level)
+    for (auto& chr : string)
     {
-    case Logger::Level::Trace:
-        return "trace";
-    case Logger::Level::Debug:
-        return "debug";
-    case Logger::Level::Info:
-        return "info";
-    case Logger::Level::Warn:
-        return "warn";
-    case Logger::Level::Error:
-        return "error";
-    case Logger::Level::Critical:
-        return "critical";
-    default:
-        return "unknown";
+        chr = static_cast<char>(std::tolower(static_cast<int>(chr)));
     }
+    return string;
 }
 
 static constexpr const char* ColorResetCode = "\033[m";
@@ -150,7 +152,7 @@ void Logger::write(Level level, Location location, std::string message)
 
     // Print the message to stderr.
     memory::Stream::stdErr.printf("{}[{}] [{}] {}: {}{}\n", levelColor(level), timestamp.string(), location.string(),
-                                  levelString(level), message, ColorResetCode);
+                                  toLower(EnumTrait::toString(level)), message, ColorResetCode);
 
     // Store the log entry.
     state().entries.emplace_back(Entry{

--- a/core/src/cubos/core/memory/any_value.cpp
+++ b/core/src/cubos/core/memory/any_value.cpp
@@ -3,6 +3,7 @@
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/any_value.hpp>
 #include <cubos/core/memory/move.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 

--- a/core/src/cubos/core/memory/buffer_stream.cpp
+++ b/core/src/cubos/core/memory/buffer_stream.cpp
@@ -88,6 +88,11 @@ const void* BufferStream::getBuffer() const
     return mBuffer;
 }
 
+std::string BufferStream::string() const
+{
+    return std::string{static_cast<const char*>(mBuffer), mPosition};
+}
+
 std::size_t BufferStream::read(void* data, std::size_t size)
 {
     std::size_t bytesRemaining = mSize - mPosition;

--- a/core/src/cubos/core/memory/stream.cpp
+++ b/core/src/cubos/core/memory/stream.cpp
@@ -1,9 +1,12 @@
 #include <array>
 #include <cctype>
+#include <cmath>
+#include <cstring>
 
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/standard_stream.hpp>
 #include <cubos/core/memory/stream.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 using namespace cubos::core::memory;
 

--- a/core/src/cubos/core/reflection/external/cstring.cpp
+++ b/core/src/cubos/core/reflection/external/cstring.cpp
@@ -1,0 +1,18 @@
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+CUBOS_REFLECT_EXTERNAL_IMPL(const char*)
+{
+    return Type::create("const char*")
+        .with(StringConversionTrait{
+            [](const void* instance) { return std::string{*static_cast<const char* const*>(instance)}; },
+            [](void*, const std::string&) { return false; }});
+}
+
+CUBOS_REFLECT_EXTERNAL_IMPL(char*)
+{
+    return Type::create("char*").with(
+        StringConversionTrait{[](const void* instance) { return std::string{*static_cast<char* const*>(instance)}; },
+                              [](void*, const std::string&) { return false; }});
+}

--- a/core/src/cubos/core/reflection/external/primitives.cpp
+++ b/core/src/cubos/core/reflection/external/primitives.cpp
@@ -2,21 +2,27 @@
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-#define AUTO_IMPL(type, name)                                                                                          \
+#define AUTO_IMPL(type)                                                                                                \
     CUBOS_REFLECT_EXTERNAL_IMPL(type)                                                                                  \
     {                                                                                                                  \
-        return Type::create(name).with(ConstructibleTrait::typed<type>().withBasicConstructors().build());             \
+        return Type::create(#type).with(ConstructibleTrait::typed<type>().withBasicConstructors().build());            \
     }
 
-AUTO_IMPL(bool, "bool")
-AUTO_IMPL(char, "char")
-AUTO_IMPL(int8_t, "int8_t")
-AUTO_IMPL(int16_t, "int16_t")
-AUTO_IMPL(int32_t, "int32_t")
-AUTO_IMPL(int64_t, "int64_t")
-AUTO_IMPL(uint8_t, "uint8_t")
-AUTO_IMPL(uint16_t, "uint16_t")
-AUTO_IMPL(uint32_t, "uint32_t")
-AUTO_IMPL(uint64_t, "uint64_t")
-AUTO_IMPL(float, "float")
-AUTO_IMPL(double, "double")
+AUTO_IMPL(bool)
+
+AUTO_IMPL(char)
+
+AUTO_IMPL(signed char)
+AUTO_IMPL(short)
+AUTO_IMPL(int)
+AUTO_IMPL(long)
+AUTO_IMPL(long long)
+
+AUTO_IMPL(unsigned char)
+AUTO_IMPL(unsigned short)
+AUTO_IMPL(unsigned int)
+AUTO_IMPL(unsigned long)
+AUTO_IMPL(unsigned long long)
+
+AUTO_IMPL(float)
+AUTO_IMPL(double)

--- a/core/src/cubos/core/reflection/external/string.cpp
+++ b/core/src/cubos/core/reflection/external/string.cpp
@@ -1,8 +1,15 @@
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/traits/string_conversion.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 CUBOS_REFLECT_EXTERNAL_IMPL(std::string)
 {
-    return Type::create("std::string").with(ConstructibleTrait::typed<std::string>().withBasicConstructors().build());
+    return Type::create("std::string")
+        .with(ConstructibleTrait::typed<std::string>().withBasicConstructors().build())
+        .with(StringConversionTrait{[](const void* instance) { return *static_cast<const std::string*>(instance); },
+                                    [](void* instance, const std::string& string) {
+                                        *static_cast<std::string*>(instance) = string;
+                                        return true;
+                                    }});
 }

--- a/core/src/cubos/core/reflection/external/string_view.cpp
+++ b/core/src/cubos/core/reflection/external/string_view.cpp
@@ -1,0 +1,11 @@
+#include <cubos/core/reflection/external/string_view.hpp>
+#include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+CUBOS_REFLECT_EXTERNAL_IMPL(std::string_view)
+{
+    return Type::create("std::string_view")
+        .with(StringConversionTrait{
+            [](const void* instance) { return std::string{*static_cast<const std::string_view*>(instance)}; },
+            [](void*, const std::string&) { return false; }});
+}

--- a/core/src/cubos/core/reflection/traits/enum.cpp
+++ b/core/src/cubos/core/reflection/traits/enum.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/enum.hpp>
 
 using cubos::core::reflection::EnumTrait;

--- a/core/src/cubos/core/reflection/traits/fields.cpp
+++ b/core/src/cubos/core/reflection/traits/fields.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 
 using namespace cubos::core::reflection;

--- a/core/src/cubos/core/reflection/type.cpp
+++ b/core/src/cubos/core/reflection/type.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 using namespace cubos::core::reflection;

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -15,7 +15,9 @@ add_executable(
     reflection/traits/nullable.cpp
     reflection/traits/enum.cpp
     reflection/external/primitives.cpp
+    reflection/external/cstring.cpp
     reflection/external/string.cpp
+    reflection/external/string_view.cpp
     reflection/external/uuid.cpp
     reflection/external/glm.cpp
     reflection/external/vector.cpp
@@ -40,6 +42,7 @@ add_executable(
     ecs/world.cpp
     ecs/query.cpp
     ecs/blueprint.cpp
+
     ecs/commands.cpp
     ecs/system.cpp
     ecs/dispatcher.cpp

--- a/core/tests/data/des/json.cpp
+++ b/core/tests/data/des/json.cpp
@@ -14,6 +14,7 @@
 
 #include "../utils.hpp"
 
+using cubos::core::Logger;
 using cubos::core::data::JSONDeserializer;
 using cubos::core::reflection::autoConstructibleTrait;
 using cubos::core::reflection::FieldsTrait;
@@ -88,7 +89,7 @@ TEST_CASE("data::JSONDeserializer")
 {
     using Json = nlohmann::json;
 
-    cubos::core::disableLogging();
+    Logger::level(Logger::Level::Critical);
 
     JSONDeserializer des{};
 

--- a/core/tests/data/fs/embedded_archive.cpp
+++ b/core/tests/data/fs/embedded_archive.cpp
@@ -5,6 +5,7 @@
 
 #include "../utils.hpp"
 
+using cubos::core::Logger;
 using cubos::core::data::EmbeddedArchive;
 using cubos::core::data::File;
 using cubos::core::memory::SeekOrigin;
@@ -32,7 +33,7 @@ static const EmbeddedArchive::Data MultipleData = {MultipleEntries,
 
 TEST_CASE("data::EmbeddedArchive")
 {
-    cubos::core::disableLogging();
+    Logger::level(Logger::Level::Critical);
 
     // Must use static since there are multiple subcases.
     static bool registered = false;

--- a/core/tests/data/fs/file_system.cpp
+++ b/core/tests/data/fs/file_system.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include <doctest/doctest.h>
 
 #include <cubos/core/data/fs/archive.hpp>
@@ -7,6 +9,7 @@
 
 #include "../utils.hpp"
 
+using cubos::core::Logger;
 using cubos::core::data::Archive;
 using cubos::core::data::File;
 using cubos::core::data::FileSystem;
@@ -61,7 +64,7 @@ inline void unmountAll(const File::Handle& handle)
 
 TEST_CASE("data::FileSystem") // NOLINT(readability-function-size)
 {
-    cubos::core::disableLogging();
+    Logger::level(Logger::Level::Critical);
     unmountAll(FileSystem::root());
 
     SUBCASE("without anything mounted")

--- a/core/tests/data/ser/debug.cpp
+++ b/core/tests/data/ser/debug.cpp
@@ -70,7 +70,7 @@ TEST_CASE("data::DebugSerializer")
     AUTO_TEST(double, 1.F, "1.0000", true);
     AUTO_TEST(std::string, "Hello, world!", "\"Hello, world!\"", true);
     AUTO_TEST(uuids::uuid, *uuids::uuid::from_string("f7063cd4-de44-47b5-b0a9-f0e7a558c9e5"),
-              "f7063cd4-de44-47b5-b0a9-f0e7a558c9e5", true);
+              "\"f7063cd4-de44-47b5-b0a9-f0e7a558c9e5\"", true);
 
     std::map<std::string, bool> map{{"false", false}, {"true", true}};
     AUTO_TEST_SPLIT(decltype(map), map, "{\"false\": false, \"true\": true}",

--- a/core/tests/ecs/dispatcher.cpp
+++ b/core/tests/ecs/dispatcher.cpp
@@ -3,6 +3,7 @@
 #include <doctest/doctest.h>
 
 #include <cubos/core/ecs/system/dispatcher.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include "utils.hpp"
 

--- a/core/tests/ecs/registry.cpp
+++ b/core/tests/ecs/registry.cpp
@@ -26,30 +26,30 @@ TEST_CASE("ecs::Registry")
     Blueprint blueprint{};
     auto entity = blueprint.create("entity");
 
-    // Initially type int32_t isn't registered.
-    CHECK(Registry::type("int32_t") == nullptr);
+    // Initially type int isn't registered.
+    CHECK(Registry::type("int") == nullptr);
 
     // After registering, it can now be found.
-    Registry::add<int32_t, VecStorage<int32_t>>();
-    REQUIRE(Registry::type("int32_t") != nullptr);
-    CHECK(Registry::type("int32_t") == &reflect<int32_t>());
+    Registry::add<int, VecStorage<int>>();
+    REQUIRE(Registry::type("int") != nullptr);
+    CHECK(Registry::type("int") == &reflect<int>());
 
     // Create a storage for it and check if its of the correct type.
-    auto storage = Registry::createStorage(reflect<int32_t>());
-    CHECK(dynamic_cast<VecStorage<int32_t>*>(storage.get()) != nullptr);
+    auto storage = Registry::createStorage(reflect<int>());
+    CHECK(dynamic_cast<VecStorage<int>*>(storage.get()) != nullptr);
 
     // Instantiate the component into a blueprint, from a package.
-    auto pkg = Package::from<int32_t>(42);
+    auto pkg = Package::from<int>(42);
     Unpackager unpackager{pkg};
-    REQUIRE(Registry::create("int32_t", unpackager, blueprint, entity));
+    REQUIRE(Registry::create("int", unpackager, blueprint, entity));
 
     // Spawn the blueprint into the world.
-    world.registerComponent<int32_t>();
+    world.registerComponent<int>();
     entity = cmds.spawn(blueprint).entity("entity");
     cmdBuffer.commit();
 
     // Package the entity and check if the component was correctly instantiated.
     pkg = world.pack(entity);
     REQUIRE(pkg.fields().size() == 1);
-    CHECK(pkg.field("int32_t").get<int32_t>() == 42);
+    CHECK(pkg.field("int").get<int>() == 42);
 }

--- a/core/tests/reflection/external/cstring.cpp
+++ b/core/tests/reflection/external/cstring.cpp
@@ -1,0 +1,19 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/external/cstring.hpp>
+
+#include "../traits/string_conversion.hpp"
+
+TEST_CASE("reflection::reflect<const char*>()")
+{
+    CHECK(reflect<const char*>().name() == "const char*");
+    testConstStringConversion<const char*>({{"", ""}, {"Hello World!", "Hello World!"}});
+}
+
+TEST_CASE("reflection::reflect<char*>()")
+{
+    CHECK(reflect<char*>().name() == "char*");
+
+    char value[] = "Hello World!";
+    testConstStringConversion<char*>({{value, "Hello World!"}});
+}

--- a/core/tests/reflection/external/map.cpp
+++ b/core/tests/reflection/external/map.cpp
@@ -16,7 +16,7 @@ static void test(const char* name, std::map<K, V> map, K insertedKey, V inserted
 
 TEST_CASE("reflection::reflect<std::map<K, V>>()")
 {
-    test<int32_t, int32_t>("std::map<int32_t, int32_t>", {{1, 2}, {2, 4}}, 3, 6);
+    test<int, int>("std::map<int, int>", {{1, 2}, {2, 4}}, 3, 6);
     test<char, std::map<char, bool>>("std::map<char, std::map<char, bool>>",
                                      {
                                          {'H', {{'i', true}, {'o', false}}},

--- a/core/tests/reflection/external/primitives.cpp
+++ b/core/tests/reflection/external/primitives.cpp
@@ -15,15 +15,21 @@ static void test(const char* name, T value)
 TEST_CASE("reflection::reflect<(primitives)>()")
 {
     test<bool>("bool", true);
+
     test<char>("char", 'A');
-    test<int8_t>("int8_t", INT8_MAX);
-    test<int16_t>("int16_t", INT16_MIN);
-    test<int32_t>("int32_t", INT32_MAX);
-    test<int64_t>("int64_t", INT64_MIN);
-    test<uint8_t>("uint8_t", UINT8_MAX);
-    test<uint16_t>("uint16_t", UINT16_MAX);
-    test<uint32_t>("uint32_t", UINT32_MAX);
-    test<uint64_t>("uint64_t", UINT64_MAX);
+
+    test<signed char>("signed char", INT8_MAX);
+    test<short>("short", INT16_MIN);
+    test<int>("int", INT16_MAX);
+    test<long>("long", INT32_MIN);
+    test<long long>("long long", INT64_MAX);
+
+    test<unsigned char>("unsigned char", UINT8_MAX);
+    test<unsigned short>("unsigned short", UINT16_MAX);
+    test<unsigned int>("unsigned int", UINT16_MAX);
+    test<unsigned long>("unsigned long", UINT32_MAX);
+    test<unsigned long long>("unsigned long long", UINT64_MAX);
+
     test<float>("float", 3.14159F);
     test<double>("double", 0.123456789);
 }

--- a/core/tests/reflection/external/string.cpp
+++ b/core/tests/reflection/external/string.cpp
@@ -4,10 +4,12 @@
 #include <cubos/core/reflection/traits/constructible.hpp>
 
 #include "../traits/constructible.hpp"
+#include "../traits/string_conversion.hpp"
 
 TEST_CASE("reflection::reflect<std::string>()")
 {
     std::string value = "Hello, world!";
     CHECK(reflect<std::string>().name() == "std::string");
     testConstructible<std::string>(&value);
+    testStringConversion<std::string>({{"", ""}, {"Hello World!", "Hello World!"}}, {});
 }

--- a/core/tests/reflection/external/string_view.cpp
+++ b/core/tests/reflection/external/string_view.cpp
@@ -1,0 +1,11 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/external/string_view.hpp>
+
+#include "../traits/string_conversion.hpp"
+
+TEST_CASE("reflection::reflect<std::string_view>()")
+{
+    CHECK(reflect<std::string_view>().name() == "std::string_view");
+    testConstStringConversion<std::string_view>({{"", ""}, {"Hello World!", "Hello World!"}});
+}

--- a/core/tests/reflection/external/unordered_map.cpp
+++ b/core/tests/reflection/external/unordered_map.cpp
@@ -16,7 +16,7 @@ static void test(const char* name, std::unordered_map<K, V> map, K insertedKey, 
 
 TEST_CASE("reflection::reflect<std::unordered_map<K, V>>()")
 {
-    test<int32_t, int32_t>("std::unordered_map<int32_t, int32_t>", {{1, 2}, {2, 4}}, 3, 6);
+    test<int, int>("std::unordered_map<int, int>", {{1, 2}, {2, 4}}, 3, 6);
     test<char, std::unordered_map<char, bool>>("std::unordered_map<char, std::unordered_map<char, bool>>",
                                                {
                                                    {'H', {{'i', true}, {'o', false}}},

--- a/core/tests/reflection/external/vector.cpp
+++ b/core/tests/reflection/external/vector.cpp
@@ -16,7 +16,7 @@ static void test(const char* name, std::vector<T> vec, T inserted)
 
 TEST_CASE("reflection::reflect<std::vector<T>>()")
 {
-    test<int32_t>("std::vector<int32_t>", {5, 4, 1}, 1);
+    test<int>("std::vector<int>", {5, 4, 1}, 1);
     test<std::vector<std::vector<char>>>("std::vector<std::vector<std::vector<char>>>", {{{'H'}, {'e'}}, {{'y', '!'}}},
                                          {{'o'}});
 }

--- a/core/tests/reflection/traits/string_conversion.hpp
+++ b/core/tests/reflection/traits/string_conversion.hpp
@@ -36,3 +36,19 @@ void testStringConversion(std::initializer_list<std::pair<T, std::string>> corre
         CHECK_FALSE(trait.from(&result, string));
     }
 }
+
+/// @brief Checks if a type's StringConversionTrait works as expected for a const type.
+/// @tparam T Type.
+/// @param expected Expected string representations for each given value.
+template <typename T>
+void testConstStringConversion(std::initializer_list<std::pair<T, std::string>> expected)
+{
+    const Type& type = reflect<T>();
+    REQUIRE(type.has<StringConversionTrait>());
+    const StringConversionTrait& trait = type.get<StringConversionTrait>();
+
+    for (const auto& [value, string] : expected)
+    {
+        CHECK(trait.into(&value) == string);
+    }
+}

--- a/docs/pages/1_getting_started/main.md
+++ b/docs/pages/1_getting_started/main.md
@@ -22,7 +22,6 @@ The following dependencies are used to compile **CUBOS.**:
 | [glad](https://github.com/Dav1dde/glad)             | Essential                 | `core/lib/glad`    | No                   | 2.0.4    |
 | [glfw](https://github.com/glfw/glfw)                | Essential                 | `core/lib/glfw`    | Optionally           | 3.3.8    |
 | [glm](https://github.com/g-truc/glm)                | Essential                 | `core/lib/glm`     | Optionally           | 0.9.9.8  |
-| [spdlog](https://github.com/gabime/spdlog)          | Essential                 | `core/lib/spdlog`  | Optionally (broken)  | 1.9.1    |
 | [fmt](https://github.com/fmtlib/fmt)                | Essential                 | `core/lib/fmt`     | Optionally (broken)  | 8.0.1    |
 | [stduuid](https://github.com/mariusbancila/stduuid) | Essential                 | `core/lib/stduuid` | No                   | 1.2.3    |
 | [doctest](https://github.com/doctest/doctest)       | Required for tests        | `core/lib/doctest` | Optionally           | 2.4.11   |
@@ -78,7 +77,6 @@ The following is a list of all the options available to configure the engine:
 | `GLFW_USE_SUBMODULE`    | Compile glfw from source?            |
 | `GLM_USE_SUBMODULE`     | Compile glm from source?             |
 | `DOCTEST_USE_SUBMODULE` | Compile doctest from source?         |
-| `SPDLOG_USE_SUBMODULE`  | Compile spdlog from source?          |
 | `FMT_USE_SUBMODULE`     | Compile fmt from source?             |
 | `BUILD_CORE_SAMPLES`    | Build **CUBOS.** `core` samples?     |
 | `BUILD_CORE_TESTS`      | Build **CUBOS.** `core` tests?       |

--- a/docs/pages/1_getting_started/main.md
+++ b/docs/pages/1_getting_started/main.md
@@ -22,7 +22,6 @@ The following dependencies are used to compile **CUBOS.**:
 | [glad](https://github.com/Dav1dde/glad)             | Essential                 | `core/lib/glad`    | No                   | 2.0.4    |
 | [glfw](https://github.com/glfw/glfw)                | Essential                 | `core/lib/glfw`    | Optionally           | 3.3.8    |
 | [glm](https://github.com/g-truc/glm)                | Essential                 | `core/lib/glm`     | Optionally           | 0.9.9.8  |
-| [fmt](https://github.com/fmtlib/fmt)                | Essential                 | `core/lib/fmt`     | Optionally (broken)  | 8.0.1    |
 | [stduuid](https://github.com/mariusbancila/stduuid) | Essential                 | `core/lib/stduuid` | No                   | 1.2.3    |
 | [doctest](https://github.com/doctest/doctest)       | Required for tests        | `core/lib/doctest` | Optionally           | 2.4.11   |
 | [imgui](https://github.com/ocornut/imgui)           | Required for imgui plugin | `engine/lib/imgui` | No                   | 1.89.9   |
@@ -77,7 +76,6 @@ The following is a list of all the options available to configure the engine:
 | `GLFW_USE_SUBMODULE`    | Compile glfw from source?            |
 | `GLM_USE_SUBMODULE`     | Compile glm from source?             |
 | `DOCTEST_USE_SUBMODULE` | Compile doctest from source?         |
-| `FMT_USE_SUBMODULE`     | Compile fmt from source?             |
 | `BUILD_CORE_SAMPLES`    | Build **CUBOS.** `core` samples?     |
 | `BUILD_CORE_TESTS`      | Build **CUBOS.** `core` tests?       |
 | `BUILD_ENGINE_SAMPLES`  | Build **CUBOS.** `engine` samples?   |

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/ecs/system/event/reader.hpp>
 #include <cubos/core/ecs/system/event/writer.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/cubos.hpp>
 

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -1,11 +1,10 @@
-#include <cubos/core/data/old/debug_serializer.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/input/bindings.hpp>
 #include <cubos/engine/input/plugin.hpp>
 #include <cubos/engine/settings/settings.hpp>
 
-using cubos::core::data::old::Debug;
 using cubos::core::io::Window;
 
 using namespace cubos::engine;
@@ -214,7 +213,7 @@ static void init(Read<Assets> assets, Write<Input> input)
 {
     auto bindings = assets->read<InputBindings>(BindingsAsset);
     input->bind(*bindings);
-    CUBOS_INFO("Loaded bindings: {}", Debug(input->bindings().at(0)));
+    CUBOS_INFO("Loaded bindings: {}", input->bindings().at(0));
 }
 /// [Loading the bindings]
 

--- a/engine/samples/settings/main.cpp
+++ b/engine/samples/settings/main.cpp
@@ -1,3 +1,5 @@
+#include <cubos/core/reflection/external/string.hpp>
+
 #include <cubos/engine/cubos.hpp>
 #include <cubos/engine/settings/plugin.hpp>
 

--- a/engine/src/cubos/engine/assets/asset.cpp
+++ b/engine/src/cubos/engine/assets/asset.cpp
@@ -1,6 +1,8 @@
 #include <cubos/core/data/old/deserializer.hpp>
 #include <cubos/core/data/old/serializer.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/string_view.hpp>
 #include <cubos/core/reflection/external/uuid.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>

--- a/engine/src/cubos/engine/assets/bridges/file.cpp
+++ b/engine/src/cubos/engine/assets/bridges/file.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/data/fs/file_system.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 #include <cubos/engine/assets/bridges/file.hpp>
 

--- a/engine/src/cubos/engine/cubos.cpp
+++ b/engine/src/cubos/engine/cubos.cpp
@@ -2,6 +2,7 @@
 
 #include <cubos/core/ecs/system/commands.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 #include <cubos/engine/cubos.hpp>
 
@@ -119,8 +120,6 @@ Cubos::Cubos()
 Cubos::Cubos(int argc, char** argv)
 {
     std::vector<std::string> arguments(argv + 1, argv + argc);
-
-    core::initializeLogger();
 
     this->addResource<DeltaTime>(0.0F);
     this->addResource<ShouldQuit>(true);

--- a/engine/src/cubos/engine/input/axis.cpp
+++ b/engine/src/cubos/engine/input/axis.cpp
@@ -2,6 +2,7 @@
 
 #include <cubos/core/io/keyboard.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/input/axis.hpp>
 

--- a/engine/src/cubos/engine/input/input.cpp
+++ b/engine/src/cubos/engine/input/input.cpp
@@ -1,4 +1,7 @@
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 #include <cubos/engine/input/input.hpp>
 

--- a/engine/src/cubos/engine/renderer/deferred_renderer.cpp
+++ b/engine/src/cubos/engine/renderer/deferred_renderer.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <random>
 
 #include <glm/gtc/matrix_transform.hpp>
@@ -8,6 +9,7 @@
 #include <cubos/core/gl/debug.hpp>
 #include <cubos/core/gl/util.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/renderer/deferred_renderer.hpp>
 #include <cubos/engine/renderer/frame.hpp>

--- a/engine/src/cubos/engine/settings/plugin.cpp
+++ b/engine/src/cubos/engine/settings/plugin.cpp
@@ -1,6 +1,7 @@
 #include <cubos/core/data/fs/file_system.hpp>
 #include <cubos/core/data/fs/standard_archive.hpp>
 #include <cubos/core/data/old/json_deserializer.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
 #include <cubos/engine/settings/plugin.hpp>
 

--- a/engine/src/cubos/engine/voxels/grid.cpp
+++ b/engine/src/cubos/engine/voxels/grid.cpp
@@ -1,6 +1,8 @@
 #include <unordered_map>
 
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
@@ -21,9 +23,8 @@ VoxelGrid::VoxelGrid(const glm::uvec3& size)
 {
     if (size.x < 1 || size.y < 1 || size.z < 1)
     {
-        CUBOS_WARN("Grid size must be at least 1 in each dimension: was ({}, {}, {}), defaulting to (1, 1, 1).", size.x,
-                   size.y, size.z);
         mSize = {1, 1, 1};
+        CUBOS_WARN("Grid size must be at least 1 in each dimension: was {}, defaulting to {}", size, mSize);
     }
     else
     {
@@ -38,15 +39,13 @@ VoxelGrid::VoxelGrid(const glm::uvec3& size, const std::vector<uint16_t>& indice
 {
     if (size.x < 1 || size.y < 1 || size.z < 1)
     {
-        CUBOS_WARN("Grid size must be at least 1 in each dimension: was ({}, {}, {}), defaulting to (1, 1, 1).", size.x,
-                   size.y, size.z);
         mSize = {1, 1, 1};
+        CUBOS_WARN("Grid size must be at least 1 in each dimension: was {}, defaulting to {}", size, mSize);
     }
     else if (indices.size() !=
              static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * static_cast<std::size_t>(size.z))
     {
-        CUBOS_WARN("Grid size and indices size mismatch: was ({}, {}, {}), indices size is {}.", size.x, size.y, size.z,
-                   indices.size());
+        CUBOS_WARN("Grid size and indices size mismatch: was {}, indices size is {}", size, indices.size());
         mSize = {1, 1, 1};
     }
     else
@@ -170,8 +169,8 @@ void cubos::core::data::old::deserialize(Deserializer& deserializer, VoxelGrid& 
 
     if (grid.mSize.x * grid.mSize.y * grid.mSize.z != static_cast<unsigned int>(grid.mIndices.size()))
     {
-        CUBOS_WARN("Grid size and indices size mismatch: was ({}, {}, {}), indices size is {}.", grid.mSize.x,
-                   grid.mSize.y, grid.mSize.z, grid.mIndices.size());
+        CUBOS_WARN("Grid size and indices size mismatch: was {}, indices size is {}.", grid.mSize,
+                   grid.mIndices.size());
         grid.mSize = {1, 1, 1};
         grid.mIndices.clear();
         grid.mIndices.resize(1, 0);

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
             # = libs =
             glfw
             glm
-            # spdlog
             # fmt
             doctest
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
             # = libs =
             glfw
             glm
-            # fmt
             doctest
 
             # = system libs =

--- a/tools/quadrados/src/convert.cpp
+++ b/tools/quadrados/src/convert.cpp
@@ -8,6 +8,7 @@
 #include <cubos/core/log.hpp>
 #include <cubos/core/memory/endianness.hpp>
 #include <cubos/core/memory/standard_stream.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/voxels/grid.hpp>
 #include <cubos/engine/voxels/palette.hpp>

--- a/tools/tesseratos/src/tesseratos/scene_editor/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/scene_editor/plugin.cpp
@@ -4,8 +4,8 @@
 #include <imgui.h>
 #include <misc/cpp/imgui_stdlib.h>
 
-#include <cubos/core/data/old/debug_serializer.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 #include <cubos/core/reflection/type.hpp>
 
@@ -16,8 +16,6 @@
 #include <tesseratos/asset_explorer/plugin.hpp>
 #include <tesseratos/entity_selector/plugin.hpp>
 #include <tesseratos/scene_editor/plugin.hpp>
-
-using cubos::core::data::old::Debug;
 
 using cubos::core::ecs::Commands;
 using cubos::core::ecs::Entity;
@@ -100,7 +98,7 @@ static void checkAssetEventSystem(cubos::core::ecs::EventReader<AssetSelectedEve
     {
         if (assets->type(event.asset).is<Scene>())
         {
-            CUBOS_INFO("Opening scene {}", Debug(event.asset));
+            CUBOS_INFO("Opening scene {}", event.asset);
             openScene(event.asset, commands, *assets, *scene);
         }
     }

--- a/tools/tesseratos/src/tesseratos/voxel_palette_editor/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/voxel_palette_editor/plugin.cpp
@@ -1,6 +1,5 @@
 #include <imgui.h>
 
-#include <cubos/core/data/old/debug_serializer.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/reflection/type.hpp>
 
@@ -11,7 +10,6 @@
 #include <tesseratos/asset_explorer/plugin.hpp>
 #include <tesseratos/voxel_palette_editor/plugin.hpp>
 
-using cubos::core::data::old::Debug;
 using cubos::core::ecs::EventReader;
 using cubos::core::ecs::Read;
 using cubos::core::ecs::Write;
@@ -54,7 +52,7 @@ static void savePaletteUiGuard(Write<Assets> assets, Write<SelectedPaletteInfo> 
 
         if (ImGui::Button("Yes", ImVec2(80, 0)))
         {
-            CUBOS_INFO("Saving palette asset {} modificaations", Debug(selectedPalette->next));
+            CUBOS_INFO("Saving palette asset {} modificaations", selectedPalette->next);
             assets->store(selectedPalette->asset, selectedPalette->paletteCopy);
             assets->save(selectedPalette->asset);
             optionSelected = true;
@@ -65,7 +63,7 @@ static void savePaletteUiGuard(Write<Assets> assets, Write<SelectedPaletteInfo> 
 
         if (ImGui::Button("No", ImVec2(80, 0)))
         {
-            CUBOS_DEBUG("Discarding palette asset {} modifications", Debug(selectedPalette->next));
+            CUBOS_DEBUG("Discarding palette asset {} modifications", selectedPalette->next);
             optionSelected = true;
         }
 
@@ -95,7 +93,7 @@ static void checkAssetEventSystem(EventReader<AssetSelectedEvent> reader, Write<
     {
         if (assets->type(event.asset).is<VoxelPalette>())
         {
-            CUBOS_INFO("Opening palette asset {}", Debug(event.asset));
+            CUBOS_INFO("Opening palette asset {}", event.asset);
             if (!selectedPalette->asset.isNull() && selectedPalette->modified)
             {
                 CUBOS_DEBUG("Opening save palette UI guard");


### PR DESCRIPTION
# Description

Implements our own `Logger`, which no longer uses `spdlog` (functionally identical tho).
Also comes with a function which can be used to read the logs. Will be useful for implementing #274.
This refactor enables us to drop the old `Debug{}` shenanigan used to print non-primitive types, and to remove both the `fmt` and `spdlog` dependencies. One of disadvantages is having to include the external reflection header when trying to print external types, but I think its the best approach out of the two options.
This should also allow us to remove the old `DebugSerializer` entirely, but that will be left to the PR which nukes `data::old`.

Check out the commit messages, they are helpful to understand what I needed to change.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~ (is it worth it to test the logger? :thinking:)
- [x] Update samples.
