### PR TITLE
Swap global component registry for a world registry

### DIFF
--- a/core/include/cubos/core/ecs/component/manager.hpp
+++ b/core/include/cubos/core/ecs/component/manager.hpp
@@ -9,6 +9,7 @@
 
 #include <cubos/core/ecs/component/storage.hpp>
 #include <cubos/core/memory/type_map.hpp>
+#include <cubos/core/reflection/type_registry.hpp>
 
 namespace cubos::core::ecs
 {
@@ -23,6 +24,10 @@ namespace cubos::core::ecs
         /// @brief Registers a new component type with the component manager.
         /// @param type Type of the component.
         void registerType(const reflection::Type& type);
+
+        /// @brief Gets the components registered with the component manager.
+        /// @return Component types.
+        reflection::TypeRegistry registry() const;
 
         /// @brief Gets the identifier of a registered component type.
         /// @param type Component type.

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -16,6 +16,7 @@
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/external/string_view.hpp>
 #include <cubos/core/reflection/type.hpp>
+#include <cubos/core/reflection/type_registry.hpp>
 
 namespace cubos::core::ecs
 {
@@ -91,6 +92,10 @@ namespace cubos::core::ecs
         /// @param entity Entity.
         /// @return Whether the entity is alive.
         bool isAlive(Entity entity) const;
+
+        /// @brief Returns a type registry which contains all registered component types.
+        /// @return Component type registry.
+        reflection::TypeRegistry components() const;
 
         /// @brief Creates a components view for the given entity.
         ///

--- a/core/src/cubos/core/ecs/component/manager.cpp
+++ b/core/src/cubos/core/ecs/component/manager.cpp
@@ -5,6 +5,7 @@
 #include <cubos/core/reflection/type.hpp>
 
 using cubos::core::reflection::Type;
+using cubos::core::reflection::TypeRegistry;
 
 using namespace cubos::core::ecs;
 
@@ -15,6 +16,16 @@ void ComponentManager::registerType(const Type& type)
         mTypeToIds.insert(type, static_cast<uint32_t>(mStorages.size()) + 1); // Component ids start at 1.
         mStorages.emplace_back(type);
     }
+}
+
+TypeRegistry ComponentManager::registry() const
+{
+    TypeRegistry registry{};
+    for (const auto& [type, _] : mTypeToIds)
+    {
+        registry.insert(*type);
+    }
+    return registry;
 }
 
 uint32_t ComponentManager::id(const Type& type) const

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -41,6 +41,11 @@ bool World::isAlive(Entity entity) const
     return mEntityManager.isAlive(entity);
 }
 
+reflection::TypeRegistry World::components() const
+{
+    return mComponentManager.registry();
+}
+
 World::Components World::components(Entity entity)
 {
     return Components{*this, entity};

--- a/engine/include/cubos/engine/scene/bridge.hpp
+++ b/engine/include/cubos/engine/scene/bridge.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/type_registry.hpp>
 
 #include <cubos/engine/assets/bridges/file.hpp>
 #include <cubos/engine/scene/scene.hpp>
@@ -47,14 +47,18 @@ namespace cubos::engine
     {
     public:
         /// @brief Constructs a bridge.
-        ///
-        SceneBridge()
-            : FileBridge(core::reflection::reflect<Scene>())
-        {
-        }
+        /// @param components Component type registry.
+        SceneBridge(core::reflection::TypeRegistry components);
+
+        /// @brief Returns the type registry used to deserialize components.
+        /// @return Component type registry.
+        core::reflection::TypeRegistry& components();
 
     protected:
         bool loadFromFile(Assets& assets, const AnyAsset& handle, core::memory::Stream& stream) override;
         bool saveToFile(const Assets& assets, const AnyAsset& handle, core::memory::Stream& stream) override;
+
+    private:
+        core::reflection::TypeRegistry mComponents;
     };
 } // namespace cubos::engine

--- a/engine/src/cubos/engine/scene/plugin.cpp
+++ b/engine/src/cubos/engine/scene/plugin.cpp
@@ -2,12 +2,16 @@
 #include <cubos/engine/scene/bridge.hpp>
 #include <cubos/engine/scene/plugin.hpp>
 
+using cubos::core::ecs::World;
+
 using namespace cubos::engine;
 
-static void bridge(Write<Assets> assets)
+static void bridge(Write<World> world)
 {
+    auto assets = world->write<Assets>();
+
     // Add the bridge to load .cubos files.
-    assets->registerBridge(".cubos", std::make_unique<SceneBridge>());
+    assets.get().registerBridge(".cubos", std::make_unique<SceneBridge>(world->components()));
 }
 
 void cubos::engine::scenePlugin(Cubos& cubos)


### PR DESCRIPTION
# Description

Adds a getter to the `World` to access the registered component types.
Changes the `SceneBridge` to fetch those types from the `World` instead of the global registry, which will be nuked in the next PR.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Tested existing scene samples.
