### PR TITLE
Replace reserved keyword in Gizmos shader

### DIFF
--- a/engine/src/cubos/engine/gizmos/renderer.cpp
+++ b/engine/src/cubos/engine/gizmos/renderer.cpp
@@ -89,12 +89,12 @@ void GizmosRenderer::initIdPipeline()
 
             uniform uint gizmo;
             
-            out uvec2 output;
+            out uvec2 idOutput;
 
             void main()
             {
-                output.r = (gizmo >> 16U);
-                output.g = (gizmo & 65535U);
+                idOutput.r = (gizmo >> 16U);
+                idOutput.g = (gizmo & 65535U);
             }
         )");
 


### PR DESCRIPTION
# Description

Replaces GLSL reserved word "output" in gizmos id shader with "idOutput" (same as the screen picking shader).

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
