### PR TITLE
Integrate screenPickerPlugin with gizmosPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch to new system syntax (#896).
 - Bump `glad` from `d08b1aa` to `73eaae0`.
 - Bump `json` from `v3.11.2` to `v3.11.3`.
+- Change Gizmo plugin to use the Screen picker plugin (#870).
 
 ### Deprecated
 

--- a/engine/include/cubos/engine/gizmos/gizmos.hpp
+++ b/engine/include/cubos/engine/gizmos/gizmos.hpp
@@ -168,13 +168,15 @@ namespace cubos::engine
         std::vector<std::shared_ptr<Gizmo>> viewGizmos;   ///< Queued gizmos to be drawn in viewport space.
         std::vector<std::shared_ptr<Gizmo>> screenGizmos; ///< Queued gizmos to be drawn in screen space.
 
+        bool mLocking; ///< Whether the mouse has just now been pressed.
+
     private:
         /// @brief Adds a gizmo into the corresponding vector.
         /// @param gizmo Gizmo to be added.
         /// @param space Space in which the gizmo will be drawn.
         void push(const std::shared_ptr<Gizmo>& gizmo, const Space& space);
 
-        std::hash<std::string> mHasher; ///< Hash function to convert string ids into integers.
+        static uint32_t mHasher(const std::string& id); ///< Hash function to convert string ids into integers.
 
         glm::vec3 mColor; ///< Currently set color.
 

--- a/engine/include/cubos/engine/gizmos/plugin.hpp
+++ b/engine/include/cubos/engine/gizmos/plugin.hpp
@@ -27,8 +27,11 @@ namespace cubos::engine
     ///   before `cubos.gizmos.draw`.
     /// - `cubos.gizmos.draw` - queued gizmos are rendered to the window, after `cubos.renderer.draw` and
     ///   before `cubos.window.render`.
+    /// - `cubos.gizmos.pick` - the ScreenPicker resource is accessed to detect gizmos at mouse coordinates, after
+    /// `cubos.gizmos.draw`
     ///
     /// ## Dependencies
+    /// - @ref screen-picker-plugin
     /// - @ref window-plugin
 
     /// @brief Plugin entry function.

--- a/engine/src/cubos/engine/gizmos/gizmos.cpp
+++ b/engine/src/cubos/engine/gizmos/gizmos.cpp
@@ -83,6 +83,14 @@ void Gizmos::push(const std::shared_ptr<Gizmo>& gizmo, const Space& space)
     }
 }
 
