### PR TITLE
Remove `PhysicsBundle` component when finished unpacking

### DIFF
--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -102,6 +102,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
                 cmds.add(ent, impulse);
 
                 cmds.add(ent, AccumulatedCorrection{});
+                cmds.remove<PhysicsBundle>(ent);
             }
         });
 


### PR DESCRIPTION
# Description

I forgot to put this.
