### PR TITLE
Allow querying over entity relations

### DIFF
--- a/core/include/cubos/core/ecs/query/data.hpp
+++ b/core/include/cubos/core/ecs/query/data.hpp
@@ -137,12 +137,30 @@ namespace cubos::core::ecs
 
         /// @brief Accesses the match for the given entity, if there is one.
         /// @param entity Entity.
-        /// @return Requested components, or nothing if the entity does not match the query.
+        /// @return Requested data, or nothing if the entity does not match the query.
         Opt<std::tuple<Ts...>> at(Entity entity)
         {
             CUBOS_ASSERT(mFilter->targetCount() == 1);
 
             auto view = this->view().pin(0, entity);
+
+            if (view.begin() == view.end())
+            {
+                return {};
+            }
+
+            return *view.begin();
+        }
+
+        /// @brief Accesses the match for the given entities, if there is one.
+        /// @param firstEntity Entity for the first target.
+        /// @param secondEntity Entity for the second target.
+        /// @return Requested data, or nothing if the entities do not match the query.
+        Opt<std::tuple<Ts...>> at(Entity firstEntity, Entity secondEntity)
+        {
+            CUBOS_ASSERT(mFilter->targetCount() == 2);
+
+            auto view = this->view().pin(0, firstEntity).pin(1, secondEntity);
 
             if (view.begin() == view.end())
             {

--- a/core/include/cubos/core/ecs/query/filter.hpp
+++ b/core/include/cubos/core/ecs/query/filter.hpp
@@ -184,8 +184,8 @@ namespace cubos::core::ecs
         bool valid() const;
 
     private:
-        /// @brief Advances the iterator's archetype until a non-empty one is found.
-        void findArchetype();
+        /// @brief Advances the iterator to the next valid match. Wraps around.
+        void advance();
 
         /// @brief Gets the index value which represents the end of the iteration.
         /// @return End index.

--- a/core/include/cubos/core/ecs/query/term.hpp
+++ b/core/include/cubos/core/ecs/query/term.hpp
@@ -130,5 +130,11 @@ namespace cubos::core::ecs
         /// @return Result of merging the two vectors.
         static std::vector<QueryTerm> resolve(const Types& types, const std::vector<QueryTerm>& baseTerms,
                                               std::vector<QueryTerm>& otherTerms);
+
+        /// @brief Gets a string representation of vector of query terms.
+        /// @param types Type registry.
+        /// @param terms Vector of terms.
+        /// @return String representation.
+        static std::string toString(const Types& types, const std::vector<QueryTerm>& terms);
     };
 } // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/query/term.hpp
+++ b/core/include/cubos/core/ecs/query/term.hpp
@@ -35,6 +35,13 @@ namespace cubos::core::ecs
             bool optional; ///< If true, the term accesses the component but does not require it to be present.
         };
 
+        /// @brief Stores relation term data.
+        struct Relation
+        {
+            int fromTarget; ///< Index of the 'from' target accessed by this term.
+            int toTarget;   ///< Index of the 'to' target accessed by this term.
+        };
+
         /// @brief Type of the data matched by the term.
         ///
         /// If this is set to @ref DataTypeId::Invalid, then the term is an entity term.
@@ -44,6 +51,7 @@ namespace cubos::core::ecs
         union {
             Entity entity;       ///< Entity term data.
             Component component; ///< Component term data.
+            Relation relation;   ///< Relation term data.
         };
 
         /// @brief Returns a new entity term for the given target.
@@ -72,6 +80,14 @@ namespace cubos::core::ecs
         /// @return Component term.
         static QueryTerm makeOptComponent(DataTypeId type, int target);
 
