### PR TITLE
Allow registering components whose type is unknown at compile time

### DIFF
--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -53,10 +53,16 @@ namespace cubos::core::ecs
         void registerResource(TArgs... args);
 
         /// @brief Registers a component type.
-        /// @note Should be called before other operations, aside from @ref registerResource().
+        /// @param type Component type.
+        void registerComponent(const reflection::Type& type);
+
+        /// @brief Registers a component type.
         /// @tparam T Component type.
-        template <typename T>
-        void registerComponent();
+        template <reflection::Reflectable T>
+        void registerComponent()
+        {
+            this->registerComponent(reflection::reflect<T>());
+        }
 
         /// @brief Locks a resource for reading and returns it.
         /// @tparam T Resource type.
@@ -374,13 +380,6 @@ namespace cubos::core::ecs
     {
         CUBOS_TRACE("Registered resource '{}'", typeid(T).name());
         mResourceManager.add<T>(args...);
-    }
-
-    template <typename T>
-    void World::registerComponent()
-    {
-        CUBOS_TRACE("Registered component '{}'", reflection::reflect<T>().name());
-        mComponentManager.registerType(reflection::reflect<T>());
     }
 
     template <typename T>

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -14,6 +14,12 @@ World::World(std::size_t initialCapacity)
     // Edu: BAH!
 }
 
+void World::registerComponent(const reflection::Type& type)
+{
+    CUBOS_TRACE("Registered component '{}'", type.name());
+    mComponentManager.registerType(type);
+}
+
 Entity World::create()
 {
     Entity::Mask mask{};


### PR DESCRIPTION
# Description

Adds an untyped version of `World::registerComponent`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
