### PR TITLE
feat(reflection): add TypeRegistry

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/memory/any_vector.cpp"
 
     "src/cubos/core/reflection/type.cpp"
+    "src/cubos/core/reflection/type_registry.cpp"
     "src/cubos/core/reflection/traits/constructible.cpp"
     "src/cubos/core/reflection/traits/fields.cpp"
     "src/cubos/core/reflection/traits/array.cpp"

--- a/core/include/cubos/core/reflection/type_registry.hpp
+++ b/core/include/cubos/core/reflection/type_registry.hpp
@@ -16,6 +16,8 @@ namespace cubos::core::reflection
     class TypeRegistry final
     {
     public:
+        using Iterator = typename memory::UnorderedBimap<const Type*, std::string>::Iterator;
+
         /// @brief Registers the given type.
         ///
         /// Does nothing if the type is already registered.
@@ -23,6 +25,10 @@ namespace cubos::core::reflection
         ///
         /// @param type Type to register.
         void insert(const Type& type);
+
+        /// @brief Calls insert for each type in the given type registry.
+        /// @param other Type registry to copy types from.
+        void insert(const TypeRegistry& other);
 
         /// @copydoc insert(const Type&)
         /// @tparam T Type to register.
@@ -61,6 +67,14 @@ namespace cubos::core::reflection
         /// @brief Returns the number of registered types.
         /// @return Number of registered types.
         std::size_t size() const;
+
+        /// @brief Gets an iterator to the beginning of the registry.
+        /// @return Iterator.
+        Iterator begin() const;
+
+        /// @brief Gets an iterator to the end of the registry.
+        /// @return Iterator.
+        Iterator end() const;
 
     private:
         memory::UnorderedBimap<const Type*, std::string> mTypes{};

--- a/core/include/cubos/core/reflection/type_registry.hpp
+++ b/core/include/cubos/core/reflection/type_registry.hpp
@@ -1,0 +1,68 @@
+/// @file
+/// @brief Class @ref cubos::core::reflection::TypeRegistry.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <string>
+
+#include <cubos/core/memory/unordered_bimap.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::core::reflection
+{
+    /// @brief Stores a set of types which can be accessed by name.
+    /// @ingroup core-reflection
+    class TypeRegistry final
+    {
+    public:
+        /// @brief Registers the given type.
+        ///
+        /// Does nothing if the type is already registered.
+        /// Aborts if a different type with the same name is already registered.
+        ///
+        /// @param type Type to register.
+        void insert(const Type& type);
+
+        /// @copydoc insert(const Type&)
+        /// @tparam T Type to register.
+        template <Reflectable T>
+        void insert()
+        {
+            this->insert(reflect<T>());
+        }
+
+        /// @brief Checks if the given type is registered.
+        /// @param type Type to check.
+        /// @return Whether the given type is registered.
+        bool contains(const Type& type) const;
+
+        /// @copydoc contains(const Type&)
+        /// @tparam T Type to check.
+        template <Reflectable T>
+        bool contains() const
+        {
+            return this->contains(reflect<T>());
+        }
+
+        /// @brief Checks if a type with the given name is registered.
+        /// @param name Name of the type.
+        /// @return Whether a type with the given name is registered.
+        bool contains(const std::string& name) const;
+
+        /// @brief Returns the type with the given name.
+        ///
+        /// Aborts if @ref contains(const std::string&) returns false.
+        ///
+        /// @param name Name of the type.
+        /// @return Type with the given name.
+        const Type& at(const std::string& name) const;
+
+        /// @brief Returns the number of registered types.
+        /// @return Number of registered types.
+        std::size_t size() const;
+
+    private:
+        memory::UnorderedBimap<const Type*, std::string> mTypes{};
+    };
+} // namespace cubos::core::reflection

--- a/core/src/cubos/core/reflection/type.cpp
+++ b/core/src/cubos/core/reflection/type.cpp
@@ -65,7 +65,7 @@ bool Type::operator==(const Type& other) const
         return true;
     }
 
-    CUBOS_ASSERT(this->mName != other.mName, "Two types cannot be created with the same");
+    CUBOS_ASSERT(this->mName != other.mName, "Two types should never have the same name");
     return false;
 }
 

--- a/core/src/cubos/core/reflection/type_registry.cpp
+++ b/core/src/cubos/core/reflection/type_registry.cpp
@@ -1,0 +1,37 @@
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/reflection/type_registry.hpp>
+
+using cubos::core::reflection::Type;
+using cubos::core::reflection::TypeRegistry;
+
+void TypeRegistry::insert(const Type& type)
+{
+    if (mTypes.containsRight(type.name()))
+    {
+        CUBOS_ASSERT(mTypes.atRight(type.name()) == &type, "Two types should never have the same name");
+        return;
+    }
+
+    mTypes.insert(&type, type.name());
+}
+
+bool TypeRegistry::contains(const Type& type) const
+{
+    return mTypes.containsLeft(&type);
+}
+
+bool TypeRegistry::contains(const std::string& name) const
+{
+    return mTypes.containsRight(name);
+}
+
+const Type& TypeRegistry::at(const std::string& name) const
+{
+    return *mTypes.atRight(name);
+}
+
+std::size_t TypeRegistry::size() const
+{
+    return mTypes.size();
+}

