### PR TITLE
Remove `[un]packs` from the ECS

### DIFF
--- a/core/include/cubos/core/ecs/component/manager.hpp
+++ b/core/include/cubos/core/ecs/component/manager.hpp
@@ -158,22 +158,6 @@ namespace cubos::core::ecs
         /// @copydoc storage(std::size_t)
         const IStorage* storage(std::size_t id) const;
 
-        /// @brief Creates a package from a component of an entity.
-        /// @param id Entity index.
-        /// @param componentId Component identifier.
-        /// @param context Optional context to use for serialization.
-        /// @return Package containing the component.
-        data::old::Package pack(uint32_t id, std::size_t componentId, data::old::Context* context) const;
-
-        /// @brief Inserts a component into an entity, by unpacking a package.
-        /// @param id Entity index.
-        /// @param componentId Component identifier.
-        /// @param package Package to unpack.
-        /// @param context Optional context to use for deserialization.
-        /// @return Whether the unpacking was successful.
-        bool unpack(uint32_t id, std::size_t componentId, const data::old::Package& package,
-                    data::old::Context* context);
-
     private:
         struct Entry
         {

--- a/core/include/cubos/core/ecs/component/registry.hpp
+++ b/core/include/cubos/core/ecs/component/registry.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include <cubos/core/data/old/deserializer.hpp>
+#include <cubos/core/data/old/serializer.hpp>
 #include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/component/storage.hpp>
 #include <cubos/core/memory/type_map.hpp>

--- a/core/include/cubos/core/ecs/component/storage.hpp
+++ b/core/include/cubos/core/ecs/component/storage.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <cubos/core/data/old/package.hpp>
-#include <cubos/core/data/old/serialization_map.hpp>
 #include <cubos/core/ecs/entity/manager.hpp>
 
 namespace cubos::core::ecs
@@ -39,23 +37,6 @@ namespace cubos::core::ecs
         /// @param index Index of the value to be retrieved.
         /// @return Pointer to the value.
         virtual const void* get(uint32_t index) const = 0;
-
-        /// @brief Packages a value. If the value doesn't exist, undefined behavior will occur.
-        /// @param index Index of the value to package.
-        /// @param context Optional context used for serialization.
-        /// @return Packaged value.
-        virtual data::old::Package pack(uint32_t index, data::old::Context* context) const = 0;
-
-        /// @brief Unpackages a value.
-        /// @param index Index of the value to unpackage.
-        /// @param package Package to unpackage.
-        /// @param context Optional context used for deserialization.
-        /// @return Whether the unpackaging was successful.
-        virtual bool unpack(uint32_t index, const data::old::Package& package, data::old::Context* context) = 0;
-
-        /// @brief Gets the type the components being stored here.
-        /// @return Component type.
-        virtual std::type_index type() const = 0;
     };
 
     /// @brief Abstract container for a component type @p T.
@@ -67,29 +48,5 @@ namespace cubos::core::ecs
     public:
         /// @brief Component type.
         using Type = T;
-
-        // Implementation.
-
-        inline data::old::Package pack(uint32_t index, data::old::Context* context) const override
-        {
-            return data::old::Package::from(*static_cast<const T*>(this->get(index)), context);
-        }
-
-        inline bool unpack(uint32_t index, const data::old::Package& package, data::old::Context* context) override
-        {
-            T value;
-            if (package.into(value, context))
-            {
-                this->insert(index, &value);
-                return true;
-            }
-
-            return false;
-        }
-
-        inline std::type_index type() const override
-        {
-            return std::type_index(typeid(T));
-        }
     };
 } // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/resource/manager.hpp
+++ b/core/include/cubos/core/ecs/resource/manager.hpp
@@ -4,12 +4,14 @@
 
 #pragma once
 
+#include <functional>
 #include <shared_mutex>
 #include <typeindex>
 #include <unordered_map>
 #include <utility>
 
 #include <cubos/core/ecs/world.hpp>