+        /// @brief Returns a new relation term for the given relation and targets.
+        /// @warning Undefined behaviour will occur if @p type isn't registered as a relation.
+        /// @param type Relation type.
+        /// @param fromTarget Index of the target which must have the 'from' side of the relation.
+        /// @param toTarget Index of the target which must have the 'to' side of the relation.
+        /// @return Relation term.
+        static QueryTerm makeRelation(DataTypeId type, int fromTarget, int toTarget);
+
         /// @brief Checks if the term is an entity term.
         /// @return Whether it's an entity term.
         bool isEntity() const;
@@ -80,6 +96,11 @@ namespace cubos::core::ecs
         /// @param types Types registry.
         /// @return Whether it's a component term.
         bool isComponent(const Types& types) const;
+
+        /// @brief Checks if the term is a relation term.
+        /// @param types Types registry.
+        /// @return Whether it's a relation term.
+        bool isRelation(const Types& types) const;
 
         /// @brief Compares two terms.
         /// @param types Types registry.

--- a/core/include/cubos/core/ecs/system/query.hpp
+++ b/core/include/cubos/core/ecs/system/query.hpp
@@ -58,6 +58,15 @@ namespace cubos::core::ecs
             return mView.data().at(entity);
         }
 
+        /// @brief Accesses the match for the given entities, if there is one.
+        /// @param firstEntity Entity for the first target.
+        /// @param secondEntity Entity for the second target.
+        /// @return Requested data, or nothing if the entities do not match the query.
+        Opt<std::tuple<Ts...>> at(Entity firstEntity, Entity secondEntity)
+        {
+            return mView.data().at(firstEntity, secondEntity);
+        }
+
     private:
         typename QueryData<Ts...>::View mView;
     };

--- a/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
+++ b/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
@@ -77,7 +77,8 @@ namespace cubos::core::ecs
         /// @return Whether the relation exists.
         bool contains(uint32_t from, uint32_t to) const;
 
-        /// @brief Gets the row of the relation with the given indices.
+        /// @brief Gets the row of the relation with the given indices, or @ref size() if there is
+        /// none.
         /// @param from From index.
         /// @param to To index.
         /// @return Row of the data.
@@ -98,6 +99,26 @@ namespace cubos::core::ecs
         /// @param[out] from From index.
         /// @param[out] to To index.
         void indices(std::size_t row, uint32_t& from, uint32_t& to) const;
+
+        /// @brief Gets the first row with the given from index, or @ref size() if there is none.
+        /// @param index From index.
+        /// @return First row with the given from index.
+        std::size_t firstFrom(uint32_t index) const;
+
+        /// @brief Gets the first row with the given to index, or @ref size() if there is none.
+        /// @param index To index.
+        /// @return First row with the given to index.
+        std::size_t firstTo(uint32_t index) const;
+
+        /// @brief Gets the next row with the same from index, or @ref size() if there is none.
+        /// @param row Row to get the next from.
+        /// @return Next row with the same from index.
+        std::size_t nextFrom(std::size_t row) const;
+
+        /// @brief Gets the next row with the same to index, or @ref size() if there is none.
+        /// @param row Row to get the next to.
+        /// @return Next row with the same to index.
+        std::size_t nextTo(std::size_t row) const;
 
         /// @brief Gets an iterator to the first relation of the table.
         /// @return Iterator.

--- a/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
+++ b/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
@@ -92,6 +92,13 @@ namespace cubos::core::ecs
         /// @copydoc at(std::size_t)
         const void* at(std::size_t row) const;
 
+        /// @brief Get the entity indices at the given row.
+        /// @note Aborts if @p row is out of bounds.
+        /// @param row Row to get.
+        /// @param[out] from From index.
+        /// @param[out] to To index.
+        void indices(std::size_t row, uint32_t& from, uint32_t& to) const;
+
         /// @brief Gets an iterator to the first relation of the table.
         /// @return Iterator.
         Iterator begin() const;

--- a/core/samples/ecs/relations/main.cpp
+++ b/core/samples/ecs/relations/main.cpp
@@ -1,11 +1,15 @@
+#include <cubos/core/ecs/query/data.hpp>
+#include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/ecs/world.hpp>
 #include <cubos/core/log.hpp>
