### PR TITLE
Separate physics force and impulse into their own components

### DIFF
--- a/engine/include/cubos/engine/physics/components/force.hpp
+++ b/engine/include/cubos/engine/physics/components/force.hpp
@@ -15,10 +15,9 @@ namespace cubos::engine
     /// @ingroup physics-plugin
     struct Force
     {
-    public:
         CUBOS_REFLECT;
 
-        const glm::vec3 getForce() const
+        glm::vec3 getForce() const
         {
             return mForce;
         }
@@ -30,7 +29,7 @@ namespace cubos::engine
 
         void clearForce()
         {
-            mForce = {0.0f, 0.0f, 0.0f};
+            mForce = {0.0F, 0.0F, 0.0F};
         }
 
     private:

--- a/engine/include/cubos/engine/physics/components/force.hpp
+++ b/engine/include/cubos/engine/physics/components/force.hpp
@@ -1,0 +1,40 @@
+/// @file
+/// @brief Component @ref cubos::engine::Force.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/vec3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which holds forces applied on a particle.
+    /// @note Should be used with @ref Velocity.
+    /// @ingroup physics-plugin
+    struct Force
+    {
+    public:
+        CUBOS_REFLECT;
+
+        const glm::vec3 getForce() const
+        {
+            return mForce;
+        }
+
+        void addForce(glm::vec3 force)
+        {
+            mForce += force;
+        }
+
+        void clearForce()
+        {
+            mForce = {0.0f, 0.0f, 0.0f};
+        }
+
+    private:
+        glm::vec3 mForce = {0.0F, 0.0F, 0.0F};
+    };
+
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/force.hpp
+++ b/engine/include/cubos/engine/physics/components/force.hpp
@@ -17,17 +17,17 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 getForce() const
+        glm::vec3 vec() const
         {
             return mForce;
         }
 
-        void addForce(glm::vec3 force)
+        void add(glm::vec3 force)
         {
             mForce += force;
         }
 
-        void clearForce()
+        void clear()
         {
             mForce = {0.0F, 0.0F, 0.0F};
         }

--- a/engine/include/cubos/engine/physics/components/impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/impulse.hpp
@@ -17,17 +17,17 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 getImpulse() const
+        glm::vec3 vec() const
         {
             return mImpulse;
         }
 
-        void addImpulse(glm::vec3 impulse)
+        void add(glm::vec3 impulse)
         {
             mImpulse += impulse;
         }
 
-        void clearImpulse()
+        void clear()
         {
             mImpulse = {0.0F, 0.0F, 0.0F};
         }

--- a/engine/include/cubos/engine/physics/components/impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/impulse.hpp
@@ -15,10 +15,9 @@ namespace cubos::engine
     /// @ingroup physics-plugin
     struct Impulse
     {
-    public:
         CUBOS_REFLECT;
 
-        const glm::vec3 getImpulse() const
+        glm::vec3 getImpulse() const
         {
             return mImpulse;
         }
@@ -30,7 +29,7 @@ namespace cubos::engine
 
         void clearImpulse()
         {
-            mImpulse = {0.0f, 0.0f, 0.0f};
+            mImpulse = {0.0F, 0.0F, 0.0F};
         }
 
     private:

--- a/engine/include/cubos/engine/physics/components/impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/impulse.hpp
@@ -1,0 +1,40 @@
+/// @file
+/// @brief Component @ref cubos::engine::Force.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/vec3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which holds impulses applied on a particle.
+    /// @note Should be used with @ref Velocity.
+    /// @ingroup physics-plugin
+    struct Impulse
+    {
+    public:
+        CUBOS_REFLECT;
+
+        const glm::vec3 getImpulse() const
+        {
+            return mImpulse;
+        }
+
+        void addImpulse(glm::vec3 impulse)
+        {
+            mImpulse += impulse;
+        }
+
+        void clearImpulse()
+        {
+            mImpulse = {0.0f, 0.0f, 0.0f};
+        }
+
+    private:
+        glm::vec3 mImpulse;
+    };
+
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/mass.hpp
+++ b/engine/include/cubos/engine/physics/components/mass.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @brief Component @ref cubos::engine::PhysicsMass.
+/// @brief Component @ref cubos::engine::Mass.
 /// @ingroup physics-plugin
 
 #pragma once
@@ -12,7 +12,7 @@ namespace cubos::engine
 {
     /// @brief Component which defines the mass of a particle.
     /// @ingroup physics-plugin
-    struct PhysicsMass
+    struct Mass
     {
         CUBOS_REFLECT;
 

--- a/engine/include/cubos/engine/physics/components/velocity.hpp
+++ b/engine/include/cubos/engine/physics/components/velocity.hpp
@@ -11,7 +11,7 @@
 namespace cubos::engine
 {
     /// @brief Component which holds velocity and forces applied on a particle.
-    /// @note Should be used with @ref PhysicsMass and @ref Position.
+    /// @note Should be used with @ref Mass and @ref Position.
     /// @ingroup physics-plugin
     struct Velocity
     {

--- a/engine/include/cubos/engine/physics/components/velocity.hpp
+++ b/engine/include/cubos/engine/physics/components/velocity.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @brief Component @ref cubos::engine::PhysicsVelocity.
+/// @brief Component @ref cubos::engine::Velocity.
 /// @ingroup physics-plugin
 
 #pragma once
@@ -13,12 +13,10 @@ namespace cubos::engine
     /// @brief Component which holds velocity and forces applied on a particle.
     /// @note Should be used with @ref PhysicsMass and @ref Position.
     /// @ingroup physics-plugin
-    struct PhysicsVelocity
+    struct Velocity
     {
         CUBOS_REFLECT;
 
         glm::vec3 velocity;
-        glm::vec3 force;
-        glm::vec3 impulse;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/velocity.hpp
+++ b/engine/include/cubos/engine/physics/components/velocity.hpp
@@ -17,6 +17,6 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 velocity;
+        glm::vec3 vec;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/plugin.hpp
+++ b/engine/include/cubos/engine/physics/plugin.hpp
@@ -15,7 +15,7 @@
 #include <cubos/engine/physics/components/accumulated_correction.hpp>
 #include <cubos/engine/physics/components/force.hpp>
 #include <cubos/engine/physics/components/impulse.hpp>
-#include <cubos/engine/physics/components/physics_mass.hpp>
+#include <cubos/engine/physics/components/mass.hpp>
 #include <cubos/engine/physics/components/previous_position.hpp>
 #include <cubos/engine/physics/components/velocity.hpp>
 #include <cubos/engine/physics/plugins/gravity.hpp>
@@ -42,7 +42,7 @@ namespace cubos::engine
     /// - @ref Velocity - holds the information for moving an object straight.
     /// - @ref Force - holds forces applied on a particle.
     /// - @ref Impulse - holds impulses applied on a particle.
-    /// - @ref PhysicsMass - holds the mass of an object.
+    /// - @ref Mass - holds the mass of an object.
     /// - @ref PreviousPosition - holds the previous position of the entity in a substep.
     /// - @ref AccumulatedCorrection - holds the corrections accumulated from the constraints solving.
     ///

--- a/engine/include/cubos/engine/physics/plugin.hpp
+++ b/engine/include/cubos/engine/physics/plugin.hpp
@@ -13,9 +13,11 @@
 #include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/physics/components/accumulated_correction.hpp>
+#include <cubos/engine/physics/components/force.hpp>
+#include <cubos/engine/physics/components/impulse.hpp>
 #include <cubos/engine/physics/components/physics_mass.hpp>
-#include <cubos/engine/physics/components/physics_velocity.hpp>
 #include <cubos/engine/physics/components/previous_position.hpp>
+#include <cubos/engine/physics/components/velocity.hpp>
 #include <cubos/engine/physics/plugins/gravity.hpp>
 #include <cubos/engine/physics/resources/damping.hpp>
 #include <cubos/engine/physics/resources/fixed_delta_time.hpp>
@@ -37,7 +39,9 @@ namespace cubos::engine
     /// - @ref Substeps - holds the amount of substeps for the physics update.
     ///
     /// ## Components
-    /// - @ref PhysicsVelocity - holds the information for moving an object straight.
+    /// - @ref Velocity - holds the information for moving an object straight.
+    /// - @ref Force - holds forces applied on a particle.
+    /// - @ref Impulse - holds impulses applied on a particle.
     /// - @ref PhysicsMass - holds the mass of an object.
     /// - @ref PreviousPosition - holds the previous position of the entity in a substep.
     /// - @ref AccumulatedCorrection - holds the corrections accumulated from the constraints solving.

--- a/engine/include/cubos/engine/physics/plugins/gravity.hpp
+++ b/engine/include/cubos/engine/physics/plugins/gravity.hpp
@@ -6,7 +6,7 @@
 
 #include <cubos/engine/physics/components/force.hpp>
 #include <cubos/engine/physics/components/impulse.hpp>
-#include <cubos/engine/physics/components/physics_mass.hpp>
+#include <cubos/engine/physics/components/mass.hpp>
 #include <cubos/engine/physics/components/velocity.hpp>
 #include <cubos/engine/physics/resources/gravity.hpp>
 #include <cubos/engine/prelude.hpp>

--- a/engine/include/cubos/engine/physics/plugins/gravity.hpp
+++ b/engine/include/cubos/engine/physics/plugins/gravity.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <cubos/engine/physics/components/force.hpp>
+#include <cubos/engine/physics/components/impulse.hpp>
 #include <cubos/engine/physics/components/physics_mass.hpp>
-#include <cubos/engine/physics/components/physics_velocity.hpp>
+#include <cubos/engine/physics/components/velocity.hpp>
 #include <cubos/engine/physics/resources/gravity.hpp>
 #include <cubos/engine/prelude.hpp>
 

--- a/engine/samples/physics/main.cpp
+++ b/engine/samples/physics/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
                 .add(Velocity{.velocity = {0.0F, 0.0F, 0.0F}})
                 .add(Force{})
                 .add(Impulse{})
-                .add(PhysicsMass{.mass = 500.0F, .inverseMass = 1.0F / 500.0F})
+                .add(Mass{.mass = 500.0F, .inverseMass = 1.0F / 500.0F})
                 .add(AccumulatedCorrection{{0.0F, 0.0F, 0.0F}})
                 .add(LocalToWorld{});
         });

--- a/engine/samples/physics/main.cpp
+++ b/engine/samples/physics/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
                 .add(RenderableGrid{CarAsset, offset})
                 .add(Position{{0.0F, 0.0F, 0.0F}})
                 .add(PreviousPosition{{0.0F, 0.0F, 0.0F}})
-                .add(Velocity{.velocity = {0.0F, 0.0F, 0.0F}})
+                .add(Velocity{.vec = {0.0F, 0.0F, 0.0F}})
                 .add(Force{})
                 .add(Impulse{})
                 .add(Mass{.mass = 500.0F, .inverseMass = 1.0F / 500.0F})
@@ -83,9 +83,9 @@ int main(int argc, char** argv)
                 {
                     if (time.current == 0.0F)
                     {
-                        impulse.addImpulse(glm::vec3(0.0F, 5000.0F, 0.0F));
+                        impulse.add(glm::vec3(0.0F, 5000.0F, 0.0F));
                     }
-                    force.addForce(glm::vec3(0.0F, 0.0F, -5000.0F));
+                    force.add(glm::vec3(0.0F, 0.0F, -5000.0F));
                     time.current += deltaTime.value;
                 }
             }

--- a/engine/samples/physics/main.cpp
+++ b/engine/samples/physics/main.cpp
@@ -66,8 +66,9 @@ int main(int argc, char** argv)
                 .add(RenderableGrid{CarAsset, offset})
                 .add(Position{{0.0F, 0.0F, 0.0F}})
                 .add(PreviousPosition{{0.0F, 0.0F, 0.0F}})
-                .add(PhysicsVelocity{
-                    .velocity = {0.0F, 0.0F, 0.0F}, .force = {0.0F, 0.0F, 0.0F}, .impulse = {0.0F, 0.0F, 0.0F}})
+                .add(Velocity{.velocity = {0.0F, 0.0F, 0.0F}})
+                .add(Force{})
+                .add(Impulse{})
                 .add(PhysicsMass{.mass = 500.0F, .inverseMass = 1.0F / 500.0F})
                 .add(AccumulatedCorrection{{0.0F, 0.0F, 0.0F}})
                 .add(LocalToWorld{});
@@ -75,16 +76,16 @@ int main(int argc, char** argv)
 
     cubos.system("push the car")
         .tagged("cubos.physics.apply_forces")
-        .call([](Query<PhysicsVelocity&> query, MaxTime& time, const DeltaTime& deltaTime) {
-            for (auto [velocity] : query)
+        .call([](Query<Velocity&, Force&, Impulse&> query, MaxTime& time, const DeltaTime& deltaTime) {
+            for (auto [velocity, force, impulse] : query)
             {
                 if (time.current < time.max)
                 {
                     if (time.current == 0.0F)
                     {
-                        velocity.impulse += glm::vec3(0.0F, 5000.0F, 0.0F);
+                        impulse.addImpulse(glm::vec3(0.0F, 5000.0F, 0.0F));
                     }
-                    velocity.force += glm::vec3(0.0F, 0.0F, -5000.0F);
+                    force.addForce(glm::vec3(0.0F, 0.0F, -5000.0F));
                     time.current += deltaTime.value;
                 }
             }

--- a/engine/src/cubos/engine/physics/gravity.cpp
+++ b/engine/src/cubos/engine/physics/gravity.cpp
@@ -10,8 +10,8 @@ void cubos::engine::gravityPlugin(Cubos& cubos)
 
     cubos.system("apply gravity")
         .tagged("cubos.physics.apply_forces")
-        .call([](Query<PhysicsVelocity&, const PhysicsMass&> query, const Gravity& gravity) {
-            for (auto [velocity, mass] : query)
+        .call([](Query<Velocity&, Force&, const PhysicsMass&> query, const Gravity& gravity) {
+            for (auto [velocity, force, mass] : query)
             {
                 if (mass.inverseMass <= 0.0F)
                 {
@@ -21,7 +21,7 @@ void cubos::engine::gravityPlugin(Cubos& cubos)
                 // Apply gravity force
                 glm::vec3 gravitationForce = mass.mass * gravity.value;
 
-                velocity.force += gravitationForce;
+                force.addForce(gravitationForce);
             }
         });
 }

--- a/engine/src/cubos/engine/physics/gravity.cpp
+++ b/engine/src/cubos/engine/physics/gravity.cpp
@@ -10,7 +10,7 @@ void cubos::engine::gravityPlugin(Cubos& cubos)
 
     cubos.system("apply gravity")
         .tagged("cubos.physics.apply_forces")
-        .call([](Query<Velocity&, Force&, const PhysicsMass&> query, const Gravity& gravity) {
+        .call([](Query<Velocity&, Force&, const Mass&> query, const Gravity& gravity) {
             for (auto [velocity, force, mass] : query)
             {
                 if (mass.inverseMass <= 0.0F)

--- a/engine/src/cubos/engine/physics/gravity.cpp
+++ b/engine/src/cubos/engine/physics/gravity.cpp
@@ -21,7 +21,7 @@ void cubos::engine::gravityPlugin(Cubos& cubos)
                 // Apply gravity force
                 glm::vec3 gravitationForce = mass.mass * gravity.value;
 
-                force.addForce(gravitationForce);
+                force.add(gravitationForce);
             }
         });
 }

--- a/engine/src/cubos/engine/physics/plugin.cpp
+++ b/engine/src/cubos/engine/physics/plugin.cpp
@@ -56,8 +56,6 @@ static bool simulatePhysicsStep(PhysicsAccumulator& accumulator, const FixedDelt
 
 void cubos::engine::physicsPlugin(Cubos& cubos)
 {
-    cubos.addPlugin(gravityPlugin);
-
     cubos.addResource<FixedDeltaTime>();
     cubos.addResource<Substeps>();
     cubos.addResource<PhysicsAccumulator>();
@@ -69,6 +67,8 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
     cubos.addComponent<Mass>();
     cubos.addComponent<AccumulatedCorrection>();
     cubos.addComponent<PreviousPosition>();
+
+    cubos.addPlugin(gravityPlugin);
 
     // executed every frame
     cubos.system("increase fixed-step accumulator")

--- a/engine/src/cubos/engine/physics/plugin.cpp
+++ b/engine/src/cubos/engine/physics/plugin.cpp
@@ -15,11 +15,11 @@ CUBOS_REFLECT_IMPL(AccumulatedCorrection)
         .build();
 }
 
-CUBOS_REFLECT_IMPL(PhysicsMass)
+CUBOS_REFLECT_IMPL(Mass)
 {
-    return cubos::core::ecs::TypeBuilder<PhysicsMass>("cubos::engine::PhysicsMass")
-        .withField("mass", &PhysicsMass::mass)
-        .withField("inverseMass", &PhysicsMass::inverseMass)
+    return cubos::core::ecs::TypeBuilder<Mass>("cubos::engine::Mass")
+        .withField("mass", &Mass::mass)
+        .withField("inverseMass", &Mass::inverseMass)
         .build();
 }
 
@@ -66,7 +66,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
     cubos.addComponent<Velocity>();
     cubos.addComponent<Force>();
     cubos.addComponent<Impulse>();
-    cubos.addComponent<PhysicsMass>();
+    cubos.addComponent<Mass>();
     cubos.addComponent<AccumulatedCorrection>();
     cubos.addComponent<PreviousPosition>();
 
@@ -86,7 +86,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
         .after("cubos.physics.apply_forces")
         .before("cubos.physics.simulation.substeps.integrate")
         .onlyIf(simulatePhysicsStep)
-        .call([](Query<Velocity&, const Impulse&, const PhysicsMass&> query) {
+        .call([](Query<Velocity&, const Impulse&, const Mass&> query) {
             for (auto [velocity, impulse, mass] : query)
             {
                 velocity.velocity += impulse.getImpulse() * mass.inverseMass;
@@ -97,7 +97,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
         .tagged("cubos.physics.simulation.substeps.integrate")
         .after("cubos.physics.simulation.prepare")
         .onlyIf(simulatePhysicsStep)
-        .call([](Query<Position&, PreviousPosition&, Velocity&, const Force&, const PhysicsMass&> query,
+        .call([](Query<Position&, PreviousPosition&, Velocity&, const Force&, const Mass&> query,
                  const Damping& damping, const FixedDeltaTime& fixedDeltaTime, const Substeps& substeps) {
             float subDeltaTime = fixedDeltaTime.value / (float)substeps.value;
 

--- a/engine/src/cubos/engine/physics/plugin.cpp
+++ b/engine/src/cubos/engine/physics/plugin.cpp
@@ -26,7 +26,7 @@ CUBOS_REFLECT_IMPL(Mass)
 CUBOS_REFLECT_IMPL(Velocity)
 {
     return cubos::core::ecs::TypeBuilder<Velocity>("cubos::engine::Velocity")
-        .withField("velocity", &Velocity::velocity)
+        .withField("velocity", &Velocity::vec)
         .build();
 }
 
@@ -89,7 +89,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
         .call([](Query<Velocity&, const Impulse&, const Mass&> query) {
             for (auto [velocity, impulse, mass] : query)
             {
-                velocity.velocity += impulse.getImpulse() * mass.inverseMass;
+                velocity.vec += impulse.vec() * mass.inverseMass;
             }
         });
 
@@ -111,13 +111,13 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
                 }
 
                 // Apply damping
-                velocity.velocity *= glm::pow(damping.value, subDeltaTime);
+                velocity.vec *= glm::pow(damping.value, subDeltaTime);
 
                 // Apply external forces
-                glm::vec3 deltaLinearVelocity = force.getForce() * mass.inverseMass * subDeltaTime;
+                glm::vec3 deltaLinearVelocity = force.vec() * mass.inverseMass * subDeltaTime;
 
-                velocity.velocity += deltaLinearVelocity;
-                position.vec += velocity.velocity * subDeltaTime;
+                velocity.vec += deltaLinearVelocity;
+                position.vec += velocity.vec * subDeltaTime;
             }
         });
 
@@ -143,7 +143,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
 
             for (auto [position, prevPosition, velocity] : query)
             {
-                velocity.velocity = (position.vec - prevPosition.vec) / subDeltaTime;
+                velocity.vec = (position.vec - prevPosition.vec) / subDeltaTime;
             }
         });
 
@@ -154,7 +154,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
         .call([](Query<Force&> query) {
             for (auto [force] : query)
             {
-                force.clearForce();
+                force.clear();
             }
         });
 
@@ -165,7 +165,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
         .call([](Query<Impulse&> query) {
             for (auto [impulse] : query)
             {
-                impulse.clearImpulse();
+                impulse.clear();
             }
         });
 


### PR DESCRIPTION
Separate physics force and impulse into their own components.
Remove Physics prefix from physics force, impulse, velocity and mass components

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.