+#include <cubos/core/log.hpp>
 
 namespace cubos::core::ecs
 {

--- a/core/include/cubos/core/ecs/system/commands.hpp
+++ b/core/include/cubos/core/ecs/system/commands.hpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <cubos/core/data/old/serialization_map.hpp>
 #include <cubos/core/ecs/entity/hash.hpp>
 #include <cubos/core/ecs/world.hpp>
 #include <cubos/core/memory/any_value.hpp>

--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <typeindex>
 #include <unordered_set>
+#include <variant>
 
 #include <cubos/core/ecs/system/accessors.hpp>
 #include <cubos/core/ecs/system/commands.hpp>

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -12,6 +12,7 @@
 #include <cubos/core/ecs/entity/manager.hpp>
 #include <cubos/core/ecs/resource/manager.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/external/string_view.hpp>
 #include <cubos/core/reflection/type.hpp>
@@ -95,22 +96,6 @@ namespace cubos::core::ecs
 
         /// @copydoc components(Entity)
         ConstComponents components(Entity entity) const;
-
-        /// @brief Creates a package from the components of an entity.
-        /// @param entity Entity identifier.
-        /// @param context Optional context for serializing the components.
-        /// @return Package containing the components of the entity.
-        data::old::Package pack(Entity entity, data::old::Context* context = nullptr) const;
-
-        /// @brief Unpacks components specified in a package into an entity.
-        ///
-        /// Removes any components that are already present in the entity.
-        ///
-        /// @param entity Entity identifier.
-        /// @param package Package to unpack.
-        /// @param context Optional context for deserializing the components.
-        /// @return Whether the package was unpacked successfully.
-        bool unpack(Entity entity, const data::old::Package& package, data::old::Context* context = nullptr);
 
         /// @brief Returns an iterator which points to the first entity of the world.
         /// @return Iterator.

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/ecs/component/manager.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
+#include <cubos/core/log.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/type.hpp>
@@ -73,15 +74,4 @@ ComponentManager::Entry::Entry(std::unique_ptr<IStorage> storage)
     : storage(std::move(storage))
 {
     this->mutex = std::make_unique<std::shared_mutex>();
-}
-
-data::old::Package ComponentManager::pack(uint32_t id, std::size_t componentId, data::old::Context* context) const
-{
-    return mEntries[componentId - 1].storage->pack(id, context);
-}
-
-bool ComponentManager::unpack(uint32_t id, std::size_t componentId, const data::old::Package& package,
-                              data::old::Context* context)
-{
-    return mEntries[componentId - 1].storage->unpack(id, package, context);
 }

--- a/core/src/cubos/core/gl/ogl_render_device.cpp
+++ b/core/src/cubos/core/gl/ogl_render_device.cpp
@@ -28,11 +28,11 @@ static void GLAPIENTRY messageCallback(GLenum source, GLenum type, GLuint id, GL
 
     if (severity == GL_DEBUG_SEVERITY_HIGH)
     {
-        CUBOS_ERROR("OpenGL error (source = 0x{:x}, type = 0x{:x}): {}", source, type, message);
+        CUBOS_ERROR("OpenGL error (source = {}, type = {}): {}", source, type, message);
     }
     else if (severity == GL_DEBUG_SEVERITY_MEDIUM)
     {
-        CUBOS_WARN("OpenGL warning (source = 0x{:x}, type = 0x{:x}): {}", source, type, message);
+        CUBOS_WARN("OpenGL warning (source = {}, type = {}): {}", source, type, message);
     }
 }
 

--- a/core/tests/ecs/blueprint.cpp
+++ b/core/tests/ecs/blueprint.cpp
@@ -6,8 +6,6 @@
 
 #include "utils.hpp"
 
-using cubos::core::data::old::Package;
-using cubos::core::data::old::Unpackager;
 using cubos::core::ecs::Blueprint;
 using cubos::core::ecs::CommandBuffer;
 using cubos::core::ecs::Commands;
@@ -51,16 +49,7 @@ TEST_CASE("ecs::Blueprint")
     auto bar = blueprint.create("bar");
     auto baz = blueprint.create("baz");
     blueprint.add(baz, IntegerComponent{2});
-
-    // Add a ParentComponent to "baz" with id = "bar", using a deserializer.
-    {
-        // Pack the identifier of "bar".
-        auto barPkg = Package::from(bar);
-
-        // Unpack the identifier of "bar" into a ParentComponent.
-        Unpackager unpackager{barPkg};
-        Registry::create("ParentComponent", unpackager, blueprint, baz);
-    }
+    blueprint.add(baz, ParentComponent{bar});
 
     SUBCASE("spawn the blueprint")
     {

--- a/core/tests/ecs/registry.cpp
+++ b/core/tests/ecs/registry.cpp
@@ -1,6 +1,5 @@
 #include <doctest/doctest.h>
 
-#include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/component/vec_storage.hpp>
 #include <cubos/core/ecs/system/commands.hpp>
@@ -8,9 +7,6 @@
 
 #include "utils.hpp"
 
-using cubos::core::data::old::Package;
-using cubos::core::data::old::Unpackager;
-using cubos::core::ecs::Blueprint;
 using cubos::core::ecs::CommandBuffer;
 using cubos::core::ecs::Commands;
 using cubos::core::ecs::Registry;
@@ -23,8 +19,6 @@ TEST_CASE("ecs::Registry")
     World world{};
     CommandBuffer cmdBuffer{world};
     Commands cmds{cmdBuffer};
-    Blueprint blueprint{};
-    auto entity = blueprint.create("entity");
 
     // Initially type int isn't registered.
     CHECK(Registry::type("int") == nullptr);
@@ -37,19 +31,4 @@ TEST_CASE("ecs::Registry")
     // Create a storage for it and check if its of the correct type.
     auto storage = Registry::createStorage(reflect<int>());
     CHECK(dynamic_cast<VecStorage<int>*>(storage.get()) != nullptr);
-
-    // Instantiate the component into a blueprint, from a package.
-    auto pkg = Package::from<int>(42);
-    Unpackager unpackager{pkg};
-    REQUIRE(Registry::create("int", unpackager, blueprint, entity));
-
-    // Spawn the blueprint into the world.
-    world.registerComponent<int>();
-    entity = cmds.spawn(blueprint).entity("entity");
-    cmdBuffer.commit();
-
-    // Package the entity and check if the component was correctly instantiated.
-    pkg = world.pack(entity);
-    REQUIRE(pkg.fields().size() == 1);
-    CHECK(pkg.field("int").get<int>() == 42);
 }

--- a/core/tests/ecs/world.cpp
+++ b/core/tests/ecs/world.cpp
@@ -5,7 +5,6 @@
 
 #include "utils.hpp"
 
-using cubos::core::data::old::Package;
 using cubos::core::ecs::Entity;
 using cubos::core::ecs::World;
 
@@ -80,59 +79,6 @@ TEST_CASE("ecs::World")
         CHECK_FALSE(world.components(foo).has<DetectDestructorComponent>());
         CHECK(constWorld.components(foo).has<ParentComponent>());
         CHECK(destroyed);
-    }
-
-    SUBCASE("add and remove components through pack and unpack")
-    {
-        // Create an entity.
-        auto foo = world.create();
-
-        // Add an integer component.
-        auto pkg = world.pack(foo);
-        pkg.fields().emplace_back("IntegerComponent", Package::from(1));
-        CHECK(world.unpack(foo, pkg));
-        CHECK(world.components(foo).has<IntegerComponent>());
-        CHECK_FALSE(world.components(foo).has<ParentComponent>());
-
-        // Check if the component was added.
-        pkg = world.pack(foo);
-        CHECK(pkg.fields().size() == 1);
-        CHECK(pkg.field("IntegerComponent").get<int>() == 1);
-
-        // Remove the integer component and add a parent component.
-        pkg.removeField("IntegerComponent");
-        pkg.fields().emplace_back("ParentComponent", Package::from(Entity{}));
-        CHECK(world.unpack(foo, pkg));
-        CHECK_FALSE(world.components(foo).has<IntegerComponent>());
-        CHECK(world.components(foo).has<ParentComponent>());
-
-        // Check if the component was added.
-        pkg = world.pack(foo);
-        CHECK(pkg.fields().size() == 1);
-        CHECK(pkg.field("ParentComponent").get<Entity>().isNull());
-    }
-
-    SUBCASE("change a component through pack and unpack")
-    {
-        // Create an entity which has an integer component and a parent component.
-        auto bar = world.create();
-        auto foo = world.create();
-        world.components(foo).add(IntegerComponent{0}).add(ParentComponent{bar});
-        CHECK(world.components(foo).has<IntegerComponent>());
-        CHECK(world.components(foo).has<ParentComponent>());
-
-        // Change the value of the integer component.
-        auto pkg = world.pack(foo);
-        pkg.field("IntegerComponent").set<int>(1);
-        CHECK(world.unpack(foo, pkg));
-        CHECK(world.components(foo).has<IntegerComponent>());
-        CHECK(world.components(foo).has<ParentComponent>());
-
-        // Check if the value was changed.
-        pkg = world.pack(foo);
-        CHECK(pkg.fields().size() == 2);
-        CHECK(pkg.field("IntegerComponent").get<int>() == 1);
-        CHECK(pkg.field("ParentComponent").get<Entity>() == bar);
     }
 
     SUBCASE("components are correctly destructed when their entity is destroyed")

--- a/engine/src/cubos/engine/scene/bridge.cpp
+++ b/engine/src/cubos/engine/scene/bridge.cpp
@@ -3,6 +3,7 @@
 #include <cubos/core/ecs/component/registry.hpp>
 #include <cubos/core/ecs/entity/hash.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/external/unordered_map.hpp>
 


### PR DESCRIPTION
# Description

Removes all `data::old::Package` related code from the ECS, which is not needed anymore after adding reflection and allowing access to the components through `World`.
Fixed a small unrelated bug introduced in #830, where I forgot to update the format string of the OpenGL message callback.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
