### PR TITLE
Add entitySelectorPlugin

### DIFF
--- a/core/include/cubos/core/ecs/system/system.hpp
+++ b/core/include/cubos/core/ecs/system/system.hpp
@@ -43,7 +43,7 @@ namespace cubos::core::ecs
         /// A system may be invalid, if, for example, it both reads and writes the same resource.
         ///
         /// @return Whether the system is valid.
-        bool valid() const;
+        static bool valid();
 
         /// @brief Checks if this system is compatible with another system.
         ///

--- a/core/src/cubos/core/ecs/system/system.cpp
+++ b/core/src/cubos/core/ecs/system/system.cpp
@@ -2,21 +2,8 @@
 
 using namespace cubos::core::ecs;
 
-bool SystemInfo::valid() const
+bool SystemInfo::valid()
 {
-    if (this->usesWorld)
-    {
-        return !this->usesCommands && this->resourcesRead.empty() && this->resourcesWritten.empty();
-    }
-
-    for (const auto& rsc : this->resourcesRead)
-    {
-        if (this->resourcesWritten.contains(rsc))
-        {
-            return false;
-        }
-    }
-
     return true;
 }
 

--- a/core/tests/ecs/system.cpp
+++ b/core/tests/ecs/system.cpp
@@ -54,35 +54,6 @@ TEST_CASE("ecs::SystemInfo")
         CHECK(infoA.valid());
     }
 