-#include <cubos/core/reflection/traits/constructible.hpp>
-#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 
+using cubos::core::ecs::Entity;
+using cubos::core::ecs::QueryData;
+using cubos::core::ecs::QueryTerm;
+using cubos::core::ecs::TypeBuilder;
 using cubos::core::ecs::World;
-using cubos::core::reflection::ConstructibleTrait;
-using cubos::core::reflection::Type;
+using cubos::core::reflection::reflect;
 
 struct ChildOf
 {
@@ -14,20 +18,54 @@ struct ChildOf
 
 CUBOS_REFLECT_IMPL(ChildOf)
 {
-    return Type::create("ChildOf").with(ConstructibleTrait::typed<ChildOf>().withMoveConstructor().build());
+    return TypeBuilder<ChildOf>("ChildOf").build();
+}
+
+struct Name
+{
+    CUBOS_REFLECT;
+    std::string name;
+};
+
+CUBOS_REFLECT_IMPL(Name)
+{
+    return TypeBuilder<Name>("Name").withField("name", &Name::name).build();
 }
 
 int main()
 {
     World world{};
     world.registerRelation<ChildOf>();
+    world.registerComponent<Name>();
+    auto childOfRelation = world.types().id(reflect<ChildOf>());
+    auto nameComponent = world.types().id(reflect<Name>());
 
-    auto foo = world.create();
-    auto bar = world.create();
+    auto alice = world.create();
+    world.components(alice).add(Name{"Alice"});
+    auto bob = world.create();
+    world.components(bob).add(Name{"Bob"});
+    auto charlie = world.create();
+    world.components(charlie).add(Name{"Charlie"});
+    auto diego = world.create();
+    world.components(diego).add(Name{"Diego"});
+    auto eve = world.create();
+    world.components(eve).add(Name{"Eve"});
 
-    CUBOS_ASSERT(!world.related<ChildOf>(foo, bar), "foo and bar should not be related yet");
-    world.relate(foo, bar, ChildOf{});
-    CUBOS_ASSERT(world.related<ChildOf>(foo, bar), "foo and bar should now be related");
-    world.unrelate<ChildOf>(foo, bar);
-    CUBOS_ASSERT(!world.related<ChildOf>(foo, bar), "foo and bar should no longer be related");
+    world.relate(alice, charlie, ChildOf{});
+    world.relate(bob, charlie, ChildOf{});
+    world.relate(charlie, eve, ChildOf{});
+    world.relate(diego, eve, ChildOf{});
+
+    QueryData<const Name&, const Name&> query{world,
+                                    {
+                                        QueryTerm::makeWithComponent(nameComponent, 0),
+                                        QueryTerm::makeRelation(childOfRelation, 0, 1),
+                                        QueryTerm::makeWithComponent(nameComponent, 1),
+                                    }};
+
+    CUBOS_INFO("Query over all relations:");
+    for (auto [child, parent] : query.view())
+    {
+        CUBOS_INFO("{} is a child of {}", child, parent);
+    }
 }

--- a/core/src/cubos/core/ecs/query/filter.cpp
+++ b/core/src/cubos/core/ecs/query/filter.cpp
@@ -115,8 +115,9 @@ void QueryFilter::update()
 
             for (const auto& term : mTerms)
             {
-                // Filter out non 'without component' terms.
-                if (!term.isComponent(mWorld.types()) || !term.component.without)
+                // Filter out non 'without component' terms and terms with different targets.
+                if (!term.isComponent(mWorld.types()) || !term.component.without ||
+                    term.component.target != targetIndex)
                 {
                     continue;
                 }
@@ -397,6 +398,7 @@ void QueryFilter::View::Iterator::advance()
                    mCursorRows[filter.mTargetCount] >= world.tables().sparseRelation().at(link.tables[mIndex]).size())
             {
                 ++mIndex;
+                mCursorRows[filter.mTargetCount] = 0;
             }
         }
         else if (mView.mPins[link.fromTarget].isNull())
