### PR TITLE
Add DPI scaling to ImGui

### DIFF
--- a/core/include/cubos/core/io/window.hpp
+++ b/core/include/cubos/core/io/window.hpp
@@ -186,6 +186,10 @@ namespace cubos::core::io
         /// @return Window framebuffer size, in pixels.
         virtual glm::ivec2 framebufferSize() const = 0;
 
+        /// @brief Gets the window content scale, commonly known as "DPI scale".
+        /// @return Ratio between the current DPI and the platform's default DPI.
+        virtual float contentScale() const = 0;
+
         /// @brief Checks whether the window should close.
         /// @return Whether the window should close.
         virtual bool shouldClose() const = 0;

--- a/core/src/cubos/core/io/glfw_window.cpp
+++ b/core/src/cubos/core/io/glfw_window.cpp
@@ -162,6 +162,18 @@ glm::ivec2 GLFWWindow::framebufferSize() const
 #endif
 }
 
+float GLFWWindow::contentScale() const
+{
+#ifdef WITH_GLFW
+    float xscale, yscale;
+    glfwGetWindowContentScale(mHandle, &xscale, &yscale);
+    // xscale and yscale should be the same, so only return one
+    return xscale;
+#else
+    UNSUPPORTED();
+#endif
+}
+
 bool GLFWWindow::shouldClose() const
 {
 #ifdef WITH_GLFW

--- a/core/src/cubos/core/io/glfw_window.cpp
+++ b/core/src/cubos/core/io/glfw_window.cpp
@@ -165,7 +165,8 @@ glm::ivec2 GLFWWindow::framebufferSize() const
 float GLFWWindow::contentScale() const
 {
 #ifdef WITH_GLFW
-    float xscale, yscale;
+    float xscale;
+    float yscale;
     glfwGetWindowContentScale(mHandle, &xscale, &yscale);
     // xscale and yscale should be the same, so only return one
     return xscale;

--- a/core/src/cubos/core/io/glfw_window.hpp
+++ b/core/src/cubos/core/io/glfw_window.hpp
@@ -29,6 +29,7 @@ namespace cubos::core::io
         gl::RenderDevice& renderDevice() const override;
         glm::ivec2 size() const override;
         glm::ivec2 framebufferSize() const override;
+        float contentScale() const override;
         bool shouldClose() const override;
         double time() const override;
         void mouseState(MouseState state) override;

--- a/engine/src/cubos/engine/imgui/imgui.cpp
+++ b/engine/src/cubos/engine/imgui/imgui.cpp
@@ -321,6 +321,14 @@ void cubos::engine::imguiInitialize(io::Window window)
 
     bd->time = window->time();
 
+    // DPI scaling
+    float dpiScale = window->contentScale();
+    ImGui::GetStyle().ScaleAllSizes(dpiScale);
+    ImFontConfig font_cfg;
+    // Default font size is 13; scale that
+    font_cfg.SizePixels = 13.0f * dpiScale;
+    io.Fonts->AddFontDefault(&font_cfg);
+
     createDeviceObjects();
 
     CUBOS_INFO("Initialized UI");

--- a/engine/src/cubos/engine/imgui/imgui.cpp
+++ b/engine/src/cubos/engine/imgui/imgui.cpp
@@ -322,17 +322,17 @@ void cubos::engine::imguiInitialize(io::Window window, float dpiScale)
     bd->time = window->time();
 
     // DPI scaling
-    if (dpiScale < 1.0f)
+    if (dpiScale < 1.0F)
     {
         // Smaller sizes are possible but may cause crashes.
         // Anything <= 0.0f is invalid.
-        dpiScale = 1.0f;
+        dpiScale = 1.0F;
     }
     ImGui::GetStyle().ScaleAllSizes(dpiScale);
-    ImFontConfig font_cfg;
+    ImFontConfig fontCfg;
     // Default font size is 13; scale that
-    font_cfg.SizePixels = 13.0f * dpiScale;
-    io.Fonts->AddFontDefault(&font_cfg);
+    fontCfg.SizePixels = 13.0F * dpiScale;
+    io.Fonts->AddFontDefault(&fontCfg);
 
     createDeviceObjects();
 

--- a/engine/src/cubos/engine/imgui/imgui.cpp
+++ b/engine/src/cubos/engine/imgui/imgui.cpp
@@ -274,7 +274,7 @@ void main()
     bd->ibSize = 0;
 }
 
-void cubos::engine::imguiInitialize(io::Window window)
+void cubos::engine::imguiInitialize(io::Window window, float dpiScale)
 {
     // Initialize ImGui
     IMGUI_CHECKVERSION();
@@ -322,7 +322,12 @@ void cubos::engine::imguiInitialize(io::Window window)
     bd->time = window->time();
 
     // DPI scaling
-    float dpiScale = window->contentScale();
+    if (dpiScale < 1.0f)
+    {
+        // Smaller sizes are possible but may cause crashes.
+        // Anything <= 0.0f is invalid.
+        dpiScale = 1.0f;
+    }
     ImGui::GetStyle().ScaleAllSizes(dpiScale);
     ImFontConfig font_cfg;
     // Default font size is 13; scale that

--- a/engine/src/cubos/engine/imgui/imgui.hpp
+++ b/engine/src/cubos/engine/imgui/imgui.hpp
@@ -12,8 +12,9 @@ namespace cubos::engine
     /// @brief Initializes ImGui for use with the given window.
     /// @note Should only be called once and no ImGui calls should be made before this is called.
     /// @param window The window to use.
+    /// @param dpiScale Size factor by which to scale ImGui elements.
     /// @ingroup imgui-plugin
-    void imguiInitialize(core::io::Window window);
+    void imguiInitialize(core::io::Window window, float dpiScale);
 
     /// @brief Shuts down ImGui.
     /// @note Should only be called once, after @ref initialize(), and no ImGui calls should be

--- a/engine/src/cubos/engine/imgui/plugin.cpp
+++ b/engine/src/cubos/engine/imgui/plugin.cpp
@@ -1,6 +1,7 @@
 #include <cubos/engine/imgui/data_inspector.hpp>
 #include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/renderer/plugin.hpp>
+#include <cubos/engine/settings/plugin.hpp>
 #include <cubos/engine/window/plugin.hpp>
 
 #include "imgui.hpp"
@@ -10,9 +11,10 @@ using cubos::core::io::WindowEvent;
 
 using namespace cubos::engine;
 
-static void init(Read<Window> window)
+static void init(Read<Window> window, Write<Settings> settings)
 {
-    imguiInitialize(*window);
+    float dpiScale = static_cast<float>(settings->getDouble("imgui.scale", (*window)->contentScale()));
+    imguiInitialize(*window, dpiScale);
 }
 
 static void begin(EventReader<WindowEvent> events)


### PR DESCRIPTION
# Description

Adds a setting to change the scale of ImGui elements, allowing them to be displayed at a larger size. Mainly important for screens with high pixel density, where the normal scale looks tiny. Defaults to the OS's DPI scale setting.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
