### PR TITLE
Log system order on dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.1.0]
+## [v0.1.0] - 2024-02-17
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Log the system order on the dispatcher (#414, **@RiscadoA**).
+
 ## [v0.1.0] - 2024-02-17
 
 ### Added

--- a/core/include/cubos/core/ecs/system/dispatcher.hpp
+++ b/core/include/cubos/core/ecs/system/dispatcher.hpp
@@ -85,8 +85,9 @@ namespace cubos::core::ecs
         void groupAddGroup();
 
         /// @brief Adds a system, and sets it as the current system for further configuration.
+        /// @param name System name.
         /// @param system System to add.
-        void addSystem(ecs::System<void> system);
+        void addSystem(std::string name, ecs::System<void> system);
 
         /// @brief Sets the tag for the current system.
         /// @param tag Tag to run under.
@@ -143,6 +144,7 @@ namespace cubos::core::ecs
         /// @brief Internal class to handle tag settings
         struct System
         {
+            std::string name;
             std::shared_ptr<SystemSettings> settings;
             ecs::System<void> system;
             std::unordered_set<std::string> tags;
@@ -153,6 +155,7 @@ namespace cubos::core::ecs
         {
         public:
             virtual ~Step() = default;
+            virtual void debug(std::size_t depth) = 0;
             virtual void call(CommandBuffer& cmds, std::vector<ecs::System<bool>>& conditions,
                               std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& runConditions,
                               std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& retConditions) = 0;
@@ -165,6 +168,8 @@ namespace cubos::core::ecs
                 : mSystem(system)
             {
             }
+
+            void debug(std::size_t depth) override;
             void call(CommandBuffer& cmds, std::vector<ecs::System<bool>>& conditions,
                       std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& runConditions,
                       std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& retConditions) override;
@@ -186,6 +191,8 @@ namespace cubos::core::ecs
                 , mParentStep(std::move(parentStep))
             {
             }
+
+            void debug(std::size_t depth) override;
             void call(CommandBuffer& cmds, std::vector<ecs::System<bool>>& conditions,
                       std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& runConditions,
                       std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& retConditions) override;
@@ -328,10 +335,10 @@ namespace cubos::core::ecs
         mCurrGroup->conditions |= bit;
     }
 
-    inline void Dispatcher::addSystem(ecs::System<void> system)
+    inline void Dispatcher::addSystem(std::string name, ecs::System<void> system)
     {
         // Wrap the system and put it in the pending queue
-        mPendingSystems.push_back(new System{nullptr, std::move(system), {}});
+        mPendingSystems.push_back(new System{std::move(name), nullptr, std::move(system), {}});
         mCurrSystem = mPendingSystems.back();
     }
 

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -216,7 +216,8 @@ auto Cubos::SystemBuilder::other() && -> SystemBuilder&&
 
 void Cubos::SystemBuilder::finish(System<void> system)
 {
-    mDispatcher.addSystem(std::move(system));
+    CUBOS_DEBUG("Added system {}", mName);
+    mDispatcher.addSystem(std::move(mName), std::move(system));
 
     if (mCondition)
     {
@@ -237,8 +238,6 @@ void Cubos::SystemBuilder::finish(System<void> system)
     {
         mDispatcher.systemSetAfterTag(tag);
     }
-
-    CUBOS_DEBUG("Added system {}", mName);
 }
 
 Cubos::Cubos()

--- a/core/src/ecs/system/dispatcher.cpp
+++ b/core/src/ecs/system/dispatcher.cpp
@@ -176,7 +176,9 @@ void Dispatcher::compileChain()
     // on move operations, just reverse the final list for the same effect.
     std::reverse(mSystems.begin(), mSystems.end());
 
-    CUBOS_INFO("Call chain completed successfully!");
+    CUBOS_DEBUG("Compiled system chain:");
+    mMainStep->debug(0);
+
     mPendingSystems.clear();
     mCurrSystem = nullptr;
     mTagSettings.clear();
@@ -253,6 +255,13 @@ bool Dispatcher::dfsVisit(DFSNode& node, std::vector<DFSNode>& nodes)
     return false;
 }
 
+void Dispatcher::SystemStep::debug(std::size_t depth)
+{
+    std::string indent = std::string(depth * 2, ' ');
+    std::string format = indent + "- system {}";
+    CUBOS_DEBUG(format.c_str(), mSystem->name);
+}
+
 void Dispatcher::SystemStep::call(CommandBuffer& cmds, std::vector<ecs::System<bool>>& conditions,
                                   std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& runConditions,
                                   std::bitset<CUBOS_CORE_DISPATCHER_MAX_CONDITIONS>& retConditions)
@@ -296,6 +305,17 @@ void Dispatcher::SystemStep::call(CommandBuffer& cmds, std::vector<ecs::System<b
 
     // TODO: Check synchronization concerns when this gets multithreaded
     cmds.commit();
+}
+
+void Dispatcher::GroupStep::debug(std::size_t depth)
+{
+    std::string indent = std::string(depth * 2, ' ');
+    std::string format = indent + "- group {}:";
+    CUBOS_DEBUG(format.c_str(), groupTag);
+    for (auto& step : mSteps)
+    {
+        step->debug(depth + 1);
+    }
 }
 
 void Dispatcher::GroupStep::call(CommandBuffer& cmds, std::vector<ecs::System<bool>>& conditions,

--- a/core/tests/ecs/dispatcher.cpp
+++ b/core/tests/ecs/dispatcher.cpp
@@ -88,29 +88,29 @@ TEST_CASE("ecs::Dispatcher")
     {
         SUBCASE("without any constraints")
         {
-            dispatcher.addSystem(wrapSystem(pushToOrder<1>));
-            dispatcher.addSystem(wrapSystem(pushToOrder<2>));
-            dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+            dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
+            dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
+            dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
         }
 
         SUBCASE("with constraints on the systems")
         {
-            dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+            dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
             dispatcher.systemSetAfterTag("2"); // runs after "2"
-            dispatcher.addSystem(wrapSystem(pushToOrder<2>));
+            dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
             dispatcher.systemAddTag("2");
             dispatcher.systemSetAfterTag("3"); // runs after "3"
-            dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+            dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
             dispatcher.systemAddTag("3");
         }
 
         SUBCASE("with constraints on the tags")
         {
-            dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+            dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
             dispatcher.systemAddTag("1");
-            dispatcher.addSystem(wrapSystem(pushToOrder<2>));
+            dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
             dispatcher.systemAddTag("2");
-            dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+            dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
             dispatcher.systemAddTag("3");
 
             dispatcher.addTag("1");
@@ -125,13 +125,13 @@ TEST_CASE("ecs::Dispatcher")
 
     SUBCASE("1 runs first, then 3, and finally 2")
     {
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddTag("1");
         dispatcher.systemSetBeforeTag("3"); // runs before "3"
-        dispatcher.addSystem(wrapSystem(pushToOrder<2>));
+        dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
         dispatcher.systemAddTag("2");
         dispatcher.systemSetAfterTag("3"); // runs after "3"
-        dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+        dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
         dispatcher.systemAddTag("3");
 
         SUBCASE("without any superfluous constraints")
@@ -163,12 +163,12 @@ TEST_CASE("ecs::Dispatcher")
 
     SUBCASE("systems run when all of their conditions are fulfilled")
     {
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddCondition(wrapCondition(pushToOrderAndSucceed<2>));
         dispatcher.systemAddCondition(wrapCondition(pushToOrderAndSucceed<3>));
-        dispatcher.addSystem(wrapSystem(pushToOrder<4>));
+        dispatcher.addSystem("4", wrapSystem(pushToOrder<4>));
         dispatcher.systemAddTag("4");
-        dispatcher.addSystem(wrapSystem(pushToOrder<5>));
+        dispatcher.addSystem("5", wrapSystem(pushToOrder<5>));
         dispatcher.systemAddTag("5");
 
         dispatcher.addTag("4");
@@ -188,12 +188,12 @@ TEST_CASE("ecs::Dispatcher")
 
     SUBCASE("systems do not run when their conditions are not met")
     {
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddTag("1");
         dispatcher.systemAddCondition(wrapCondition(pushToOrderAndSucceed<2>));
         dispatcher.systemAddCondition(wrapCondition(pushToOrderAndFail<3>));
         dispatcher.systemAddCondition(wrapCondition(pushToOrderAndSucceed<4>));
-        dispatcher.addSystem(wrapSystem(pushToOrder<5>));
+        dispatcher.addSystem("5", wrapSystem(pushToOrder<5>));
         dispatcher.systemAddTag("5");
 
         dispatcher.addTag("5");
@@ -206,7 +206,7 @@ TEST_CASE("ecs::Dispatcher")
         dispatcher.tagAddCondition(wrapCondition(pushToOrderAndFail<9>));
         dispatcher.tagAddCondition(wrapCondition(pushToOrderAndFail<10>));
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<11>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<11>));
         dispatcher.systemSetAfterTag("1");
 
         // First, 5 tries to run, but its condition 9 fails. The condition 10 is not checked.
@@ -219,11 +219,11 @@ TEST_CASE("ecs::Dispatcher")
     SUBCASE("constraints are transitive on tags without systems")
     {
         // Tests if #413 has been fixed.
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemSetBeforeTag("a");
         dispatcher.addTag("a");
         dispatcher.tagSetBeforeTag("b");
-        dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+        dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
         dispatcher.systemAddTag("b");
 
         // 1 runs before tag "a".
@@ -238,7 +238,7 @@ TEST_CASE("ecs::Dispatcher")
     {
         dispatcher.addTag("repeat");
         dispatcher.tagRepeatWhile(wrapCondition(succeed2Times));
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddGroup("repeat");
 
         singleDispatch(dispatcher, cmdBuffer);
@@ -254,16 +254,16 @@ TEST_CASE("ecs::Dispatcher")
         dispatcher.tagInheritTag("principal");
         dispatcher.tagRepeatWhile(wrapCondition(succeed2Times));
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddTag("principal");
         dispatcher.systemAddTag("first");
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<2>));
+        dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
         dispatcher.systemAddTag("subtag");
         dispatcher.systemSetAfterTag("first");
         dispatcher.systemSetBeforeTag("last");
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+        dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
         dispatcher.systemAddTag("subtag");
         dispatcher.systemAddTag("last");
 
@@ -281,16 +281,16 @@ TEST_CASE("ecs::Dispatcher")
         dispatcher.tagInheritTag("principal");
         dispatcher.tagRepeatWhile(wrapCondition(succeed2Times));
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddTag("principal");
         dispatcher.systemAddTag("first");
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<2>));
+        dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
         dispatcher.systemAddTag("subtag");
         dispatcher.systemSetAfterTag("first");
         dispatcher.systemSetBeforeTag("last");
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+        dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
         dispatcher.systemAddTag("subtag");
         dispatcher.systemAddTag("last");
 
@@ -308,16 +308,16 @@ TEST_CASE("ecs::Dispatcher")
         dispatcher.tagRepeatWhile(wrapCondition(succeed2Times));
         dispatcher.tagAddCondition(wrapCondition(pushToOrderAndSucceed<5>));
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<1>));
+        dispatcher.addSystem("1", wrapSystem(pushToOrder<1>));
         dispatcher.systemAddTag("principal");
         dispatcher.systemAddTag("first");
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<2>));
+        dispatcher.addSystem("2", wrapSystem(pushToOrder<2>));
         dispatcher.systemAddTag("subtag");
         dispatcher.systemSetAfterTag("first");
         dispatcher.systemSetBeforeTag("last");
 
-        dispatcher.addSystem(wrapSystem(pushToOrder<3>));
+        dispatcher.addSystem("3", wrapSystem(pushToOrder<3>));
         dispatcher.systemAddTag("subtag");
         dispatcher.systemAddTag("last");
 


### PR DESCRIPTION
# Description

Stores the received system names in the dispatcher and prints them after compiling the chain.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
