### PR TITLE
Collider gizmos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Buttons to add/remove components through the entity inspector (#906).
 - Narrow-phase collision detection plugin (#524).
 - Ephemeral trait, used to indicate that relations and components shouldn't be persisted.
+- Collider gizmos plugin, used to view collision shapes.
 
 ### Changed
 

--- a/engine/include/cubos/engine/gizmos/gizmos.hpp
+++ b/engine/include/cubos/engine/gizmos/gizmos.hpp
@@ -103,6 +103,15 @@ namespace cubos::engine
         void drawWireBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner, float lifespan = 0.0F,
                          Space space = Space::World);
 
+        /// @brief Draws a wireframe box gizmo.
+        /// @param id Identifier of the gizmo.
+        /// @param transform Transformation matrix to apply to a unit-sized box centered at the origin.
+        /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
+        /// frame.
+        /// @param space Space to draw the gizmo in.
+        void drawWireBox(const std::string& id, const glm::mat4& transform, float lifespan = 0.0F,
+                         Space space = Space::World);
+
         /// @brief Checks whether the left mouse button was pressed over a gizmo.
         /// @param id Identifier of the gizmo.
         /// @return Whether the gizmo was pressed.

--- a/engine/src/gizmos/gizmos.cpp
+++ b/engine/src/gizmos/gizmos.cpp
@@ -103,29 +103,40 @@ void Gizmos::drawBox(const std::string& id, glm::vec3 corner, glm::vec3 opposite
 
 void Gizmos::drawWireBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner, float lifespan, Space space)
 {
-    // Front
-    drawLine(id, corner, glm::vec3{oppositeCorner[0], corner[1], corner[2]}, lifespan, space);
-    drawLine(id, corner, glm::vec3{corner[0], oppositeCorner[1], corner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{oppositeCorner[0], oppositeCorner[1], corner[2]},
-             glm::vec3{corner[0], oppositeCorner[1], corner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{oppositeCorner[0], oppositeCorner[1], corner[2]},
-             glm::vec3{oppositeCorner[0], corner[1], corner[2]}, lifespan, space);
+    auto size = oppositeCorner - corner;
+    auto center = corner + size * 0.5F;
+    auto transform = glm::scale(glm::translate(glm::mat4{1.0F}, center), size);
+    this->drawWireBox(id, transform, lifespan, space);
+}
 
-    // Back
-    drawLine(id, oppositeCorner, glm::vec3{corner[0], oppositeCorner[1], oppositeCorner[2]}, lifespan, space);
-    drawLine(id, oppositeCorner, glm::vec3{oppositeCorner[0], corner[1], oppositeCorner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{corner[0], corner[1], oppositeCorner[2]},
-             glm::vec3{corner[0], oppositeCorner[1], oppositeCorner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{corner[0], corner[1], oppositeCorner[2]},
-             glm::vec3{oppositeCorner[0], corner[1], oppositeCorner[2]}, lifespan, space);
+void Gizmos::drawWireBox(const std::string& id, const glm::mat4& transform, float lifespan, Space space)
+{
+    glm::vec3 corners[8] = {
+        {-0.5F, -0.5F, -0.5F}, {0.5F, -0.5F, -0.5F}, {0.5F, 0.5F, -0.5F}, {-0.5F, 0.5F, -0.5F},
+        {-0.5F, -0.5F, 0.5F},  {0.5F, -0.5F, 0.5F},  {0.5F, 0.5F, 0.5F},  {-0.5F, 0.5F, 0.5F},
+    };
 
-    // Sides
-    drawLine(id, corner, glm::vec3{corner[0], corner[1], oppositeCorner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{corner[0], oppositeCorner[1], corner[2]},
-             glm::vec3{corner[0], oppositeCorner[1], oppositeCorner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{oppositeCorner[0], corner[1], corner[2]},
-             glm::vec3{oppositeCorner[0], corner[1], oppositeCorner[2]}, lifespan, space);
-    drawLine(id, glm::vec3{oppositeCorner[0], oppositeCorner[1], corner[2]}, oppositeCorner, lifespan, space);
+    // Transform corners.
+    for (auto& corner : corners)
+    {
+        corner = glm::vec3{transform * glm::vec4{corner, 1.0F}};
+    }
+
+    // Draw edges.
+    drawLine(id, corners[0], corners[1], lifespan, space);
+    drawLine(id, corners[1], corners[2], lifespan, space);
+    drawLine(id, corners[2], corners[3], lifespan, space);
+    drawLine(id, corners[3], corners[0], lifespan, space);
+
+    drawLine(id, corners[4], corners[5], lifespan, space);
+    drawLine(id, corners[5], corners[6], lifespan, space);
+    drawLine(id, corners[6], corners[7], lifespan, space);
+    drawLine(id, corners[7], corners[4], lifespan, space);
+
+    drawLine(id, corners[0], corners[4], lifespan, space);
+    drawLine(id, corners[1], corners[5], lifespan, space);
+    drawLine(id, corners[2], corners[6], lifespan, space);
+    drawLine(id, corners[3], corners[7], lifespan, space);
 }
 
 void Gizmos::drawCutCone(const std::string& id, glm::vec3 firstBaseCenter, float firstBaseRadius,

--- a/tools/tesseratos/CMakeLists.txt
+++ b/tools/tesseratos/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESSERATOS_SOURCE
 	"src/tesseratos/toolbox/plugin.cpp"
 	"src/tesseratos/transform_gizmo/plugin.cpp"
 	"src/tesseratos/metrics_panel/plugin.cpp"
+	"src/tesseratos/collider_gizmos/plugin.cpp"
 )
 
 add_library(tesseratos ${TESSERATOS_SOURCE})

--- a/tools/tesseratos/include/tesseratos/collider_gizmos/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/collider_gizmos/plugin.hpp
@@ -1,0 +1,27 @@
+/// @dir
+/// @brief @ref tesseratos-collider-gizmos-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup tesseratos-collider-gizmos-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+namespace tesseratos
+{
+    /// @defgroup tesseratos-collider-gizmos-plugin Collider gizmos
+    /// @ingroup tesseratos
+    /// @brief Draws gizmos for selected colliders.
+    ///
+    /// ## Dependencies
+    /// - @ref gizmos-plugin
+    /// - @ref collisions-plugin
+    /// - @ref tesseratos-toolbox-plugin
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class
+    /// @ingroup tesseratos-collider-gizmos-plugin
+    void colliderGizmosPlugin(cubos::engine::Cubos& cubos);
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/collider_gizmos/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/collider_gizmos/plugin.cpp
@@ -1,0 +1,44 @@
+#include <cubos/engine/collisions/plugin.hpp>
+#include <cubos/engine/collisions/shapes/box.hpp>
+#include <cubos/engine/gizmos/plugin.hpp>
+#include <cubos/engine/transform/plugin.hpp>
+
+#include <tesseratos/collider_gizmos/plugin.hpp>
+#include <tesseratos/entity_selector/plugin.hpp>
+#include <tesseratos/toolbox/plugin.hpp>
+
+using cubos::engine::BoxCollisionShape;
+using cubos::engine::Commands;
+using cubos::engine::Cubos;
+using cubos::engine::Entity;
+using cubos::engine::Gizmos;
+using cubos::engine::LocalToWorld;
+using cubos::engine::Position;
+using cubos::engine::Query;
+
+void tesseratos::colliderGizmosPlugin(Cubos& cubos)
+{
+    cubos.addPlugin(cubos::engine::gizmosPlugin);
+    cubos.addPlugin(cubos::engine::collisionsPlugin);
+    cubos.addPlugin(toolboxPlugin);
+
+    cubos.system("draw box collision shape gizmos")
+        .after("cubos.transform.update")
+        .before("cubos.gizmos.draw")
+        .call([](Toolbox& toolbox, Gizmos& gizmos, const EntitySelector& selector,
+                 Query<Entity, const LocalToWorld&, const BoxCollisionShape&> boxes) {
+            bool showAll = toolbox.isOpen("All Collider Gizmos");
+
+            gizmos.color({1.0F, 0.0F, 0.0F});
+
+            for (auto [ent, localToWorld, shape] : boxes)
+            {
+                if (showAll || ent == selector.selection)
+                {
+                    auto size = shape.box.halfSize * 2.0F;
+                    auto transform = glm::scale(localToWorld.mat, size);
+                    gizmos.drawWireBox("collider-gizmos", transform);
+                }
+            }
+        });
+}

--- a/tools/tesseratos/src/tesseratos/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/plugin.cpp
@@ -1,4 +1,5 @@
 #include <tesseratos/asset_explorer/plugin.hpp>
+#include <tesseratos/collider_gizmos/plugin.hpp>
 #include <tesseratos/debug_camera/plugin.hpp>
 #include <tesseratos/entity_inspector/plugin.hpp>
 #include <tesseratos/metrics_panel/plugin.hpp>
@@ -20,4 +21,5 @@ void tesseratos::plugin(cubos::engine::Cubos& cubos)
     cubos.addPlugin(settingsInspectorPlugin);
     cubos.addPlugin(metricsPanelPlugin);
     cubos.addPlugin(transformGizmoPlugin);
+    cubos.addPlugin(colliderGizmosPlugin);
 }


### PR DESCRIPTION
# Description

Adds an overload for `drawWireBox` which allows the caller to specify the box rotation.
Adds a new tesseratos plugin `colliderGizmosPlugin` which allows viewing all colliders through the gizmos plugin or only the selected entity.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
