### PR TITLE
Fix crash on empty grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - System condition being ignored by Cubos (#1032, **@RiscadoA**).
 - Wrong tranform gizmo position for entities with parents (#1003, **@DiogoMendonc-a**).
 - Free camera controller angle not being bounded (#1016, **@diogomsmiranda**).
+- Crash when meshing an empty voxel grid (**@RiscadoA**).
 
 ## [v0.1.0] - 2024-02-17
 

--- a/engine/src/renderer/deferred_renderer.cpp
+++ b/engine/src/renderer/deferred_renderer.cpp
@@ -566,6 +566,13 @@ cubos::engine::RendererGrid DeferredRenderer::upload(const VoxelGrid& grid)
     std::vector<uint32_t> indices;
     triangulate(grid, vertices, indices);
 
+    // Handle the empty grid edge case.
+    if (vertices.empty())
+    {
+        deferredGrid->indexCount = 0;
+        return deferredGrid;
+    }
+
     // Create the vertex array, vertex buffer and index buffer.
     VertexArrayDesc vaDesc;
     vaDesc.elementCount = 3;
@@ -784,9 +791,12 @@ void DeferredRenderer::onRender(const glm::mat4& view, const Viewport& viewport,
 
         // 4.3.2. Draw the geometry.
         auto grid = std::static_pointer_cast<DeferredGrid>(drawCmd.grid);
-        mRenderDevice.setVertexArray(grid->va);
-        mRenderDevice.setIndexBuffer(grid->ib);
-        mRenderDevice.drawTrianglesIndexed(0, grid->indexCount);
+        if (grid->indexCount > 0)
+        {
+            mRenderDevice.setVertexArray(grid->va);
+            mRenderDevice.setIndexBuffer(grid->ib);
+            mRenderDevice.drawTrianglesIndexed(0, grid->indexCount);
+        }
     }
 
     if (pickingBuffer)
@@ -810,10 +820,13 @@ void DeferredRenderer::onRender(const glm::mat4& view, const Viewport& viewport,
 
             // 5.2.2. Draw the entity identifiers to the entity picking framebuffer.
             auto grid = std::static_pointer_cast<DeferredGrid>(drawCmd.grid);
-            mPickingIndexBp->setConstant(drawCmd.entityIndex);
-            mRenderDevice.setVertexArray(grid->va);
-            mRenderDevice.setIndexBuffer(grid->ib);
-            mRenderDevice.drawTrianglesIndexed(0, grid->indexCount);
+            if (grid->indexCount > 0)
+            {
+                mPickingIndexBp->setConstant(drawCmd.entityIndex);
+                mRenderDevice.setVertexArray(grid->va);
+                mRenderDevice.setIndexBuffer(grid->ib);
+                mRenderDevice.drawTrianglesIndexed(0, grid->indexCount);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Fixes a renderer crash when we creating empty voxel grids.

## Checklist

- [ ] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
