### PR TITLE
Move relations to other tables when the archetype changes 

### DIFF
--- a/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
+++ b/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
@@ -66,10 +66,22 @@ namespace cubos::core::ecs
         /// @return How many relations were erased.
         std::size_t eraseFrom(uint32_t from);
 
+        /// @brief Moves all relations with the given from index to another table.
+        /// @param from From index.
+        /// @param other Other table. Must have the same relation type.
+        /// @return How many relations were erased.
+        std::size_t moveFrom(uint32_t from, SparseRelationTable& other);
+
         /// @brief Removes all relations to the given index.
         /// @param to To index.
-        /// @return How many relations were erased.
+        /// @return How many relations were moved.
         std::size_t eraseTo(uint32_t to);
+
+        /// @brief Moves all relations with the given to index to another table.
+        /// @param to To index index.
+        /// @param other Other table. Must have the same relation type.
+        /// @return How many relations were moved.
+        std::size_t moveTo(uint32_t to, SparseRelationTable& other);
 
         /// @brief Checks whether the given relation exists between the given indices.
         /// @param from From index.

--- a/core/src/cubos/core/ecs/table/sparse_relation/table.cpp
+++ b/core/src/cubos/core/ecs/table/sparse_relation/table.cpp
@@ -104,6 +104,22 @@ std::size_t SparseRelationTable::eraseFrom(uint32_t from)
     return count;
 }
 
+std::size_t SparseRelationTable::moveFrom(uint32_t from, SparseRelationTable& other)
+{
+    std::size_t count = 0;
+
+    while (mFromRows.contains(from))
+    {
+        auto rowIndex = mFromRows.at(from).first;
+        auto& row = mRows[rowIndex];
+        other.insert(row.from, row.to, this->at(rowIndex));
+        this->erase(row.from, row.to);
+        count += 1;
+    }
+
+    return count;
+}
+
 std::size_t SparseRelationTable::eraseTo(uint32_t to)
 {
     std::size_t count = 0;
@@ -111,6 +127,22 @@ std::size_t SparseRelationTable::eraseTo(uint32_t to)
     while (mToRows.contains(to))
     {
         auto& row = mRows[mToRows.at(to).first];
+        this->erase(row.from, row.to);
+        count += 1;
+    }
+
+    return count;
+}
+
+std::size_t SparseRelationTable::moveTo(uint32_t to, SparseRelationTable& other)
+{
+    std::size_t count = 0;
+
+    while (mToRows.contains(to))
+    {
+        auto rowIndex = mToRows.at(to).first;
+        auto& row = mRows[rowIndex];
+        other.insert(row.from, row.to, this->at(rowIndex));
         this->erase(row.from, row.to);
         count += 1;
     }

--- a/core/src/cubos/core/ecs/world.cpp
+++ b/core/src/cubos/core/ecs/world.cpp
@@ -256,7 +256,34 @@ auto World::Components::add(const reflection::Type& type, void* value) -> Compon
     newTable.column(columnId).pushMove(value);
 
     // For each sparse relation table the entity is on, move its relations to the new corresponding one.
-    // TODO
+    for (const auto& [_, index] : mWorld.mTables.sparseRelation())
+    {
+        // For each table where the entity's archetype is the 'from' archetype.
+        if (index.from().contains(oldArchetype))
+        {
+            for (const auto& oldTableId : index.from().at(oldArchetype))
+            {
+                // Move all occurrences of the entity in the 'from' column to the new table.
+                auto newTableId = oldTableId;
+                newTableId.from = newArchetype;
+                auto& newTable = mWorld.mTables.sparseRelation().create(newTableId, mWorld.mTypes);
+                mWorld.mTables.sparseRelation().at(oldTableId).moveFrom(mEntity.index, newTable);
+            }
+        }
+
+        // For each table where the entity's archetype is the 'to' archetype.
+        if (index.to().contains(oldArchetype))
+        {
+            for (const auto& oldTableId : index.to().at(oldArchetype))
+            {
+                // Move all occurrences of the entity in the 'to' column to the new table.
+                auto newTableId = oldTableId;
+                newTableId.to = newArchetype;
+                auto& newTable = mWorld.mTables.sparseRelation().create(newTableId, mWorld.mTypes);
+                mWorld.mTables.sparseRelation().at(oldTableId).moveTo(mEntity.index, newTable);
+            }
+        }
+    }
 
     CUBOS_DEBUG("Added component {} to entity {}", type.name(), mEntity, mEntity);
     return *this;
@@ -288,7 +315,34 @@ auto World::Components::remove(const reflection::Type& type) -> Components&
     oldTable.swapMove(mEntity.index, newTable);
 
     // For each sparse relation table the entity is on, move its relations to the new corresponding one.
-    // TODO
+    for (const auto& [_, index] : mWorld.mTables.sparseRelation())
+    {
+        // For each table where the entity's archetype is the 'from' archetype.
+        if (index.from().contains(oldArchetype))
+        {
+            for (const auto& oldTableId : index.from().at(oldArchetype))
+            {
+                // Move all occurrences of the entity in the 'from' column to the new table.
+                auto newTableId = oldTableId;
+                newTableId.from = newArchetype;
+                auto& newTable = mWorld.mTables.sparseRelation().create(newTableId, mWorld.mTypes);
+                mWorld.mTables.sparseRelation().at(oldTableId).moveFrom(mEntity.index, newTable);
+            }
+        }
+
+        // For each table where the entity's archetype is the 'to' archetype.
+        if (index.to().contains(oldArchetype))
+        {
+            for (const auto& oldTableId : index.to().at(oldArchetype))
+            {
+                // Move all occurrences of the entity in the 'to' column to the new table.
+                auto newTableId = oldTableId;
+                newTableId.to = newArchetype;
+                auto& newTable = mWorld.mTables.sparseRelation().create(newTableId, mWorld.mTypes);
+                mWorld.mTables.sparseRelation().at(oldTableId).moveTo(mEntity.index, newTable);
+            }
+        }
+    }
 
     CUBOS_DEBUG("Removed component {} from entity {}", type.name(), mEntity);
     return *this;


### PR DESCRIPTION
# Description

I forgot to move relations between tables when their entity's archetypes change.
This adds a test to cover that scenario and fixes the bug.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