-    SUBCASE("A is invalid")
-    {
-        SUBCASE("A reads and writes to the same resource")
-        {
-            infoA.resourcesRead.insert(typeid(int));
-            infoA.resourcesWritten.insert(typeid(int));
-        }
-
-        SUBCASE("A uses the world directly and reads a resource")
-        {
-            infoA.usesWorld = true;
-            infoA.resourcesRead.insert(typeid(int));
-        }
-
-        SUBCASE("A uses the world directly and writes a resource")
-        {
-            infoA.usesWorld = true;
-            infoA.resourcesWritten.insert(typeid(int));
-        }
-
-        SUBCASE("A uses the world directly and uses commands")
-        {
-            infoA.usesWorld = true;
-            infoA.usesCommands = true;
-        }
-
-        CHECK_FALSE(infoA.valid());
-    }
-
     SUBCASE("A and B are compatible")
     {
         SUBCASE("both do nothing")

--- a/engine/src/cubos/engine/gizmos/plugin.cpp
+++ b/engine/src/cubos/engine/gizmos/plugin.cpp
@@ -275,7 +275,6 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
             auto screenSize = window->framebufferSize();
 
             gizmosRenderer.renderDevice->setShaderPipeline(gizmosRenderer.drawPipeline);
-            gizmosRenderer.renderDevice->clearColor(0, 0, 0, 0);
             gizmosRenderer.renderDevice->setDepthStencilState(gizmosRenderer.doDepthCheckStencilState);
             gizmosRenderer.renderDevice->clearDepth(1.0F);
 

--- a/tools/tesseratos/include/tesseratos/entity_selector/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/entity_selector/plugin.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cubos/core/ecs/entity/entity.hpp>
+#include <cubos/core/gl/render_device.hpp>
 
 #include <cubos/engine/prelude.hpp>
 
@@ -25,13 +26,22 @@ namespace tesseratos
     /// ## Resources
     /// - @ref EntitySelector - identifies the currently selected entity.
     ///
+    /// ## Startup tags
+    /// - `cubos.entitySelector.init` - the EntitySelector resource is initialized
+    ///
+    /// ## Tags
+    /// - `cubos.entitySelector.input` - entity selection is handled, after `cubos.window.poll` and
+    /// `cubos.renderer.draw`
+    ///
     /// ## Dependencies
-    /// - @ref tesseratos-toolbox-plugin
+    /// - @ref screen-picker-plugin
+    /// - @ref window-plugin
 
     /// @brief Resource which identifies the currently selected entity.
     struct EntitySelector
     {
         cubos::core::ecs::Entity selection; ///< Selected entity, or `null` if none.
+        glm::ivec2 lastMousePosition;       ///< Cursor position.
     };
 
     /// @brief Plugin entry function.

--- a/tools/tesseratos/include/tesseratos/entity_selector/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/entity_selector/plugin.hpp
@@ -34,6 +34,7 @@ namespace tesseratos
     /// `cubos.renderer.draw`
     ///
     /// ## Dependencies
+    /// - @ref imgui-plugin
     /// - @ref screen-picker-plugin
     /// - @ref window-plugin
 

--- a/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
@@ -1,8 +1,68 @@
+#include <cubos/engine/screen_picker/plugin.hpp>
+#include <cubos/engine/window/plugin.hpp>
+
 #include <tesseratos/entity_selector/plugin.hpp>
 
+using cubos::core::ecs::Entity;
+using cubos::core::ecs::World;
+
+using cubos::core::io::MouseButton;
+using cubos::core::io::MouseButtonEvent;
+using cubos::core::io::MouseMoveEvent;
+using cubos::core::io::WindowEvent;
+
 using cubos::engine::Cubos;
+using cubos::engine::EventReader;
+using cubos::engine::ScreenPicker;
+
+using namespace tesseratos;
 
 void tesseratos::entitySelectorPlugin(Cubos& cubos)
 {
+    cubos.addPlugin(cubos::engine::screenPickerPlugin);
+    cubos.addPlugin(cubos::engine::windowPlugin);
+
     cubos.addResource<EntitySelector>();
+
+    cubos.startupSystem("initialize EntitySelector")
+        .tagged("cubos.entitySelector.init")
+        .call([](EntitySelector& entitySelector) {
+            entitySelector.selection = Entity{};
+            entitySelector.lastMousePosition = glm::ivec2{0, 0};
+        });
+
+    cubos.system("process window input")
+        .tagged("cubos.entitySelector.input")
+        .after("cubos.window.poll")
+        .after("cubos.renderer.draw")
+        .call([](const ScreenPicker& screenPicker, EntitySelector& entitySelector, const World& world,
+                 EventReader<WindowEvent> windowEvent) {
+            for (const auto& event : windowEvent)
+            {
+                if (std::holds_alternative<MouseMoveEvent>(event))
+                {
+                    entitySelector.lastMousePosition = std::get<MouseMoveEvent>(event).position;
+                }
+                else if (std::holds_alternative<MouseButtonEvent>(event))
+                {
+                    if (std::get<MouseButtonEvent>(event).button == cubos::core::io::MouseButton::Left)
+                    {
+                        if (!std::get<MouseButtonEvent>(event).pressed)
+                        {
+                            uint32_t entityId =
+                                screenPicker.at(entitySelector.lastMousePosition.x, entitySelector.lastMousePosition.y);
+
+                            if (entityId == UINT32_MAX)
+                            {
+                                entitySelector.selection = Entity{};
+                            }
+                            else
+                            {
+                                entitySelector.selection = Entity{entityId, world.generation(entityId)};
+                            }
+                        }
+                    }
+                }
+            }
+        });
 }

--- a/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
@@ -1,3 +1,6 @@
+#include <imgui.h>
+
+#include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/screen_picker/plugin.hpp>
 #include <cubos/engine/window/plugin.hpp>
 
@@ -19,6 +22,7 @@ using namespace tesseratos;
 
 void tesseratos::entitySelectorPlugin(Cubos& cubos)
 {
+    cubos.addPlugin(cubos::engine::imguiPlugin);
     cubos.addPlugin(cubos::engine::screenPickerPlugin);
     cubos.addPlugin(cubos::engine::windowPlugin);
 
@@ -39,6 +43,12 @@ void tesseratos::entitySelectorPlugin(Cubos& cubos)
                  EventReader<WindowEvent> windowEvent) {
             for (const auto& event : windowEvent)
             {
+                if (ImGui::GetIO().WantCaptureMouse)
+                {
+                    // Consume event but don't do anything
+                    continue;
+                }
+
                 if (std::holds_alternative<MouseMoveEvent>(event))
                 {
                     entitySelector.lastMousePosition = std::get<MouseMoveEvent>(event).position;

--- a/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
@@ -35,7 +35,7 @@ void tesseratos::entitySelectorPlugin(Cubos& cubos)
             entitySelector.lastMousePosition = glm::ivec2{0, 0};
         });
 
-    cubos.system("process window input")
+    cubos.system("process window input for EntitySelector")
         .tagged("cubos.entitySelector.input")
         .after("cubos.window.poll")
         .after("cubos.renderer.draw")


### PR DESCRIPTION
# Description

Provides the entitySelector plugin for Tesseratos, which reacts to mouse clicks and sets the currently selected entity to the entity at the clicked coords, using ScreenPicker. Also provides some fixes needed for the plugin to work.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
