### PR TITLE
Fix AnyVector::swapErase double destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong tranform gizmo position for entities with parents (#1003, **@DiogoMendonc-a**).
 - Free camera controller angle not being bounded (#1016, **@diogomsmiranda**).
 - Crash when meshing an empty voxel grid (**@RiscadoA**).
+- Double destruction in AnyVector::swapErase (**@RiscadoA**).
 
 ## [v0.1.0] - 2024-02-17
 

--- a/core/src/memory/any_vector.cpp
+++ b/core/src/memory/any_vector.cpp
@@ -149,9 +149,12 @@ void AnyVector::swapErase(std::size_t index)
         // If the element isn't the last one, we move the last element to its place.
         mConstructibleTrait->moveConstruct(static_cast<char*>(mData) + mStride * index,
                                            static_cast<char*>(mData) + mStride * (mSize - 1));
+        this->pop();
     }
-
-    this->pop();
+    else
+    {
+        --mSize;
+    }
 }
 
 void AnyVector::swapMove(std::size_t index, void* destination)


### PR DESCRIPTION
# Description

Turns out some components were being destroyed twice, which led to a double free error, due to a bug in AnyVector::swapErase.

## Checklist

- [x] Self-review changes.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
