### PR TITLE
Add symmetric entity relations

### DIFF
--- a/core/include/cubos/core/ecs/query/filter.hpp
+++ b/core/include/cubos/core/ecs/query/filter.hpp
@@ -71,6 +71,9 @@ namespace cubos::core::ecs
             /// @brief Relation data type.
             DataTypeId dataType;
 
+            /// @brief Whether the link is symmetric.
+            bool isSymmetric;
+
             /// @brief From target index.
             int fromTarget;
 
@@ -80,8 +83,23 @@ namespace cubos::core::ecs
             /// @brief Tables which match the link, found through calls to @ref update().
             std::vector<SparseRelationTableId> tables;
 
+            /// @brief Tables which match the reverse link, found through calls to @ref update().
+            ///
+            /// Only filled if @ref isSymmetric is true.
+            std::vector<SparseRelationTableId> reverseTables;
+
+            /// @brief Whether each of the tables in @ref reverseTables is already in @ref tables.
+            ///
+            /// Only filled if @ref isSymmetric is true.
+            std::vector<bool> reverseTablesSeen;
+
             /// @brief How many tables have already been seen through @ref SparseRelationTableRegistry::collect.
             std::size_t seenCount{0};
+
+            /// @brief Gets the nth table in the link, as if the reverseTables vector was appended to the end of the
+            /// tables vector.
+            /// @param index Table index.
+            SparseRelationTableId table(std::size_t index) const;
         };
 
         World& mWorld;

