### PR TITLE
Add screenPickerPlugin

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -80,6 +80,9 @@ set(CUBOS_ENGINE_SOURCE
     "src/cubos/engine/renderer/viewport.cpp"
 
     "src/cubos/engine/splitscreen/plugin.cpp"
+
+    "src/cubos/engine/screenpicker/plugin.cpp"
+    "src/cubos/engine/screenpicker/screenpicker.cpp"
 )
 
 # Create cubos engine

--- a/engine/include/cubos/engine/screenpicker/plugin.hpp
+++ b/engine/include/cubos/engine/screenpicker/plugin.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cubos/engine/cubos.hpp>
+
+namespace cubos::engine
+{
+    void screenPickerPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/screenpicker/plugin.hpp
+++ b/engine/include/cubos/engine/screenpicker/plugin.hpp
@@ -22,7 +22,7 @@ namespace cubos::engine
     /// - `cubos.screenpicker.init` - the ScreenPicker resource is initialized, after `cubos.window.init`
     ///
     /// ## Tags
-    /// - `cubos.screenpicker.clear` - the picking texture is cleared, before `cubos.renderer.draw`
+    /// - `cubos.screenpicker.clear` - the picking texture is cleared
     /// - `cubos.screenpicker.resize` - window resize events are handled and the ScreenPicker texture is resized, after
     /// `cubos.window.poll` and before `cubos.screenpicker.clear`.
     ///

--- a/engine/include/cubos/engine/screenpicker/plugin.hpp
+++ b/engine/include/cubos/engine/screenpicker/plugin.hpp
@@ -1,8 +1,36 @@
+/// @dir
+/// @brief @ref screenpicker-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup screenpicker-plugin
+
 #pragma once
 
 #include <cubos/engine/cubos.hpp>
 
 namespace cubos::engine
 {
+    /// @defgroup screenpicker-plugin ScreenPicker
+    /// @ingroup engine
+    /// @brief Used to select entities and gizmos by clicking them.
+    ///
+    /// ## Resources
+    /// - @ref ScreenPicker - provides a texture to store entity and gizmo ids.
+    ///
+    /// ## Startup tags
+    /// - `cubos.screenpicker.init` - the ScreenPicker resource is initialized, after `cubos.window.init`
+    ///
+    /// ## Tags
+    /// - `cubos.screenpicker.clear` - the picking texture is cleared, before `cubos.renderer.draw`
+    /// - `cubos.screenpicker.resize` - window resize events are handled and the ScreenPicker texture is resized, after
+    /// `cubos.window.poll` and before `cubos.screenpicker.clear`.
+    ///
+    /// ## Dependencies
+    /// - @ref window-plugin
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class.
+    /// @ingroup screenpicker-plugin
     void screenPickerPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/screenpicker/screenpicker.hpp
+++ b/engine/include/cubos/engine/screenpicker/screenpicker.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cubos/core/gl/render_device.hpp>
+
+#include <cubos/engine/cubos.hpp>
+
+namespace cubos::engine
+{
+    class ScreenPicker final
+    {
+    public:
+        void init(cubos::core::gl::RenderDevice* currentRenderDevice, glm::ivec2 size);
+        void resizeTexture(glm::ivec2 size);
+        void clearTexture();
+        core::gl::Framebuffer framebuffer();
+        uint32_t at(int x, int y) const;
+        glm::uvec2 size() const;
+
+    private:
+        cubos::core::gl::RenderDevice* renderDevice;
+        core::gl::Framebuffer idFramebuffer;
+        core::gl::Texture2D idTexture;
+        glm::ivec2 textureSize;
+
+        void initIdTexture(glm::ivec2 size);
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/screenpicker/screenpicker.hpp
+++ b/engine/include/cubos/engine/screenpicker/screenpicker.hpp
@@ -43,10 +43,10 @@ namespace cubos::engine
         glm::uvec2 size() const;
 
     private:
-        cubos::core::gl::RenderDevice* renderDevice; ///< Active render device.
-        core::gl::Framebuffer idFramebuffer;         ///< Framebuffer used to draw to the picking texture.
-        core::gl::Texture2D idTexture; ///< Picking texture, stores entity/gizmo ids for each pixel on the screen.
-        glm::ivec2 textureSize;        ///< Size of the picking texture in pixels.
+        cubos::core::gl::RenderDevice* mRenderDevice; ///< Active render device.
+        core::gl::Framebuffer mIdFramebuffer;         ///< Framebuffer used to draw to the picking texture.
+        core::gl::Texture2D mIdTexture; ///< Picking texture, stores entity/gizmo ids for each pixel on the screen.
+        glm::ivec2 mTextureSize;        ///< Size of the picking texture in pixels.
 
         /// @brief Creates the picking texture with a specified size.
         /// @param size Size of the picking texture in pixels.

--- a/engine/include/cubos/engine/screenpicker/screenpicker.hpp
+++ b/engine/include/cubos/engine/screenpicker/screenpicker.hpp
@@ -1,3 +1,7 @@
+/// @file
+/// @brief Resource @ref cubos::engine::ScreenPicker.
+/// @ingroup screenpicker-plugin
+
 #pragma once
 
 #include <cubos/core/gl/render_device.hpp>
@@ -6,22 +10,46 @@
 
 namespace cubos::engine
 {
+    /// @brief Resource which provides a texture to store entity/gizmo ids, for selection with a mouse.
+    ///
+    /// @ingroup screenpicker-plugin
     class ScreenPicker final
     {
     public:
+        /// @brief Initializes ScreenPicker for a render device.
+        /// @param renderDevice The current Render device being used.
+        /// @param size The size of the window in pixels.
         void init(cubos::core::gl::RenderDevice* currentRenderDevice, glm::ivec2 size);
+
+        /// @brief Resizes the picking texture.
+        /// @param size New size of the texture.
         void resizeTexture(glm::ivec2 size);
+
+        /// @brief Clears the picking texture.
         void clearTexture();
+
+        /// @brief Returns the framebuffer used to draw to the picking texture.
+        /// @return Framebuffer used to draw to the picking texture.
         core::gl::Framebuffer framebuffer();
+
+        /// @brief Returns the identifier associated to the pixel in the coords (x, y).
+        /// @param x Coordinate of pixel in x axis
+        /// @param y Coordinate of pixel in y axis
+        /// @return Entity or gizmo identifier associated to the pixel in the coords (x, y).
         uint32_t at(int x, int y) const;
+
+        /// @brief Returns the size of the picking texture in pixels.
+        /// @return Size of the picking texture in pixels.
         glm::uvec2 size() const;
 
     private:
-        cubos::core::gl::RenderDevice* renderDevice;
-        core::gl::Framebuffer idFramebuffer;
-        core::gl::Texture2D idTexture;
-        glm::ivec2 textureSize;
+        cubos::core::gl::RenderDevice* renderDevice; ///< Active render device.
+        core::gl::Framebuffer idFramebuffer;         ///< Framebuffer used to draw to the picking texture.
+        core::gl::Texture2D idTexture; ///< Picking texture, stores entity/gizmo ids for each pixel on the screen.
+        glm::ivec2 textureSize;        ///< Size of the picking texture in pixels.
 
+        /// @brief Creates the picking texture with a specified size.
+        /// @param size Size of the picking texture in pixels.
         void initIdTexture(glm::ivec2 size);
     };
 } // namespace cubos::engine

--- a/engine/src/cubos/engine/screenpicker/plugin.cpp
+++ b/engine/src/cubos/engine/screenpicker/plugin.cpp
@@ -40,7 +40,7 @@ void cubos::engine::screenPickerPlugin(Cubos& cubos)
 
     cubos.startupSystem(initScreenPickerSystem).tagged("cubos.screenpicker.init").after("cubos.window.init");
 
-    cubos.system(clearTexture).tagged("cubos.screenpicker.clear").before("cubos.renderer.draw");
+    cubos.system(clearTexture).tagged("cubos.screenpicker.clear");
     cubos.system(processResize)
         .tagged("cubos.screenpicker.resize")
         .after("cubos.window.poll")

--- a/engine/src/cubos/engine/screenpicker/plugin.cpp
+++ b/engine/src/cubos/engine/screenpicker/plugin.cpp
@@ -1,0 +1,45 @@
+#include <cubos/core/io/window.hpp>
+
+#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/screenpicker/plugin.hpp>
+#include <cubos/engine/screenpicker/screenpicker.hpp>
+#include <cubos/engine/window/plugin.hpp>
+
+using cubos::core::io::ResizeEvent;
+using cubos::core::io::Window;
+using cubos::core::io::WindowEvent;
+
+using namespace cubos::engine;
+
+static void processResize(Write<ScreenPicker> screenPicker, EventReader<WindowEvent> windowEvent)
+{
+    for (const auto& event : windowEvent)
+    {
+        if (std::holds_alternative<ResizeEvent>(event))
+        {
+            screenPicker->resizeTexture(std::get<ResizeEvent>(event).size);
+        }
+    }
+}
+
+static void clearTexture(Write<ScreenPicker> screenPicker)
+{
+    screenPicker->clearTexture();
+}
+
+static void initScreenPickerSystem(Write<ScreenPicker> screenPicker, Read<Window> window)
+{
+    screenPicker->init(&(*window)->renderDevice(), (*window)->framebufferSize());
+}
+
+void cubos::engine::screenPickerPlugin(Cubos& cubos)
+{
+    cubos.addPlugin(cubos::engine::windowPlugin);
+
+    cubos.addResource<ScreenPicker>();
+
+    cubos.startupSystem(initScreenPickerSystem).tagged("cubos.screenpicker.init").after("cubos.window.init");
+
+    cubos.system(processResize).tagged("cubos.screenpicker.resize").after("cubos.window.poll");
+    cubos.system(clearTexture).tagged("cubos.screenpicker.clear").before("cubos.renderer.draw");
+}

--- a/engine/src/cubos/engine/screenpicker/plugin.cpp
+++ b/engine/src/cubos/engine/screenpicker/plugin.cpp
@@ -40,6 +40,9 @@ void cubos::engine::screenPickerPlugin(Cubos& cubos)
 
     cubos.startupSystem(initScreenPickerSystem).tagged("cubos.screenpicker.init").after("cubos.window.init");
 
-    cubos.system(processResize).tagged("cubos.screenpicker.resize").after("cubos.window.poll");
     cubos.system(clearTexture).tagged("cubos.screenpicker.clear").before("cubos.renderer.draw");
+    cubos.system(processResize)
+        .tagged("cubos.screenpicker.resize")
+        .after("cubos.window.poll")
+        .before("cubos.screenpicker.clear");
 }

--- a/engine/src/cubos/engine/screenpicker/screenpicker.cpp
+++ b/engine/src/cubos/engine/screenpicker/screenpicker.cpp
@@ -25,7 +25,7 @@ void ScreenPicker::clearTexture()
     // Since the texture is in RG16UInt format, it's filled with UINT16_MAX instead (two values make up an identifier)
     std::fill(texBuffer, texBuffer + (std::size_t)mTextureSize.x * (std::size_t)mTextureSize.y * 2U, UINT16_MAX);
 
-    mIdTexture->update(0, 0, mTextureSize.x, mTextureSize.y, texBuffer);
+    mIdTexture->update(0, 0, (std::size_t)mTextureSize.x, (std::size_t)mTextureSize.y, texBuffer);
 
     delete[] texBuffer;
 }

--- a/engine/src/cubos/engine/screenpicker/screenpicker.cpp
+++ b/engine/src/cubos/engine/screenpicker/screenpicker.cpp
@@ -8,7 +8,7 @@ using namespace cubos::core::gl;
 
 void ScreenPicker::init(cubos::core::gl::RenderDevice* currentRenderDevice, glm::ivec2 size)
 {
-    renderDevice = currentRenderDevice;
+    mRenderDevice = currentRenderDevice;
     initIdTexture(size);
 }
 
@@ -19,30 +19,30 @@ void ScreenPicker::resizeTexture(glm::ivec2 size)
 
 void ScreenPicker::clearTexture()
 {
-    auto* texBuffer = new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
+    auto* texBuffer = new uint16_t[(std::size_t)mTextureSize.x * (std::size_t)mTextureSize.y * 2U];
 
     // UINT32_MAX mean 'nothing's here'
     // Since the texture is in RG16UInt format, it's filled with UINT16_MAX instead (two values make up an identifier)
-    std::fill(texBuffer, texBuffer + (std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U, UINT16_MAX);
+    std::fill(texBuffer, texBuffer + (std::size_t)mTextureSize.x * (std::size_t)mTextureSize.y * 2U, UINT16_MAX);
 
-    idTexture->update(0, 0, textureSize.x, textureSize.y, texBuffer);
+    mIdTexture->update(0, 0, mTextureSize.x, mTextureSize.y, texBuffer);
 
     delete[] texBuffer;
 }
 
 Framebuffer ScreenPicker::framebuffer()
 {
-    return idFramebuffer;
+    return mIdFramebuffer;
 }
 
 uint32_t ScreenPicker::at(int x, int y) const
 {
-    auto* texBuffer = new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
+    auto* texBuffer = new uint16_t[(std::size_t)mTextureSize.x * (std::size_t)mTextureSize.y * 2U];
 
-    idTexture->read(texBuffer);
+    mIdTexture->read(texBuffer);
 
-    uint16_t r = texBuffer[(ptrdiff_t)(y * textureSize.x + x) * 2U];
-    uint16_t g = texBuffer[(ptrdiff_t)(y * textureSize.x + x) * 2U + 1U];
+    uint16_t r = texBuffer[(ptrdiff_t)(y * mTextureSize.x + x) * 2U];
+    uint16_t g = texBuffer[(ptrdiff_t)(y * mTextureSize.x + x) * 2U + 1U];
 
     uint32_t id = (static_cast<uint32_t>(r) << 16U) | g;
 
@@ -53,7 +53,7 @@ uint32_t ScreenPicker::at(int x, int y) const
 
 glm::uvec2 ScreenPicker::size() const
 {
-    return static_cast<glm::uvec2>(textureSize);
+    return static_cast<glm::uvec2>(mTextureSize);
 }
 
 void ScreenPicker::initIdTexture(glm::ivec2 size)
@@ -64,13 +64,13 @@ void ScreenPicker::initIdTexture(glm::ivec2 size)
     texDesc.usage = Usage::Dynamic;
     texDesc.format = TextureFormat::RG16UInt;
 
-    idTexture = renderDevice->createTexture2D(texDesc);
+    mIdTexture = mRenderDevice->createTexture2D(texDesc);
 
     FramebufferDesc frameDesc;
     frameDesc.targetCount = 1;
-    frameDesc.targets[0].setTexture2DTarget(idTexture);
+    frameDesc.targets[0].setTexture2DTarget(mIdTexture);
 
-    idFramebuffer = renderDevice->createFramebuffer(frameDesc);
+    mIdFramebuffer = mRenderDevice->createFramebuffer(frameDesc);
 
-    textureSize = size;
+    mTextureSize = size;
 }

--- a/engine/src/cubos/engine/screenpicker/screenpicker.cpp
+++ b/engine/src/cubos/engine/screenpicker/screenpicker.cpp
@@ -21,6 +21,8 @@ void ScreenPicker::clearTexture()
 {
     auto* texBuffer = new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
 
+    // UINT32_MAX mean 'nothing's here'
+    // Since the texture is in RG16UInt format, it's filled with UINT16_MAX instead (two values make up an identifier)
     std::fill(texBuffer, texBuffer + (std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U, UINT16_MAX);
 
     idTexture->update(0, 0, textureSize.x, textureSize.y, texBuffer);

--- a/engine/src/cubos/engine/screenpicker/screenpicker.cpp
+++ b/engine/src/cubos/engine/screenpicker/screenpicker.cpp
@@ -1,0 +1,76 @@
+#include <cubos/core/gl/render_device.hpp>
+
+#include <cubos/engine/screenpicker/screenpicker.hpp>
+
+using cubos::engine::ScreenPicker;
+
+using namespace cubos::core::gl;
+
+void ScreenPicker::init(cubos::core::gl::RenderDevice* currentRenderDevice, glm::ivec2 size)
+{
+    renderDevice = currentRenderDevice;
+    initIdTexture(size);
+}
+
+void ScreenPicker::resizeTexture(glm::ivec2 size)
+{
+    initIdTexture(size);
+}
+
+void ScreenPicker::clearTexture()
+{
+    auto* texBuffer =
+        new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
+
+    std::fill(texBuffer, texBuffer + (std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U, UINT16_MAX);
+
+    idTexture->update(0, 0, textureSize.x, textureSize.y, texBuffer);
+
+    delete[] texBuffer;
+}
+
+Framebuffer ScreenPicker::framebuffer()
+{
+    return idFramebuffer;
+}
+
+uint32_t ScreenPicker::at(int x, int y) const
+{
+    auto* texBuffer =
+        new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
+
+    idTexture->read(texBuffer);
+
+    uint16_t r = texBuffer[(ptrdiff_t)(y * textureSize.x + x) * 2U];
+    uint16_t g = texBuffer[(ptrdiff_t)(y * textureSize.x + x) * 2U + 1U];
+
+    uint32_t id = (static_cast<uint32_t>(r) << 16U) | g;
+
+    delete[] texBuffer;
+
+    return id;
+}
+
+glm::uvec2 ScreenPicker::size() const
+{
+    return static_cast<glm::uvec2>(textureSize);
+}
+
+void ScreenPicker::initIdTexture(glm::ivec2 size)
+{
+    Texture2DDesc texDesc;
+    texDesc.width = (std::size_t)size.x;
+    texDesc.height = (std::size_t)size.y;
+    texDesc.usage = Usage::Dynamic;
+    texDesc.format = TextureFormat::RG16UInt;
+
+    idTexture = renderDevice->createTexture2D(texDesc);
+
+    FramebufferDesc frameDesc;
+    frameDesc.targetCount = 1;
+    frameDesc.targets[0].setTexture2DTarget(idTexture);
+
+    idFramebuffer = renderDevice->createFramebuffer(frameDesc);
+
+    textureSize = size;
+}

--- a/engine/src/cubos/engine/screenpicker/screenpicker.cpp
+++ b/engine/src/cubos/engine/screenpicker/screenpicker.cpp
@@ -19,8 +19,7 @@ void ScreenPicker::resizeTexture(glm::ivec2 size)
 
 void ScreenPicker::clearTexture()
 {
-    auto* texBuffer =
-        new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
+    auto* texBuffer = new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
 
     std::fill(texBuffer, texBuffer + (std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U, UINT16_MAX);
 
@@ -36,8 +35,7 @@ Framebuffer ScreenPicker::framebuffer()
 
 uint32_t ScreenPicker::at(int x, int y) const
 {
-    auto* texBuffer =
-        new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
+    auto* texBuffer = new uint16_t[(std::size_t)textureSize.x * (std::size_t)textureSize.y * 2U];
 
     idTexture->read(texBuffer);
 


### PR DESCRIPTION
# Description

Adds a new plugin in `cubos::engine`, which adds the resource `ScreenPicker`. This resource provides a texture with entity/gizmo IDs for mouse picking.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
