### PR TITLE
Add delta time modifier and play/pause plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Narrow-phase collision detection plugin (#524).
 - Ephemeral trait, used to indicate that relations and components shouldn't be persisted.
 - Collider gizmos plugin, used to view collision shapes.
+- Delta Time multiplier, can be used to adjust simulation speed (#866).
 
 ### Changed
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -21,9 +21,8 @@ namespace cubos::core::ecs
     /// @ingroup core-ecs
     struct DeltaTime
     {
-        DeltaTime(float value);
-
-        float value; ///< Time in seconds.
+        float value{0.0F};      ///< Time in seconds.
+        float multiplier{1.0F}; ///< Multiplier which will be used when updating the value field.
     };
 
     /// @brief Resource used as a flag to indicate whether the main loop should stop running.
@@ -33,9 +32,7 @@ namespace cubos::core::ecs
     /// @ingroup core-ecs
     struct ShouldQuit
     {
-        ShouldQuit(bool value);
-
-        bool value; ///< Whether the main loop should stop running.
+        bool value{true}; ///< Whether the main loop should stop running.
     };
 
     /// @brief Resource which stores the command-line arguments.
@@ -45,8 +42,6 @@ namespace cubos::core::ecs
     /// @ingroup core-ecs
     struct Arguments
     {
-        Arguments(std::vector<std::string> value);
-
         const std::vector<std::string> value; ///< Command-line arguments.
     };
 

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -11,21 +11,6 @@ using cubos::core::ecs::DeltaTime;
 using cubos::core::ecs::ShouldQuit;
 using cubos::core::ecs::TagBuilder;
 
-DeltaTime::DeltaTime(float value)
-    : value(value)
-{
-}
-
-ShouldQuit::ShouldQuit(bool value)
-    : value(value)
-{
-}
-
-Arguments::Arguments(std::vector<std::string> value)
-    : value(std::move(value))
-{
-}
-
 TagBuilder::TagBuilder(World& world, core::ecs::Dispatcher& dispatcher, std::vector<std::string>& tags)
     : mWorld(world)
     , mDispatcher(dispatcher)
@@ -265,9 +250,9 @@ Cubos::Cubos(int argc, char** argv)
 {
     std::vector<std::string> arguments(argv + 1, argv + argc);
 
-    this->addResource<DeltaTime>(0.0F);
-    this->addResource<ShouldQuit>(true);
-    this->addResource<Arguments>(arguments);
+    this->addResource<DeltaTime>();
+    this->addResource<ShouldQuit>();
+    this->addResource<Arguments>(Arguments{.value = arguments});
 }
 
 void Cubos::run()
@@ -290,7 +275,9 @@ void Cubos::run()
     {
         mMainDispatcher.callSystems(cmds);
         currentTime = std::chrono::steady_clock::now();
-        mWorld.write<DeltaTime>().get().value = std::chrono::duration<float>(currentTime - previousTime).count();
+
+        auto& dt = mWorld.write<DeltaTime>().get();
+        dt.value = std::chrono::duration<float>(currentTime - previousTime).count() * dt.multiplier;
         previousTime = currentTime;
     } while (!mWorld.read<ShouldQuit>().get().value);
 }

--- a/tools/tesseratos/CMakeLists.txt
+++ b/tools/tesseratos/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TESSERATOS_SOURCE
 	"src/tesseratos/transform_gizmo/plugin.cpp"
 	"src/tesseratos/metrics_panel/plugin.cpp"
 	"src/tesseratos/collider_gizmos/plugin.cpp"
+	"src/tesseratos/play_pause/plugin.cpp"
 )
 
 add_library(tesseratos ${TESSERATOS_SOURCE})

--- a/tools/tesseratos/include/tesseratos/play_pause/plugin.hpp
+++ b/tools/tesseratos/include/tesseratos/play_pause/plugin.hpp
@@ -1,0 +1,26 @@
+/// @dir
+/// @brief @ref tesseratos-play-pause-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup tesseratos-play-pause-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+namespace tesseratos
+{
+    /// @defgroup tesseratos-play-pause-plugin Play Pause
+    /// @ingroup tesseratos
+    /// @brief Allows changing the current simulation speed, or even pause it.
+    ///
+    /// ## Dependencies
+    /// - @ref imgui-plugin
+    /// - @ref tesseratos-toolbox-plugin
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class
+    /// @ingroup tesseratos-play-pause-plugin
+    void playPausePlugin(cubos::engine::Cubos& cubos);
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/play_pause/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/play_pause/plugin.cpp
@@ -1,0 +1,70 @@
+#include <imgui.h>
+
+#include <cubos/engine/imgui/plugin.hpp>
+
+#include <tesseratos/play_pause/plugin.hpp>
+#include <tesseratos/toolbox/plugin.hpp>
+
+using cubos::core::reflection::reflect;
+
+using cubos::engine::Cubos;
+using cubos::engine::DeltaTime;
+
+namespace
+{
+    struct State
+    {
+        bool paused{false};
+        float multiplier{1.0F};
+    };
+} // namespace
+
+void tesseratos::playPausePlugin(Cubos& cubos)
+{
+    cubos.addPlugin(cubos::engine::imguiPlugin);
+    cubos.addPlugin(toolboxPlugin);
+
+    cubos.addResource<State>();
+
+    cubos.system("show Play Pause UI").tagged("cubos.imgui").call([](State& state, Toolbox& toolbox, DeltaTime& dt) {
+        if (!toolbox.isOpen("Play Pause"))
+        {
+            return;
+        }
+
+        if (ImGui::Begin("Play Pause"))
+        {
+            if (ImGui::Button("Play"))
+            {
+                state.paused = false;
+                dt.multiplier = state.multiplier;
+            }
+
+            ImGui::SameLine();
+
+            if (ImGui::Button("Pause"))
+            {
+                state.paused = true;
+                dt.multiplier = 0.0;
+            }
+
+            ImGui::SameLine();
+
+            ImGui::Text(state.paused ? "(Paused)" : "(Running)");
+
+            ImGui::SliderFloat("Speed Multiplier", &state.multiplier, 0.0F, 5.0F);
+
+            if (ImGui::Button("Reset"))
+            {
+                state.multiplier = 1.0F;
+            }
+
+            ImGui::End();
+        }
+
+        if (!state.paused)
+        {
+            dt.multiplier = state.multiplier;
+        }
+    });
+}

--- a/tools/tesseratos/src/tesseratos/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/plugin.cpp
@@ -3,6 +3,7 @@
 #include <tesseratos/debug_camera/plugin.hpp>
 #include <tesseratos/entity_inspector/plugin.hpp>
 #include <tesseratos/metrics_panel/plugin.hpp>
+#include <tesseratos/play_pause/plugin.hpp>
 #include <tesseratos/plugin.hpp>
 #include <tesseratos/scene_editor/plugin.hpp>
 #include <tesseratos/settings_inspector/plugin.hpp>
@@ -22,4 +23,5 @@ void tesseratos::plugin(cubos::engine::Cubos& cubos)
     cubos.addPlugin(metricsPanelPlugin);
     cubos.addPlugin(transformGizmoPlugin);
     cubos.addPlugin(colliderGizmosPlugin);
+    cubos.addPlugin(playPausePlugin);
 }


### PR DESCRIPTION
# Description

Adds a multiplier field to the delta time resource and a new tesseratos plugin which allows modifying it.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
