### PR TITLE
Add support for ccache when using MSYS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,14 @@ if(CCACHE_EXE)
 
             file(COPY_FILE
                 ${CCACHE_PATH} ${CMAKE_BINARY_DIR}/cl.exe
-                ONLY_IF_DIFFERENT)
+                RESULT FILE_NOT_FOUND ONLY_IF_DIFFERENT)
+
+            if (FILE_NOT_FOUND)
+                set(CCACHE_PATH C:/msys64/mingw64/bin/ccache.exe)
+                file(COPY_FILE
+                    ${CCACHE_PATH} ${CMAKE_BINARY_DIR}/cl.exe
+                    ONLY_IF_DIFFERENT)
+            endif()
 
             set(CMAKE_VS_GLOBALS
                 "CLToolExe=cl.exe"


### PR DESCRIPTION
# Description

Add a different path where cmake will look for the ccache binary when it doesn't find it in the default one.

## Checklist

- [x] Self-review changes.
