### PR TITLE
Allow adding and removing components on the entity inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metrics panel plugin, which only shows FPS statistics for now (#275).
 - Parent-child hierarchies to the transform plugin, at last (#334).
 - New trait type for handling bit masks.
+- Buttons to add/remove components through the entity inspector (#906).
 
 ### Changed
 

--- a/engine/include/cubos/engine/imgui/data_inspector.hpp
+++ b/engine/include/cubos/engine/imgui/data_inspector.hpp
@@ -16,41 +16,34 @@ namespace cubos::engine
     {
     public:
         /// @brief Displays a reflectable value on the UI.
-        /// @note This should always be called inside a `ImGui::BeginTable(..., 2)` and `ImGui::EndTable()`.
-        /// @param name Value name.
         /// @param type Value type.
         /// @param value Pointer to value.
-        void show(const std::string& name, const core::reflection::Type& type, const void* value);
+        void show(const core::reflection::Type& type, const void* value);
 
         /// @brief Displays a reflectable value on the UI and allows modifying it.
-        /// @note This should always be called inside a `ImGui::BeginTable(..., 2)` and `ImGui::EndTable()`.
-        /// @param name Value name.
         /// @param type Value type.
         /// @param value Pointer to value.
         /// @return Whether the object was modified.
-        bool edit(const std::string& name, const core::reflection::Type& type, void* value);
+        bool edit(const core::reflection::Type& type, void* value);
 
         /// @copybrief show
-        /// @note This should always be called inside a `ImGui::BeginTable(..., 2)` and `ImGui::EndTable()`.
         /// @tparam T Value type.
         /// @param name Value name.
         /// @param value Pointer to value.
         template <typename T>
-        void show(const std::string& name, const T& value)
+        void show(const T& value)
         {
-            this->show(name, core::reflection::reflect<T>(), &value);
+            this->show(core::reflection::reflect<T>(), &value);
         }
 
         /// @copybrief edit
-        /// @note This should always be called inside a `ImGui::BeginTable(..., 2)` and `ImGui::EndTable()`.
         /// @tparam T Value type.
-        /// @param name Value name.
         /// @param value Pointer to value.
         /// @return Whether the object was modified.
         template <typename T>
-        bool edit(const std::string& name, T& value)
+        bool edit(T& value)
         {
-            return this->edit(name, core::reflection::reflect<T>(), &value);
+            return this->edit(core::reflection::reflect<T>(), &value);
         }
 
     private:

--- a/engine/samples/imgui/main.cpp
+++ b/engine/samples/imgui/main.cpp
@@ -60,12 +60,26 @@ CUBOS_REFLECT_IMPL(Person)
 
 struct DummyResource
 {
+    CUBOS_REFLECT;
+
     int integer;
     Person person;
     std::vector<Person> persons;
     std::vector<int32_t> vec;
     std::map<int32_t, int32_t> map;
 };
+
+CUBOS_REFLECT_IMPL(DummyResource)
+{
+    return Type::create("DummyResource")
+        .with(FieldsTrait()
+                  .withField("integer", &DummyResource::integer)
+                  .withField("person", &DummyResource::person)
+                  .withField("persons", &DummyResource::persons)
+                  .withField("vec", &DummyResource::vec)
+                  .withField("v", &DummyResource::map))
+        .with(ConstructibleTrait::typed<Person>().withDefaultConstructor().build());
+}
 /// [Creating a dummy resource]
 
 int main()
@@ -105,15 +119,7 @@ int main()
         .tagged("cubos.imgui")
         .call([](DataInspector& inspector, DummyResource& data) {
             ImGui::Begin("Data Inspector");
-            ImGui::BeginTable("id1", 2);
-
-            inspector.show("data.integer", data.integer);
-            inspector.edit("data.person", data.person);
-            inspector.edit("data.persons", data.persons);
-            inspector.edit("data.vec", data.vec);
-            inspector.edit("data.map", data.map);
-
-            ImGui::EndTable();
+            inspector.edit(data);
             ImGui::End();
         });
     /// [DataInspector window example]

--- a/engine/src/imgui/data_inspector.cpp
+++ b/engine/src/imgui/data_inspector.cpp
@@ -29,14 +29,19 @@ using namespace cubos::engine;
 /// @brief Displays a menu where the user can "set" the data to null (if it has NullableTrait)
 static bool nullifyMenu(const Type& type, void* value);
 
-void DataInspector::show(const std::string& name, const core::reflection::Type& type, const void* value)
+void DataInspector::show(const core::reflection::Type& type, const void* value)
 {
-    this->inspect(name, type, const_cast<void*>(value), true);
+    ImGui::BeginTable("inspector", 2);
+    this->inspect("", type, const_cast<void*>(value), true);
+    ImGui::EndTable();
 }
 
-bool DataInspector::edit(const std::string& name, const core::reflection::Type& type, void* value)
+bool DataInspector::edit(const core::reflection::Type& type, void* value)
 {
-    return this->inspect(name, type, value, false);
+    ImGui::BeginTable("inspector", 2);
+    auto changed = this->inspect("", type, value, false);
+    ImGui::EndTable();
+    return changed;
 }
 
 bool DataInspector::inspect(const std::string& name, const Type& type, void* value, bool readOnly)
@@ -336,13 +341,17 @@ std::string DataInspector::stringKnown(const void* value, const Type& type)
 
 void DataInspector::showKnown(const std::string& name, const Type& type, const void* value)
 {
-    ImGui::TableSetColumnIndex(0);
-    ImGui::AlignTextToFramePadding();
-    ImGui::TreeNodeEx(name.c_str(),
-                      ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_Bullet);
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+
+    if (!name.empty())
     {
-        ImGui::SetTooltip("%s", type.name().c_str());
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TreeNodeEx(name.c_str(),
+                          ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_Bullet);
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+        {
+            ImGui::SetTooltip("%s", type.name().c_str());
+        }
     }
 
     std::string str = stringKnown(value, type);
@@ -352,18 +361,25 @@ void DataInspector::showKnown(const std::string& name, const Type& type, const v
 
 void DataInspector::withStructured(const std::string& name, const Type& type, auto fn)
 {
-    ImGui::TableSetColumnIndex(0);
-    ImGui::AlignTextToFramePadding();
-    bool nodeOpen = ImGui::TreeNode(name.c_str());
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+    if (!name.empty())
     {
-        ImGui::SetTooltip("%s", type.name().c_str());
-    }
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        bool nodeOpen = ImGui::TreeNode(name.c_str());
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+        {
+            ImGui::SetTooltip("%s", type.name().c_str());
+        }
 
-    if (nodeOpen)
+        if (nodeOpen)
+        {
+            fn();
+            ImGui::TreePop();
+        }
+    }
+    else
     {
         fn();
-        ImGui::TreePop();
     }
 }
 
@@ -381,13 +397,16 @@ void DataInspector::withStructured(const std::string& name, const Type& type, au
 
 bool DataInspector::editKnown(const std::string& name, const Type& type, void* value)
 {
-    ImGui::TableSetColumnIndex(0);
-    ImGui::AlignTextToFramePadding();
-    ImGui::TreeNodeEx(name.c_str(),
-                      ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_Bullet);
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+    if (!name.empty())
     {
-        ImGui::SetTooltip("%s", type.name().c_str());
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TreeNodeEx(name.c_str(),
+                          ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_Bullet);
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+        {
+            ImGui::SetTooltip("%s", type.name().c_str());
+        }
     }
 
     ImGui::PushID("editKnown");

--- a/tools/tesseratos/src/tesseratos/settings_inspector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/settings_inspector/plugin.cpp
@@ -41,9 +41,7 @@ void tesseratos::settingsInspectorPlugin(Cubos& cubos)
                 }
                 else
                 {
-                    ImGui::BeginTable("split", 2, ImGuiTableFlags_BordersOuter | ImGuiTableFlags_Resizable);
-                    inspector.edit("Settings", map);
-                    ImGui::EndTable();
+                    inspector.edit(map);
                 }
             }
             ImGui::End();


### PR DESCRIPTION
# Description

Modifies `DataInspector` to show/edit the contents of a value without a tree node, allowing for more flexibility outside it.
Adds add/remove component buttons to `EntityInspector`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