--- a/core/src/cubos/core/reflection/type_registry.cpp
+++ b/core/src/cubos/core/reflection/type_registry.cpp
@@ -16,6 +16,14 @@ void TypeRegistry::insert(const Type& type)
     mTypes.insert(&type, type.name());
 }
 
+void TypeRegistry::insert(const TypeRegistry& other)
+{
+    for (const auto& [type, _] : other)
+    {
+        this->insert(*type);
+    }
+}
+
 bool TypeRegistry::contains(const Type& type) const
 {
     return mTypes.containsLeft(&type);
@@ -34,4 +42,14 @@ const Type& TypeRegistry::at(const std::string& name) const
 std::size_t TypeRegistry::size() const
 {
     return mTypes.size();
+}
+
+auto TypeRegistry::begin() const -> Iterator
+{
+    return mTypes.begin();
+}
+
+auto TypeRegistry::end() const -> Iterator
+{
+    return mTypes.end();
 }

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
 
     reflection/reflect.cpp
     reflection/type.cpp
+    reflection/type_registry.cpp
     reflection/traits/constructible.cpp
     reflection/traits/fields.cpp
     reflection/traits/nullable.cpp

--- a/core/tests/reflection/type.cpp
+++ b/core/tests/reflection/type.cpp
@@ -44,6 +44,7 @@ TEST_CASE("reflection::Type")
     {
         auto& anotherType = Type::create("Bar");
         REQUIRE(anotherType != type);
+        Type::destroy(anotherType);
     }
 
     Type::destroy(type);

--- a/core/tests/reflection/type_registry.cpp
+++ b/core/tests/reflection/type_registry.cpp
@@ -13,6 +13,7 @@ TEST_CASE("reflection::Type")
     CHECK_FALSE(registry.contains("int"));
     CHECK_FALSE(registry.contains<int>());
     CHECK(registry.size() == 0);
+    CHECK(registry.begin() == registry.end());
 
     SUBCASE("single insert")
     {
@@ -20,10 +21,27 @@ TEST_CASE("reflection::Type")
         CHECK(registry.size() == 1);
     }
 
+    SUBCASE("single insert other registry")
+    {
+        TypeRegistry other{};
+        other.insert<int>();
+        registry.insert(other);
+        CHECK(registry.size() == 1);
+    }
+
     SUBCASE("double insert")
     {
         registry.insert<int>();
         registry.insert<int>();
+        CHECK(registry.size() == 1);
+    }
+
+    SUBCASE("double insert other registry")
+    {
+        TypeRegistry other{};
+        other.insert<int>();
+        registry.insert(other);
+        registry.insert(other);
         CHECK(registry.size() == 1);
     }
 
@@ -35,6 +53,13 @@ TEST_CASE("reflection::Type")
         registry.insert<float>();
         registry.insert<double>();
         CHECK(registry.size() == 5);
+    }
+
+    if (registry.size() == 1)
+    {
+        CHECK(registry.begin() != registry.end());
+        CHECK(++registry.begin() == registry.end());
+        CHECK(registry.begin()->first->is<int>());
     }
 
     REQUIRE(registry.contains("int"));

--- a/core/tests/reflection/type_registry.cpp
+++ b/core/tests/reflection/type_registry.cpp
@@ -1,0 +1,42 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/reflection/type_registry.hpp>
+
+using cubos::core::reflection::TypeRegistry;
+
+TEST_CASE("reflection::Type")
+{
+    TypeRegistry registry{};
+
+    CHECK_FALSE(registry.contains("int"));
+    CHECK_FALSE(registry.contains<int>());
+    CHECK(registry.size() == 0);
+
+    SUBCASE("single insert")
+    {
+        registry.insert<int>();
+        CHECK(registry.size() == 1);
+    }
+
+    SUBCASE("double insert")
+    {
+        registry.insert<int>();
+        registry.insert<int>();
+        CHECK(registry.size() == 1);
+    }
+
+    SUBCASE("with other types")
+    {
+        registry.insert<short>();
+        registry.insert<int>();
+        registry.insert<long>();
+        registry.insert<float>();
+        registry.insert<double>();
+        CHECK(registry.size() == 5);
+    }
+
+    REQUIRE(registry.contains("int"));
+    CHECK(registry.at("int").is<int>());
+}


### PR DESCRIPTION
# Description

Adds a `TypeRegistry` utility class, used to keep a set of types which can be queried by their name.
Will be useful to reduce code duplication in #848.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