@@ -480,7 +482,8 @@ void QueryFilter::View::Iterator::advance()
 
                 // Find the index of the table which matches the pinned entities.
                 mIndex = 0;
-                while (link.tables[mIndex].from != fromArchetype || link.tables[mIndex].to != toArchetype)
+                while (mIndex < link.tables.size() &&
+                       (link.tables[mIndex].from != fromArchetype || link.tables[mIndex].to != toArchetype))
                 {
                     ++mIndex;
                 }

--- a/core/src/cubos/core/ecs/query/term.cpp
+++ b/core/src/cubos/core/ecs/query/term.cpp
@@ -288,7 +288,7 @@ std::vector<QueryTerm> QueryTerm::resolve(const Types& types, const std::vector<
 
 std::string QueryTerm::toString(const Types& types, const std::vector<QueryTerm>& terms)
 {
-    std::string result = "";
+    std::string result;
 
     for (const auto& term : terms)
     {

--- a/core/src/cubos/core/ecs/query/term.cpp
+++ b/core/src/cubos/core/ecs/query/term.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/ecs/query/term.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/type.hpp>
 
 using cubos::core::ecs::QueryTerm;
 
@@ -269,4 +270,46 @@ std::vector<QueryTerm> QueryTerm::resolve(const Types& types, const std::vector<
     }
 
     return terms;
+}
+
+std::string QueryTerm::toString(const Types& types, const std::vector<QueryTerm>& terms)
+{
+    std::string result = "";
+
+    for (const auto& term : terms)
+    {
+        if (!result.empty())
+        {
+            result += ", ";
+        }
+
+        if (term.isEntity())
+        {
+            result += "Entity(" + std::to_string(term.entity.target) + ")";
+        }
+        else if (term.isComponent(types))
+        {
+            if (term.component.optional)
+            {
+                result += '?';
+            }
+            else if (term.component.without)
+            {
+                result += '!';
+            }
+
+            result += types.type(term.type).name() + "(" + std::to_string(term.component.target) + ")";
+        }
+        else if (term.isRelation(types))
+        {
+            result += types.type(term.type).name() + "(" + std::to_string(term.relation.fromTarget) + ", " +
+                      std::to_string(term.relation.toTarget) + ")";
+        }
+        else
+        {
+            CUBOS_UNREACHABLE();
+        }
+    }
+
+    return result;
 }

--- a/core/src/cubos/core/ecs/table/sparse_relation/registry.cpp
+++ b/core/src/cubos/core/ecs/table/sparse_relation/registry.cpp
@@ -28,6 +28,7 @@ SparseRelationTable& SparseRelationTableRegistry::create(SparseRelationTableId i
         mTables.emplace(std::piecewise_construct, std::forward_as_tuple(id),
                         std::forward_as_tuple(types.type(id.dataType)));
         mTypeIndices[id.dataType].insert(id);
+        mIds.emplace_back(id);
     }
 
     return mTables.at(id);

--- a/core/src/cubos/core/ecs/table/sparse_relation/table.cpp
+++ b/core/src/cubos/core/ecs/table/sparse_relation/table.cpp
@@ -138,6 +138,13 @@ const void* SparseRelationTable::at(std::size_t row) const
     return mRelations.at(row);
 }
 
+void SparseRelationTable::indices(std::size_t row, uint32_t& from, uint32_t& to) const
+{
+    auto& data = mRows[row];
+    from = data.from;
+    to = data.to;
+}
+
 auto SparseRelationTable::begin() const -> Iterator
 {
     return Iterator{*this, 0};

--- a/core/src/cubos/core/ecs/table/sparse_relation/table.cpp
+++ b/core/src/cubos/core/ecs/table/sparse_relation/table.cpp
@@ -125,7 +125,12 @@ bool SparseRelationTable::contains(uint32_t from, uint32_t to) const
 
 std::size_t SparseRelationTable::row(uint32_t from, uint32_t to) const
 {
-    return static_cast<std::size_t>(mPairRows.at(pairId(from, to)));
+    if (auto it = mPairRows.find(pairId(from, to)); it != mPairRows.end())
+    {
+        return it->second;
+    }
+
+    return this->size();
 }
 
 void* SparseRelationTable::at(std::size_t row)
@@ -140,9 +145,40 @@ const void* SparseRelationTable::at(std::size_t row) const
 
 void SparseRelationTable::indices(std::size_t row, uint32_t& from, uint32_t& to) const
 {
-    auto& data = mRows[row];
-    from = data.from;
-    to = data.to;
+    from = mRows[row].from;
+    to = mRows[row].to;
+}
+
+std::size_t SparseRelationTable::firstFrom(uint32_t index) const
+{
+    if (auto it = mFromRows.find(index); it != mFromRows.end())
+    {
+        return it->second.first;
+    }
+
+    return this->size();
+}
+
+std::size_t SparseRelationTable::firstTo(uint32_t index) const
+{
+    if (auto it = mToRows.find(index); it != mToRows.end())
+    {
+        return it->second.first;
+    }
+
+    return this->size();
+}
+
+std::size_t SparseRelationTable::nextFrom(std::size_t row) const
+{
+    auto next = mRows[row].fromLink.next;
+    return next == UINT32_MAX ? this->size() : static_cast<std::size_t>(next);
+}
+
+std::size_t SparseRelationTable::nextTo(std::size_t row) const
+{
+    auto next = mRows[row].toLink.next;
+    return next == UINT32_MAX ? this->size() : static_cast<std::size_t>(next);
 }
 
 auto SparseRelationTable::begin() const -> Iterator

--- a/core/src/cubos/core/ecs/types.cpp
+++ b/core/src/cubos/core/ecs/types.cpp
@@ -39,11 +39,13 @@ void Types::add(const reflection::Type& type, Kind kind)
 
 DataTypeId Types::id(const reflection::Type& type) const
 {
+    CUBOS_ASSERT(mTypes.contains(type), "Type {} not registered", type.name());
     return mTypes.at(type);
 }
 
 DataTypeId Types::id(const std::string& name) const
 {
+    CUBOS_ASSERT(mNames.contains(name), "Type {} not registered", name);
     return mNames.at(name);
 }
 

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -144,7 +144,7 @@ void World::relate(Entity from, Entity to, const reflection::Type& type, void* v
     CUBOS_ASSERT(this->isAlive(to));
 
     auto dataType = mTypes.id(type);
-    CUBOS_ASSERT(mTypes.isRelation(dataType));
+    CUBOS_ASSERT(mTypes.isRelation(dataType), "Type {} is not registered as a relation", type.name());
 
     // Create a sparse relation table identifier from the archetypes of both entities.
     auto fromArchetype = mEntityPool.archetype(from.index);
@@ -230,7 +230,7 @@ auto World::Components::end() -> Iterator
 auto World::Components::add(const reflection::Type& type, void* value) -> Components&
 {
     auto typeId = mWorld.mTypes.id(type);
-    CUBOS_ASSERT(mWorld.mTypes.isComponent(typeId), "Type '{}' is not registered as a component", type.name());
+    CUBOS_ASSERT(mWorld.mTypes.isComponent(typeId), "Type {} is not registered as a component", type.name());
     auto columnId = ColumnId::make(typeId);
 
     auto oldArchetype = mWorld.mEntityPool.archetype(mEntity.index);
@@ -265,7 +265,7 @@ auto World::Components::add(const reflection::Type& type, void* value) -> Compon
 auto World::Components::remove(const reflection::Type& type) -> Components&
 {
     auto typeId = mWorld.mTypes.id(type);
-    CUBOS_ASSERT(mWorld.mTypes.isComponent(typeId), "Type '{}' is not registered as a component", type.name());
+    CUBOS_ASSERT(mWorld.mTypes.isComponent(typeId), "Type {} is not registered as a component", type.name());
     auto columnId = ColumnId::make(typeId);
 
     // If the old archetype doesn't contain this component type, then we don't do anything.

--- a/core/tests/ecs/query/term.cpp
+++ b/core/tests/ecs/query/term.cpp
@@ -149,7 +149,7 @@ TEST_CASE("ecs::QueryTerm")
     SUBCASE("resolve with both types of terms")
     {
         // Equivalent to having Query<Opt<IntegerComponent&>, Entity, IntegerComponent&, Entity>, with the manual terms
-        // below.
+        // Integer(0), Integer(1)
         std::vector<QueryTerm> otherTerms = {
             QueryTerm::makeOptComponent(integerComponent, -1),
             QueryTerm::makeEntity(-1),
@@ -187,7 +187,7 @@ TEST_CASE("ecs::QueryTerm")
         REQUIRE(otherTerms[3].entity.target == 1);
     }
 
-    SUBCASE("resolve with relation terms")
+    SUBCASE("resolve with relations but without base terms")
     {
         // Equivalent to having Query<Entity, EmptyRelation&, Entity, EmptyRelation& Entity> with no manual terms.
         std::vector<QueryTerm> otherTerms = {
@@ -224,6 +224,38 @@ TEST_CASE("ecs::QueryTerm")
         REQUIRE(otherTerms[3].relation.fromTarget == 1);
         REQUIRE(otherTerms[3].relation.toTarget == 2);
         REQUIRE(otherTerms[4].entity.target == 2);
+    }
+
+    SUBCASE("resolve with relation but with base terms")
+    {
+        // Equivalent to having Query<Entity, Entity> with the manual terms Entity(0), EmptyRelation(0, 1), Entity(1).
+        std::vector<QueryTerm> otherTerms = {
+            QueryTerm::makeEntity(-1),
+            QueryTerm::makeEntity(-1),
+        };
+        auto result = QueryTerm::resolve(types,
+                                         {
+                                             QueryTerm::makeEntity(0),
+                                             QueryTerm::makeRelation(emptyRelation, 0, 1),
+                                             QueryTerm::makeEntity(1),
+                                         },
+                                         otherTerms);
+
+        REQUIRE(result.size() == 3);
+
+        REQUIRE(result[0].isEntity());
+        REQUIRE(result[0].entity.target == 0);
+
+        REQUIRE(result[1].isRelation(types));
+        REQUIRE(result[1].relation.fromTarget == 0);
+        REQUIRE(result[1].relation.toTarget == 1);
+
+        REQUIRE(result[2].isEntity());
+        REQUIRE(result[2].entity.target == 1);
+
+        REQUIRE(otherTerms.size() == 2);
+        REQUIRE(otherTerms[0].entity.target == 0);
+        REQUIRE(otherTerms[1].entity.target == 1);
     }
 }
 // NOLINTEND(readability-function-size)

--- a/core/tests/ecs/utils.hpp
+++ b/core/tests/ecs/utils.hpp
@@ -76,4 +76,7 @@ inline void setupWorld(cubos::core::ecs::World& world)
     world.registerComponent<DetectDestructorComponent>();
     world.registerComponent<EntityArrayComponent>();
     world.registerComponent<EntityDictionaryComponent>();
+    world.registerRelation<EmptyRelation>();
+    world.registerRelation<IntegerRelation>();
+    world.registerRelation<DetectDestructorRelation>();
 }


### PR DESCRIPTION
# Description

Changes the query code to allow querying over a single relation and two targets.
Also allows pinning one or both of the targets so that users can query, for example, all of the children of a specific entity.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
