### PR TITLE
refactor: move Cubos to core

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -113,6 +113,7 @@ set(CUBOS_CORE_SOURCE
     "src/cubos/core/ecs/world.cpp"
     "src/cubos/core/ecs/command_buffer.cpp"
     "src/cubos/core/ecs/types.cpp"
+    "src/cubos/core/ecs/cubos.cpp"
 
     "src/cubos/core/geom/box.cpp"
     "src/cubos/core/geom/capsule.cpp"

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -12,15 +12,13 @@
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/world.hpp>
 
-#include <cubos/engine/prelude.hpp>
-
-namespace cubos::engine
+namespace cubos::core::ecs
 {
     /// @brief Resource which stores the time since the last iteration of the main loop started.
     ///
     /// This resource is added and updated by the @ref Cubos class.
     ///
-    /// @ingroup engine
+    /// @ingroup core-ecs
     struct DeltaTime
     {
         DeltaTime(float value);
@@ -32,7 +30,7 @@ namespace cubos::engine
     ///
     /// This resource is added by the @ref Cubos class, initially set to true.
     ///
-    /// @ingroup engine
+    /// @ingroup core-ecs
     struct ShouldQuit
     {
         ShouldQuit(bool value);
@@ -44,7 +42,7 @@ namespace cubos::engine
     ///
     /// This resource is added by the @ref Cubos class.
     ///
-    /// @ingroup engine
+    /// @ingroup core-ecs
     struct Arguments
     {
         Arguments(std::vector<std::string> value);
@@ -53,7 +51,7 @@ namespace cubos::engine
     };
 
     /// @brief Used to chain configurations related to tags.
-    /// @ingroup engine
+    /// @ingroup core-ecs
     class TagBuilder
     {
     public:
@@ -87,7 +85,7 @@ namespace cubos::engine
     };
 
     /// @brief Used to chain configurations related to systems
-    /// @ingroup engine
+    /// @ingroup core-ecs
     class SystemBuilder
     {
     public:
@@ -126,7 +124,7 @@ namespace cubos::engine
 
     /// @brief Represents the engine itself, and exposes the interface with which the game
     /// developer interacts with. Ties up all the different parts of the engine together.
-    /// @ingroup engine
+    /// @ingroup core-ecs
     class Cubos final
     {
     public:
@@ -269,4 +267,4 @@ namespace cubos::engine
         mStartupDispatcher.addSystem(func);
         return {mStartupDispatcher, mMainTags};
     }
-} // namespace cubos::engine
+} // namespace cubos::core::ecs

--- a/core/src/cubos/core/ecs/cubos.cpp
+++ b/core/src/cubos/core/ecs/cubos.cpp
@@ -1,12 +1,16 @@
 #include <utility>
 
 #include <cubos/core/ecs/command_buffer.hpp>
+#include <cubos/core/ecs/cubos.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 
-#include <cubos/engine/cubos.hpp>
-
-using namespace cubos::engine;
+using cubos::core::ecs::Arguments;
+using cubos::core::ecs::Cubos;
+using cubos::core::ecs::DeltaTime;
+using cubos::core::ecs::ShouldQuit;
+using cubos::core::ecs::SystemBuilder;
+using cubos::core::ecs::TagBuilder;
 
 DeltaTime::DeltaTime(float value)
     : value(value)

--- a/docs/pages/2_features/ecs.md
+++ b/docs/pages/2_features/ecs.md
@@ -36,6 +36,7 @@ systems, since they have clearly defined dependencies.
 ### Our implementation
 
 **CUBOS.** ECS contains the following concepts:
+- **Cubos** - used to configure and run an ECS world and systems.
 - **World** - the main object that holds all of the ECS state.
 - **Entities** - represent objects in the game world (e.g. a car, a player, a 
   tree).
@@ -46,13 +47,6 @@ systems, since they have clearly defined dependencies.
   "DeltaTime", @ref cubos::engine::Input "Input").
 - **Systems** - functions which operate on resources and entities' components.
   This is where the logic is implemented.
-- **Dispatcher** - decides when each system is called and knows which systems
-  are independent from each other so they can be called at the same time
-  (parallel computing).
-
-On the engine side, the @ref cubos::core::ecs::Dispatcher "Dispatcher" is not
-exposed. Instead, the @ref cubos::engine::Cubos "Cubos" class is used to
-add systems and specify when they should be called.
 
 One important thing to note is that in an ECS the data is completely
 decoupled from the logic. What this means is that entities and components
@@ -139,8 +133,8 @@ their velocities and the delta time.
 
 Before components and resources are used in a World, they must be registered
 on it. This should be done once, at the start of the program. For example,
-using the **CUBOS.** @ref cubos::engine::Cubos "main class", for the previous
-example we would write:
+using the **CUBOS.** @ref cubos::core::ecs::Cubos "main class", for the
+previous example we would write:
 
 ```cpp
 cubos.addComponent<Position>();
@@ -166,8 +160,8 @@ world.destroy(entity);
 
 If necessary, you can access the world in a system through the arguments
 `const World&` or `World&`. However, this is not recommended, since it
-becomes impossible for the dispatcher to know what the system is accessing, and
-thus it cannot parallelize it.
+becomes impossible to know what the system is accessing, and thus we cannot
+parallelize it.
 
 Instead, you should use the @ref cubos::core::ecs::Commands "Commands"
 argument. Through it you can queue operations to be executed at a later time,

--- a/docs/pages/2_features/plugins.md
+++ b/docs/pages/2_features/plugins.md
@@ -19,11 +19,11 @@ An application which just prints `"Hello World!"` and which does absolutely
 nothing else - not even open a window - would look like this:
 
 ```cpp
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 #include <iostream>
 
-using Cubos = cubos::engine::Cubos;
+using cubos::engine::Cubos;
 
 void helloWorld()
 {
@@ -56,11 +56,11 @@ If we were to put the hello world functionality on a plugin, the previous
 example would look like this:
 
 ```cpp
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 #include <iostream>
 
-using Cubos = cubos::engine::Cubos;
+using cubos::engine::Cubos;
 
 void helloWorld()
 {

--- a/docs/pages/2_features/plugins.md
+++ b/docs/pages/2_features/plugins.md
@@ -9,11 +9,11 @@ familiar with the concepts of components, resources and systems.
 
 ## Configuring the engine
 
-Plugins are a feature of the @ref cubos::engine::Cubos class. This class is the
-main thing you'll be interacting with when developing a game with **CUBOS.**.
-It is used to configure the engine and run the game loop. Through it, you can
-register new components, resources and configure systems to be run on specific
-conditions.
+Plugins are a feature of the @ref cubos::core::ecs::Cubos class. This class is
+the main thing you'll be interacting with when developing a game with
+**CUBOS.**. It is used to configure the engine and run the game loop. Through
+it, you can register new components, resources and configure systems to be run
+on specific conditions.
 
 An application which just prints `"Hello World!"` and which does absolutely
 nothing else - not even open a window - would look like this:

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -9,7 +9,6 @@ message("# Building engine tests: " ${BUILD_ENGINE_TESTS})
 
 # Set engine source files
 set(CUBOS_ENGINE_SOURCE
-	"src/cubos/engine/cubos.cpp"
 	"src/cubos/engine/prelude.cpp"
 
 	"src/cubos/engine/settings/plugin.cpp"

--- a/engine/include/cubos/engine/assets/plugin.hpp
+++ b/engine/include/cubos/engine/assets/plugin.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <cubos/engine/assets/assets.hpp>
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/collisions/plugin.hpp
+++ b/engine/include/cubos/engine/collisions/plugin.hpp
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/gizmos/gizmos.hpp
+++ b/engine/include/cubos/engine/gizmos/gizmos.hpp
@@ -11,7 +11,7 @@
 
 #include <cubos/core/gl/render_device.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/gizmos/plugin.hpp
+++ b/engine/include/cubos/engine/gizmos/plugin.hpp
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
 #include <cubos/engine/gizmos/gizmos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/imgui/plugin.hpp
+++ b/engine/include/cubos/engine/imgui/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/input/plugin.hpp
+++ b/engine/include/cubos/engine/input/plugin.hpp
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
 #include <cubos/engine/input/input.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/module.dox
+++ b/engine/include/cubos/engine/module.dox
@@ -9,10 +9,9 @@ namespace cubos::engine
     /// @defgroup engine Engine
     /// @brief @b CUBOS. engine library.
     ///
-    /// The engine library is built on top of the @ref core "core library" and contains code
-    /// exclusive to game execution. This includes the main loop, asset management, rendering and
-    /// physics. It is built around the @ref Cubos class and designed to be as modular as possible.
-    /// Each sub-module corresponds to a plugin, or a set of plugins.
+    /// The engine library is built on top of the @ref core "core library" and contains code exclusive to game
+    /// execution. This includes asset management, rendering and physics. It is built around the @ref Cubos class and
+    /// designed to be as modular as possible. Each sub-module corresponds to a plugin, or a set of plugins.
     ///
     /// The library re-exports some of the @ref core "core library" functionality for convenience
     /// such that the user doesn't have to use the @ref cubos::core namespace directly very often.

--- a/engine/include/cubos/engine/physics/plugin.hpp
+++ b/engine/include/cubos/engine/physics/plugin.hpp
@@ -12,7 +12,6 @@
 #include <cubos/core/reflection/external/glm.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 
-#include <cubos/engine/cubos.hpp>
 #include <cubos/engine/physics/components/accumulated_correction.hpp>
 #include <cubos/engine/physics/components/physics_mass.hpp>
 #include <cubos/engine/physics/components/physics_velocity.hpp>
@@ -21,6 +20,7 @@
 #include <cubos/engine/physics/resources/damping.hpp>
 #include <cubos/engine/physics/resources/fixed_delta_time.hpp>
 #include <cubos/engine/physics/resources/substeps.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/physics/plugins/gravity.hpp
+++ b/engine/include/cubos/engine/physics/plugins/gravity.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
 #include <cubos/engine/physics/components/physics_mass.hpp>
 #include <cubos/engine/physics/components/physics_velocity.hpp>
 #include <cubos/engine/physics/resources/gravity.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/prelude.hpp
+++ b/engine/include/cubos/engine/prelude.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cubos/core/ecs/cubos.hpp>
 #include <cubos/core/ecs/entity/entity.hpp>
 #include <cubos/core/ecs/system/event/reader.hpp>
 #include <cubos/core/ecs/system/event/writer.hpp>
@@ -8,6 +9,18 @@
 
 namespace cubos::engine
 {
+    /// @copydoc cubos::core::ecs::Cubos
+    using Cubos = core::ecs::Cubos;
+
+    /// @copydoc cubos::core::ecs::DeltaTime
+    using DeltaTime = core::ecs::DeltaTime;
+
+    /// @copydoc cubos::core::ecs::ShouldQuit
+    using ShouldQuit = core::ecs::ShouldQuit;
+
+    /// @copydoc cubos::core::ecs::Arguments
+    using Arguments = core::ecs::Arguments;
+
     /// @copydoc cubos::core::ecs::Query
     template <typename... ComponentTypes>
     using Query = core::ecs::Query<ComponentTypes...>;

--- a/engine/include/cubos/engine/scene/plugin.hpp
+++ b/engine/include/cubos/engine/scene/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/scene/scene.hpp>
 
 namespace cubos::engine

--- a/engine/include/cubos/engine/screen_picker/plugin.hpp
+++ b/engine/include/cubos/engine/screen_picker/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/screen_picker/screen_picker.hpp>
 
 namespace cubos::engine

--- a/engine/include/cubos/engine/screen_picker/screen_picker.hpp
+++ b/engine/include/cubos/engine/screen_picker/screen_picker.hpp
@@ -6,7 +6,7 @@
 
 #include <cubos/core/gl/render_device.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/settings/plugin.hpp
+++ b/engine/include/cubos/engine/settings/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/settings/settings.hpp>
 
 namespace cubos::engine

--- a/engine/include/cubos/engine/splitscreen/plugin.hpp
+++ b/engine/include/cubos/engine/splitscreen/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/transform/plugin.hpp
+++ b/engine/include/cubos/engine/transform/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/transform/local_to_world.hpp>
 #include <cubos/engine/transform/position.hpp>
 #include <cubos/engine/transform/rotation.hpp>

--- a/engine/include/cubos/engine/utils/free_camera_controller/plugin.hpp
+++ b/engine/include/cubos/engine/utils/free_camera_controller/plugin.hpp
@@ -9,9 +9,9 @@
 
 #include <cubos/core/ecs/system/event/reader.hpp>
 
-#include <cubos/engine/cubos.hpp>
 #include <cubos/engine/input/input.hpp>
 #include <cubos/engine/input/plugin.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/transform/position.hpp>
 #include <cubos/engine/transform/rotation.hpp>
 #include <cubos/engine/utils/free_camera_controller/controller.hpp>

--- a/engine/include/cubos/engine/voxels/plugin.hpp
+++ b/engine/include/cubos/engine/voxels/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/include/cubos/engine/window/plugin.hpp
+++ b/engine/include/cubos/engine/window/plugin.hpp
@@ -9,7 +9,7 @@
 
 #include <cubos/core/io/window.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -2,7 +2,7 @@
 #include <cubos/core/ecs/system/event/writer.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 using namespace cubos::engine;
 

--- a/engine/samples/gizmos/main.cpp
+++ b/engine/samples/gizmos/main.cpp
@@ -1,5 +1,5 @@
-#include <cubos/engine/cubos.hpp>
 #include <cubos/engine/gizmos/plugin.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/renderer/plugin.hpp>
 #include <cubos/engine/settings/settings.hpp>
 #include <cubos/engine/transform/plugin.hpp>

--- a/engine/samples/hello-cubos/main.cpp
+++ b/engine/samples/hello-cubos/main.cpp
@@ -3,7 +3,7 @@
 /// [Include Components]
 
 /// [Include]
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 using cubos::engine::Cubos;
 /// [Include]

--- a/engine/samples/settings/main.cpp
+++ b/engine/samples/settings/main.cpp
@@ -1,6 +1,6 @@
 #include <cubos/core/reflection/external/string.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/settings/plugin.hpp>
 
 using namespace cubos::engine;

--- a/engine/src/cubos/engine/collisions/broad_phase/plugin.hpp
+++ b/engine/src/cubos/engine/collisions/broad_phase/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {

--- a/engine/src/cubos/engine/screen_picker/plugin.cpp
+++ b/engine/src/cubos/engine/screen_picker/plugin.cpp
@@ -1,6 +1,6 @@
 #include <cubos/core/io/window.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 #include <cubos/engine/screen_picker/plugin.hpp>
 #include <cubos/engine/screen_picker/screen_picker.hpp>
 #include <cubos/engine/window/plugin.hpp>

--- a/tools/tesseratos/include/tesseratos/debug_camera/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/debug_camera/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/entity_inspector/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/entity_inspector/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/entity_selector/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/entity_selector/plugin.hpp
@@ -9,7 +9,7 @@
 
 #include <cubos/core/ecs/entity/entity.hpp>
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/metrics_panel/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/metrics_panel/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 /// @brief @ref tesseratos module.
 namespace tesseratos

--- a/tools/tesseratos/include/tesseratos/scene_editor/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/scene_editor/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/settings_inspector/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/settings_inspector/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/toolbox/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/toolbox/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/transform_gizmo/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/transform_gizmo/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/voxel_palette_editor/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/voxel_palette_editor/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {

--- a/tools/tesseratos/include/tesseratos/world_inspector/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/world_inspector/plugin.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <cubos/engine/cubos.hpp>
+#include <cubos/engine/prelude.hpp>
 
 namespace tesseratos
 {


### PR DESCRIPTION
# Description

Moves the Cubos class from the engine to the core/ecs directory.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