+uint32_t Gizmos::mHasher(const std::string& id)
+{
+    uint32_t hash = static_cast<uint32_t>(std::hash<std::string>{}(id));
+    // Set 32nd bit to distinguish from entities
+    hash |= static_cast<uint32_t>(1 << 31);
+    return hash;
+}
+
 void Gizmos::drawLine(const std::string& id, glm::vec3 from, glm::vec3 to, float lifespan, Space space)
 {
     push(std::make_shared<LineGizmo>((uint32_t)mHasher(id), from, to, mColor, lifespan), space);

--- a/engine/src/cubos/engine/gizmos/renderer.cpp
+++ b/engine/src/cubos/engine/gizmos/renderer.cpp
@@ -5,33 +5,6 @@ using cubos::engine::GizmosRenderer;
 
 using namespace cubos::core::gl;
 
-void GizmosRenderer::initIdTexture(glm::ivec2 size)
-{
-    Texture2DDesc texDesc;
-    texDesc.width = (std::size_t)size.x;
-    texDesc.height = (std::size_t)size.y;
-    texDesc.usage = Usage::Dynamic;
-    texDesc.format = TextureFormat::RG16UInt;
-
-    idTexture = renderDevice->createTexture2D(texDesc);
-
-    texDesc.format = TextureFormat::Depth16;
-    mDepthTexture = renderDevice->createTexture2D(texDesc);
-
-    FramebufferDesc frameDesc;
-    frameDesc.targetCount = 1;
-
-    FramebufferDesc::FramebufferTarget target;
-    target.setTexture2DTarget(idTexture);
-
-    frameDesc.targets[0] = target;
-    frameDesc.depthStencil.setTexture2DTarget(mDepthTexture);
-
-    idFramebuffer = renderDevice->createFramebuffer(frameDesc);
-
-    textureSize = size;
-}
-
 void GizmosRenderer::initDrawPipeline()
 {
     auto vs = renderDevice->createShaderStage(Stage::Vertex, R"(
@@ -101,7 +74,7 @@ void GizmosRenderer::initIdPipeline()
     idPipeline = renderDevice->createShaderPipeline(vs, ps);
 }
 
-void GizmosRenderer::init(RenderDevice* currentRenderDevice, glm::ivec2 size)
+void GizmosRenderer::init(RenderDevice* currentRenderDevice)
 {
     renderDevice = currentRenderDevice;
 
@@ -112,8 +85,6 @@ void GizmosRenderer::init(RenderDevice* currentRenderDevice, glm::ivec2 size)
     dss.depth.enabled = false;
     dss.depth.writeEnabled = false;
     noDepthCheckStencilState = renderDevice->createDepthStencilState(dss);
-
-    initIdTexture(size);
 
     initDrawPipeline();
     initIdPipeline();
@@ -140,11 +111,6 @@ void GizmosRenderer::initLinePrimitive()
     linePrimitive.vb = renderDevice->createVertexBuffer(sizeof(verts), verts, Usage::Dynamic);
     linePrimitive.vaDesc.buffers[0] = linePrimitive.vb;
     linePrimitive.va = renderDevice->createVertexArray(linePrimitive.vaDesc);
-}
-
-void GizmosRenderer::resizeTexture(glm::ivec2 size)
-{
-    initIdTexture(size);
 }
 
 void GizmosRenderer::initBoxPrimitive()

--- a/engine/src/cubos/engine/gizmos/renderer.hpp
+++ b/engine/src/cubos/engine/gizmos/renderer.hpp
@@ -31,28 +31,18 @@ namespace cubos::engine
         Primitive cutConePrimitive; ///< GL cut cone information.
         Primitive ringPrimitive;    ///< GL ring information.
 
-        glm::ivec2 textureSize;               ///< Size of the id texture.
-        cubos::core::gl::Texture2D idTexture; ///< Texture holding the ids of the gizmo that was drawn to each pixel.
-        cubos::core::gl::Framebuffer idFramebuffer; ///< Buffer holding the id texture.
-
         cubos::core::gl::DepthStencilState doDepthCheckStencilState; ///< Stencil State that performs depth checks.
         cubos::core::gl::DepthStencilState noDepthCheckStencilState; ///< Stencil State that ignores depth checks.
 
         /// @brief Sets up the render device to be used.
         /// @param renderDevice the current Render device being used.
-        void init(cubos::core::gl::RenderDevice* currentRenderDevice, glm::ivec2 size);
-
-        /// @brief Resizes the id texture.
-        /// @param size New size of the texture.
-        void resizeTexture(glm::ivec2 size);
+        void init(cubos::core::gl::RenderDevice* currentRenderDevice);
 
         glm::ivec2 lastMousePosition; ///< Cursor position.
         bool mousePressed;            ///< Whether or not the mouse left button is pressed.
 
     private:
         cubos::core::gl::Texture2D mDepthTexture;
-
-        void initIdTexture(glm::ivec2 size);
 
         void initIdPipeline();
         void initDrawPipeline();

--- a/engine/src/cubos/engine/screen_picker/screen_picker.cpp
+++ b/engine/src/cubos/engine/screen_picker/screen_picker.cpp
@@ -38,6 +38,11 @@ Framebuffer ScreenPicker::framebuffer()
 uint32_t ScreenPicker::at(int x, int y) const
 {
     y = mTextureSize.y - y - 1;
+    if (x >= mTextureSize.x || x < 0 || y >= mTextureSize.y || y < 0)
+    {
+        return UINT32_MAX;
+    }
+
     auto* texBuffer = new uint16_t[(std::size_t)mTextureSize.x * (std::size_t)mTextureSize.y * 2U];
 
     mIdTexture->read(texBuffer);

--- a/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/entity_selector/plugin.cpp
@@ -57,7 +57,7 @@ void tesseratos::entitySelectorPlugin(Cubos& cubos)
                 {
                     if (std::get<MouseButtonEvent>(event).button == cubos::core::io::MouseButton::Left)
                     {
-                        if (!std::get<MouseButtonEvent>(event).pressed)
+                        if (std::get<MouseButtonEvent>(event).pressed)
                         {
                             uint32_t entityId =
                                 screenPicker.at(entitySelector.lastMousePosition.x, entitySelector.lastMousePosition.y);
@@ -66,7 +66,7 @@ void tesseratos::entitySelectorPlugin(Cubos& cubos)
                             {
                                 entitySelector.selection = Entity{};
                             }
-                            else
+                            else if (entityId < static_cast<uint32_t>(1 << 31))
                             {
                                 entitySelector.selection = Entity{entityId, world.generation(entityId)};
                             }


### PR DESCRIPTION
# Description

Changes gizmosPlugin to store gizmo ids in screenPickerPlugin instead of a separate buffer.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
