### PR TITLE
fix(assets): make Assets::write compilable

### DIFF
--- a/engine/include/cubos/engine/assets/assets.hpp
+++ b/engine/include/cubos/engine/assets/assets.hpp
@@ -160,7 +160,7 @@ namespace cubos::engine
             // Create a strong handle to the asset, so that the asset starts loading if it isn't already.
             auto strong = this->load(handle);
             auto lock = this->lockWrite(strong);
-            auto data = static_cast<T*>(this->access(strong, typeid(T), lock, true));
+            auto data = static_cast<T*>(this->access(strong, core::reflection::reflect<T>(), lock, true));
             return AssetWrite<T>(*data, std::move(lock));
         }
 


### PR DESCRIPTION
# Description

Fixed compile error in `Assets::write`.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
