### PR TITLE
Add Shader asset and bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show childOf hierarchy on the world inspector (#991, **@diogomsmiranda**).
 - Rotation to the Transform Gizmo (#878, **@DiogoMendonc-a**).
 - Rotated box Gizmo (#878, **@DiogoMendonc-a**).
+- Shader asset and bridge (#1058, **@tomas7770**).
 
 ### Fixed
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -92,6 +92,10 @@ set(CUBOS_ENGINE_SOURCE
 	"src/screen_picker/screen_picker.cpp"
 	
 	"src/fixed_step/plugin.cpp"
+
+	"src/render/shader/plugin.cpp"
+	"src/render/shader/shader.cpp"
+	"src/render/shader/bridge.cpp"
 )
 
 # Create cubos engine

--- a/engine/include/cubos/engine/render/module.dox
+++ b/engine/include/cubos/engine/render/module.dox
@@ -1,0 +1,9 @@
+/// @dir
+/// @brief @ref render-plugins module.
+
+namespace cubos::engine
+{
+    /// @defgroup render-plugins Render
+    /// @ingroup engine
+    /// @brief Provides plugins for graphics rendering.
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/shader/bridge.hpp
+++ b/engine/include/cubos/engine/render/shader/bridge.hpp
@@ -1,0 +1,35 @@
+/// @file
+/// @brief Class @ref cubos::engine::ShaderBridge.
+/// @ingroup render-shader-plugin
+
+#pragma once
+
+#include <cubos/core/memory/stream.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/assets/bridges/file.hpp>
+#include <cubos/engine/render/shader/shader.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Bridge for loading shader assets.
+    /// @ingroup render-shader-plugin
+    class ShaderBridge : public FileBridge
+    {
+    public:
+        /// @brief Constructs a bridge.
+        /// @param renderDevice Render device used to create the shader.
+        ShaderBridge(core::gl::RenderDevice& renderDevice)
+            : FileBridge(cubos::core::reflection::reflect<cubos::engine::Shader>())
+            , mRenderDevice(renderDevice)
+        {
+        }
+
+    protected:
+        bool loadFromFile(Assets& assets, const AnyAsset& handle, cubos::core::memory::Stream& stream) override;
+        bool saveToFile(const Assets& assets, const AnyAsset& handle, cubos::core::memory::Stream& stream) override;
+
+    private:
+        core::gl::RenderDevice& mRenderDevice; ///< Render device used to create the shader.
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/shader/plugin.hpp
+++ b/engine/include/cubos/engine/render/shader/plugin.hpp
@@ -1,0 +1,30 @@
+/// @dir
+/// @brief @ref render-shader-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup render-shader-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+#include <cubos/engine/render/shader/shader.hpp>
+
+namespace cubos::engine
+{
+    /// @defgroup render-shader-plugin Shader
+    /// @ingroup render-plugins
+    /// @brief Adds shader assets to @b CUBOS.
+    ///
+    /// ## Bridges
+    /// - @ref ShaderBridge - registered with the `.glsl` extension, loads @ref Shader assets.
+    ///
+    /// ## Dependencies
+    /// - @ref assets-plugin
+    /// - @ref window-plugin
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class.
+    /// @ingroup render-shader-plugin
+    void shaderPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/shader/shader.hpp
+++ b/engine/include/cubos/engine/render/shader/shader.hpp
@@ -1,0 +1,33 @@
+/// @file
+/// @brief Class @ref cubos::engine::Shader.
+/// @ingroup render-shader-plugin
+
+#pragma once
+
+#include <cubos/core/gl/render_device.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Contains a shader stage created from GLSL code.
+    /// @ingroup render-shader-plugin
+    class Shader final
+    {
+    public:
+        CUBOS_REFLECT;
+
+        ~Shader() = default;
+
+        /// @brief Constructs a shader from code.
+        /// @param shaderStage Shader stage created from GLSL code.
+        Shader(cubos::core::gl::ShaderStage shaderStage)
+            : mShaderStage(std::move(shaderStage)){};
+
+        /// @brief Returns the asset's shader stage.
+        /// @return Shader stage.
+        cubos::core::gl::ShaderStage shaderStage() const;
+
+    private:
+        cubos::core::gl::ShaderStage mShaderStage;
+    };
+} // namespace cubos::engine

--- a/engine/src/render/shader/bridge.cpp
+++ b/engine/src/render/shader/bridge.cpp
@@ -1,0 +1,62 @@
+#include <cubos/core/log.hpp>
+
+#include <cubos/engine/render/shader/bridge.hpp>
+
+using namespace cubos::engine;
+
+using cubos::core::memory::Stream;
+
+bool ShaderBridge::loadFromFile(Assets& assets, const AnyAsset& handle, Stream& stream)
+{
+    // Dump the shader code into a string.
+    std::string contents;
+    stream.readUntil(contents, nullptr);
+
+    // Read shader stage type
+    auto stageTypeString = assets.readMeta(handle)->get("stage");
+    cubos::core::gl::Stage stageType;
+    if (stageTypeString == "Vertex")
+    {
+        stageType = cubos::core::gl::Stage::Vertex;
+    }
+    else if (stageTypeString == "Geometry")
+    {
+        stageType = cubos::core::gl::Stage::Geometry;
+    }
+    else if (stageTypeString == "Pixel")
+    {
+        stageType = cubos::core::gl::Stage::Pixel;
+    }
+    else if (stageTypeString == "Compute")
+    {
+        stageType = cubos::core::gl::Stage::Compute;
+    }
+    else
+    {
+        CUBOS_ERROR("Shader asset metadata must have a 'stage' property set to one of ''Vertex', 'Geometry', 'Pixel' "
+                    "or 'Compute'");
+        return false;
+    }
+
+    cubos::core::gl::ShaderStage shaderStage = mRenderDevice.createShaderStage(stageType, contents.c_str());
+    if (shaderStage == nullptr)
+    {
+        CUBOS_ERROR("Shader asset stage creation failed");
+        return false;
+    }
+
+    // Store the asset's data.
+    assets.store(handle, Shader(shaderStage));
+    return true;
+}
+
+bool ShaderBridge::saveToFile(const Assets& assets, const AnyAsset& handle, cubos::core::memory::Stream& stream)
+{
+    // Ignore unused argument warnings
+    (void)assets;
+    (void)handle;
+    (void)stream;
+
+    CUBOS_ERROR("Shader assets are not saveable");
+    return false;
+}

--- a/engine/src/render/shader/plugin.cpp
+++ b/engine/src/render/shader/plugin.cpp
@@ -1,0 +1,25 @@
+#include <cubos/core/io/window.hpp>
+
+#include <cubos/engine/assets/bridges/binary.hpp>
+#include <cubos/engine/assets/plugin.hpp>
+#include <cubos/engine/prelude.hpp>
+#include <cubos/engine/render/shader/bridge.hpp>
+#include <cubos/engine/render/shader/plugin.hpp>
+#include <cubos/engine/window/plugin.hpp>
+
+using cubos::core::io::Window;
+using cubos::engine::ShaderBridge;
+
+void cubos::engine::shaderPlugin(Cubos& cubos)
+{
+    cubos.addPlugin(assetsPlugin);
+    cubos.addPlugin(windowPlugin);
+
+    cubos.startupSystem("setup Shader asset bridge")
+        .tagged("cubos.assets.bridge")
+        .after("cubos.window.init")
+        .call([](Assets& assets, Window& window) {
+            // Add the bridge to load .glsl files.
+            assets.registerBridge(".glsl", std::make_unique<ShaderBridge>(window->renderDevice()));
+        });
+}

--- a/engine/src/render/shader/shader.cpp
+++ b/engine/src/render/shader/shader.cpp
@@ -1,0 +1,21 @@
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+#include <cubos/engine/render/shader/shader.hpp>
+
+using namespace cubos::engine;
+
+CUBOS_REFLECT_IMPL(Shader)
+{
+    using namespace cubos::core::reflection;
+
+    return Type::create("cubos::engine::Shader")
+        .with(ConstructibleTrait::typed<Shader>().withMoveConstructor().build());
+}
+
+cubos::core::gl::ShaderStage Shader::shaderStage() const
+{
+    return mShaderStage;
+}


### PR DESCRIPTION
# Description

Adds a new `shaderPlugin`, which registers a new `ShaderBridge`, and assets of the `Shader` type, which contain a `cubos::core::gl::ShaderStage`, created from a file's GLSL code.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