--- a/core/include/cubos/core/ecs/query/filter.hpp
+++ b/core/include/cubos/core/ecs/query/filter.hpp
@@ -68,6 +68,9 @@ namespace cubos::core::ecs
         /// @brief Holds the necessary data for each link.
         struct Link
         {
+            /// @brief Relation data type.
+            DataTypeId dataType;
+
             /// @brief From target index.
             int fromTarget;
 

--- a/core/include/cubos/core/ecs/reflection.hpp
+++ b/core/include/cubos/core/ecs/reflection.hpp
@@ -10,6 +10,13 @@
 
 namespace cubos::core::ecs
 {
+    /// @brief Trait used to identify symmetric relations.
+    ///
+    /// Symmetric relations are relations where the order of the entities does not matter.
+    struct SymmetricTrait
+    {
+    };
+
     /// @brief Builder for @ref reflection::Type objects which represent ECS types.
     ///
     /// Used to reduce the amount of boilerplate code required to define a ECS types.
@@ -28,6 +35,14 @@ namespace cubos::core::ecs
             : mType(reflection::Type::create(std::move(name)))
         {
             mType.with(reflection::ConstructibleTrait::typed<T>().withBasicConstructors().build());
+        }
+
+        /// @brief Makes the type symmetric. Only used by relation types.
+        /// @return Builder.
+        TypeBuilder&& symmetric() &&
+        {
+            mType.with(SymmetricTrait{});
+            return std::move(*this);
         }
 
         /// @brief Adds a field to the type.

--- a/core/include/cubos/core/ecs/table/sparse_relation/registry.hpp
+++ b/core/include/cubos/core/ecs/table/sparse_relation/registry.hpp
@@ -93,19 +93,15 @@ namespace cubos::core::ecs
         /// @param index Entity index.
         void erase(ArchetypeId archetype, uint32_t index);
 
-        /// @brief Collects new tables which match the given filter.
-        /// @param[out] tables Vector to insert the table identifiers into.
+        /// @brief Calls the given function for each new table.
         /// @param counter Counter previously returned by this function. Zero should be used for the first call.
-        /// @param filter Function which receives a table identifier and returns a boolean.
+        /// @param func Function which receives a table identifier.
         /// @return Counter to be passed to this function in a future call.
-        std::size_t collect(std::vector<SparseRelationTableId>& tables, std::size_t counter, auto filter)
+        std::size_t forEach(std::size_t counter, auto func)
         {
             for (; counter < mIds.size(); ++counter)
             {
-                if (filter(mIds[counter]))
-                {
-                    tables.emplace_back(mIds[counter]);
-                }
+                func(mIds[counter]);
             }
 
             return counter;

--- a/core/include/cubos/core/ecs/types.hpp
+++ b/core/include/cubos/core/ecs/types.hpp
@@ -80,6 +80,11 @@ namespace cubos::core::ecs
         /// @return Whether the identifier refers to a relation.
         bool isRelation(DataTypeId id) const;
 
+        /// @brief Checks if the given data type is a symmetric relation.
+        /// @param id Data type identifier.
+        /// @return Whether the identifier refers to a symmetric relation.
+        bool isSymmetricRelation(DataTypeId id) const;
+
         /// @brief Gets a type registry with only the component types.
         /// @return Component type registry.
         reflection::TypeRegistry components() const;
@@ -97,6 +102,7 @@ namespace cubos::core::ecs
         {
             const reflection::Type* type; ///< Data type.
             Kind kind;                    ///< Data type kind.
+            bool isSymmetric;             ///< Whether the relation is symmetric (ignored for components).
         };
 
         /// @brief Registers a new data type.

--- a/core/src/cubos/core/ecs/query/filter.cpp
+++ b/core/src/cubos/core/ecs/query/filter.cpp
@@ -55,6 +55,7 @@ QueryFilter::QueryFilter(World& world, const std::vector<QueryTerm>& terms)
         {
             CUBOS_ASSERT(mLinkCount < MaxLinkCount, "Currently only {} links are supported", MaxLinkCount);
             mTermCursors.emplace_back(mTargetCount + mLinkCount);
+            mLinks[mLinkCount].dataType = term.type;
             mLinks[mLinkCount].fromTarget = term.relation.fromTarget;
             mLinks[mLinkCount].toTarget = term.relation.toTarget;
             ++mLinkCount;
@@ -146,6 +147,11 @@ void QueryFilter::update()
         // Collect all tables which match any of the target archetypes.
         link.seenCount =
             mWorld.tables().sparseRelation().collect(link.tables, link.seenCount, [&](SparseRelationTableId id) {
+                if (id.dataType != link.dataType)
+                {
+                    return false;
+                }
+
                 // The from archetype must be one of the from target archetypes.
                 bool found = false;
                 for (const auto& archetype : mTargets[link.fromTarget].archetypes)

--- a/core/src/cubos/core/ecs/types.cpp
+++ b/core/src/cubos/core/ecs/types.cpp
@@ -1,7 +1,7 @@
+#include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/ecs/types.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/reflection/external/string.hpp>
-#include <cubos/core/reflection/type.hpp>
 
 using cubos::core::ecs::DataTypeId;
 using cubos::core::ecs::DataTypeIdHash;
@@ -34,7 +34,7 @@ void Types::add(const reflection::Type& type, Kind kind)
     auto inserted = mNames.emplace(type.name(), id).second;
     CUBOS_ASSERT(inserted, "A different type with the same name {} was already registered", type.name());
     mTypes.insert(type, id);
-    mEntries.push_back({.type = &type, .kind = kind});
+    mEntries.push_back({.type = &type, .kind = kind, .isSymmetric = type.has<SymmetricTrait>()});
 }
 
 DataTypeId Types::id(const reflection::Type& type) const
@@ -67,6 +67,11 @@ bool Types::isComponent(DataTypeId id) const
 bool Types::isRelation(DataTypeId id) const
 {
     return mEntries[id.inner].kind == Kind::Relation;
+}
+
+bool Types::isSymmetricRelation(DataTypeId id) const
+{
+    return mEntries[id.inner].kind == Kind::Relation && mEntries[id.inner].isSymmetric;
 }
 
 TypeRegistry Types::components() const

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -146,6 +146,16 @@ void World::relate(Entity from, Entity to, const reflection::Type& type, void* v
     auto dataType = mTypes.id(type);
     CUBOS_ASSERT(mTypes.isRelation(dataType), "Type {} is not registered as a relation", type.name());
 
+    if (mTypes.isSymmetricRelation(dataType))
+    {
+        // If the relation is symmetric, then we need to make sure that the 'from' entity is always
+        // the one with the lowest index.
+        if (from.index > to.index)
+        {
+            std::swap(from, to);
+        }
+    }
+
     // Create a sparse relation table identifier from the archetypes of both entities.
     auto fromArchetype = mEntityPool.archetype(from.index);
     auto toArchetype = mEntityPool.archetype(to.index);
@@ -162,7 +172,17 @@ void World::unrelate(Entity from, Entity to, const reflection::Type& type)
     CUBOS_ASSERT(this->isAlive(to));
 
     auto dataType = mTypes.id(type);
-    CUBOS_ASSERT(mTypes.isRelation(dataType));
+    CUBOS_ASSERT(mTypes.isRelation(dataType), "Type {} is not registered as a relation", type.name());
+
+    if (mTypes.isSymmetricRelation(dataType))
+    {
+        // If the relation is symmetric, then we need to make sure that the 'from' entity is always
+        // the one with the lowest index.
+        if (from.index > to.index)
+        {
+            std::swap(from, to);
+        }
+    }
 
     auto fromArchetype = mEntityPool.archetype(from.index);
     auto toArchetype = mEntityPool.archetype(to.index);
@@ -182,6 +202,16 @@ bool World::related(Entity from, Entity to, const reflection::Type& type) const
 
     auto dataType = mTypes.id(type);
     CUBOS_ASSERT(mTypes.isRelation(dataType));
+
+    if (mTypes.isSymmetricRelation(dataType))
+    {
+        // If the relation is symmetric, then we need to make sure that the 'from' entity is always
+        // the one with the lowest index.
+        if (from.index > to.index)
+        {
+            std::swap(from, to);
+        }
+    }
 
     auto fromArchetype = mEntityPool.archetype(from.index);
     auto toArchetype = mEntityPool.archetype(to.index);

--- a/core/tests/ecs/types.cpp
+++ b/core/tests/ecs/types.cpp
@@ -4,7 +4,7 @@
 #include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-#include "../utils.hpp"
+#include "utils.hpp"
 
 using cubos::core::ecs::Types;
 using cubos::core::reflection::reflect;
@@ -19,4 +19,14 @@ TEST_CASE("ecs::Types")
     REQUIRE(types.id(reflect<int>()).inner == 0);
     REQUIRE(types.type({.inner = 0}).is<int>());
     REQUIRE(types.isComponent({.inner = 0}));
+    REQUIRE_FALSE(types.isRelation({.inner = 0}));
+
+    types.addRelation(reflect<SymmetricRelation>());
+    REQUIRE(types.contains("SymmetricRelation"));
+    REQUIRE(types.id("SymmetricRelation").inner == 1);
+    REQUIRE(types.id(reflect<SymmetricRelation>()).inner == 1);
+    REQUIRE(types.type({.inner = 1}).is<SymmetricRelation>());
+    REQUIRE_FALSE(types.isComponent({.inner = 1}));
+    REQUIRE(types.isRelation({.inner = 1}));
+    REQUIRE(types.isSymmetricRelation({.inner = 1}));
 }

--- a/core/tests/ecs/utils.cpp
+++ b/core/tests/ecs/utils.cpp
@@ -57,6 +57,14 @@ CUBOS_REFLECT_IMPL(IntegerRelation)
         .build();
 }
 
+CUBOS_REFLECT_IMPL(SymmetricRelation)
+{
+    return cubos::core::ecs::TypeBuilder<SymmetricRelation>("SymmetricRelation")
+        .withField("value", &SymmetricRelation::value)
+        .symmetric()
+        .build();
+}
+
 CUBOS_REFLECT_IMPL(DetectDestructorRelation)
 {
     using namespace cubos::core::reflection;

--- a/core/tests/ecs/utils.hpp
+++ b/core/tests/ecs/utils.hpp
@@ -60,6 +60,14 @@ struct IntegerRelation
     int value;
 };
 
+// A symmetric relation which stores a single integer.
+struct SymmetricRelation
+{
+    CUBOS_REFLECT;
+
+    int value;
+};
+
 // A relation which can be used to test if destructors are called correctly.
 struct DetectDestructorRelation
 {
@@ -78,5 +86,6 @@ inline void setupWorld(cubos::core::ecs::World& world)
     world.registerComponent<EntityDictionaryComponent>();
     world.registerRelation<EmptyRelation>();
     world.registerRelation<IntegerRelation>();
+    world.registerRelation<SymmetricRelation>();
     world.registerRelation<DetectDestructorRelation>();
 }


### PR DESCRIPTION
Blocked on #888.

# Description

Adds the `SymmetricTrait` which can be added to relation types, making their direction not matter.
This will be useful for relations like `CollidesWith`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
