### PR TITLE
feat(ecs): add Commands::EntityBuilder::named

### DIFF
--- a/core/include/cubos/core/ecs/system/arguments/commands.hpp
+++ b/core/include/cubos/core/ecs/system/arguments/commands.hpp
@@ -144,6 +144,11 @@ namespace cubos::core::ecs
         /// @return Entity identifier.
         Entity entity() const;
 
+        /// @brief Adds a @ref Name component to the entity.
+        /// @param name Entity name.
+        /// @return Reference to this builder, for chaining.
+        EntityBuilder& named(std::string name);
+
         /// @brief Adds a component to the entity.
         /// @param type Component type.
         /// @param value Component value.

--- a/core/src/ecs/system/arguments/commands.cpp
+++ b/core/src/ecs/system/arguments/commands.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/ecs/blueprint.hpp>
 #include <cubos/core/ecs/command_buffer.hpp>
+#include <cubos/core/ecs/name.hpp>
 #include <cubos/core/ecs/system/arguments/commands.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 
@@ -62,6 +63,11 @@ Commands::EntityBuilder::EntityBuilder(CommandBuffer& buffer, Entity entity)
 Entity Commands::EntityBuilder::entity() const
 {
     return mEntity;
+}
+
+Commands::EntityBuilder& Commands::EntityBuilder::named(std::string name)
+{
+    return this->add(Name{std::move(name)});
 }
 
 Commands::EntityBuilder& Commands::EntityBuilder::add(const reflection::Type& type, void* value)

--- a/core/tests/ecs/commands.cpp
+++ b/core/tests/ecs/commands.cpp
@@ -1,12 +1,14 @@
 #include <doctest/doctest.h>
 
 #include <cubos/core/ecs/command_buffer.hpp>
+#include <cubos/core/ecs/name.hpp>
 #include <cubos/core/ecs/system/arguments/commands.hpp>
 
 #include "utils.hpp"
 
 using cubos::core::ecs::CommandBuffer;
 using cubos::core::ecs::Commands;
+using cubos::core::ecs::Name;
 using cubos::core::ecs::World;
 
 TEST_CASE("ecs::Commands")
@@ -17,12 +19,13 @@ TEST_CASE("ecs::Commands")
     setupWorld(world);
 
     // Create an entity.
-    auto foo = cmds.create().add(IntegerComponent{0}).entity();
+    auto foo = cmds.create().named("foo").add(IntegerComponent{0}).entity();
     CHECK_FALSE(foo.isNull());
     CHECK_FALSE(world.isAlive(foo)); // Still hasn't been committed.
     cmdBuffer.commit();
     CHECK(world.isAlive(foo)); // Now it has been committed.
     CHECK(world.components(foo).has<IntegerComponent>());
+    CHECK(world.components(foo).has<Name>());
 
     SUBCASE("destroy the entity")
     {


### PR DESCRIPTION
# Description

Can be used to give names to entities more easily.
Just shortened `.add(Name{"foo})` for `.named("foo")`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
