### PR TITLE
Add GBuffer plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rotation to the Transform Gizmo (#878, **@DiogoMendonc-a**).
 - Rotated box Gizmo (#878, **@DiogoMendonc-a**).
 - Shader asset and bridge (#1058, **@tomas7770**).
+- GBuffer plugin (#1061, **@RiscadoA**).
 
 ### Changed
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -96,6 +96,9 @@ set(CUBOS_ENGINE_SOURCE
 	"src/render/shader/plugin.cpp"
 	"src/render/shader/shader.cpp"
 	"src/render/shader/bridge.cpp"
+
+	"src/render/g_buffer/plugin.cpp"
+	"src/render/g_buffer/g_buffer.cpp"
 )
 
 # Create cubos engine

--- a/engine/include/cubos/engine/render/g_buffer/g_buffer.hpp
+++ b/engine/include/cubos/engine/render/g_buffer/g_buffer.hpp
@@ -1,0 +1,32 @@
+/// @file
+/// @brief Component @ref cubos::engine::GBuffer.
+/// @ingroup render-g-buffer-plugin
+
+#pragma once
+
+#include <glm/vec2.hpp>
+
+#include <cubos/core/gl/render_device.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which stores the GBuffer textures of a render target.
+    /// @ingroup render-g-buffer-plugin
+    struct GBuffer
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Size of the GBuffer textures, in pixels.
+        glm::uvec2 size = {0, 0};
+
+        /// @brief Stores the position of the objects in the scene.
+        core::gl::Texture2D position{nullptr};
+
+        /// @brief Stores the normal of the objects in the scene.
+        core::gl::Texture2D normal{nullptr};
+
+        /// @brief Stores the albedo of the objects in the scene.
+        core::gl::Texture2D albedo{nullptr};
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/g_buffer/plugin.hpp
+++ b/engine/include/cubos/engine/render/g_buffer/plugin.hpp
@@ -1,0 +1,35 @@
+/// @dir
+/// @brief @ref render-g-buffer-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup render-g-buffer-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+namespace cubos::engine
+{
+    /// @defgroup render-g-buffer-plugin G-Buffer
+    /// @ingroup render-plugins
+    /// @brief Adds and manages @ref GBuffer components.
+    ///
+    /// ## Dependencies
+    /// - @ref window-plugin
+    /// - @ref render-target-plugin
+
+    // TODO move this to render target plugin when that's done
+    extern Tag resizeRenderTargetTag;
+
+    /// @brief Recreates the GBuffer if necessary - for example, due to a render target resize.
+    extern Tag createGBufferTag;
+
+    /// @brief Systems which draw to GBuffer textures should be tagged with this.
+    extern Tag drawToGBufferTag;
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class.
+    /// @ingroup render-g-buffer-plugin
+    void gBufferPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/target/target.hpp
+++ b/engine/include/cubos/engine/render/target/target.hpp
@@ -1,0 +1,30 @@
+/// @file
+/// @brief Component @ref cubos::engine::RenderTarget.
+/// @ingroup render-target-plugin
+
+#pragma once
+
+#include <glm/vec2.hpp>
+
+#include <cubos/core/gl/render_device.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which represents a render target.
+    ///
+    /// If the framebuffer is set to nullptr, the target will be assumed to be the window.
+    /// In that case, the size will be automatically updated to the window's size.
+    ///
+    /// @ingroup render-target-plugin
+    struct RenderTarget
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Size of the target texture, in pixels.
+        glm::uvec2 size = {0, 0};
+
+        /// @brief Framebuffer to render to.
+        core::gl::Framebuffer framebuffer{nullptr};
+    };
+} // namespace cubos::engine

--- a/engine/src/render/g_buffer/g_buffer.cpp
+++ b/engine/src/render/g_buffer/g_buffer.cpp
@@ -1,0 +1,10 @@
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/render/g_buffer/g_buffer.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::GBuffer)
+{
+    return core::ecs::TypeBuilder<GBuffer>("cubos::engine::GBuffer").withField("size", &GBuffer::size).build();
+}

--- a/engine/src/render/g_buffer/plugin.cpp
+++ b/engine/src/render/g_buffer/plugin.cpp
@@ -1,0 +1,54 @@
+#include <cubos/core/io/window.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/render/g_buffer/g_buffer.hpp>
+#include <cubos/engine/render/g_buffer/plugin.hpp>
+#include <cubos/engine/render/target/target.hpp>
+
+using cubos::core::gl::Texture2DDesc;
+using cubos::core::gl::TextureFormat;
+using cubos::core::gl::Usage;
+using cubos::core::io::Window;
+
+CUBOS_DEFINE_TAG(cubos::engine::resizeRenderTargetTag);
+CUBOS_DEFINE_TAG(cubos::engine::createGBufferTag);
+CUBOS_DEFINE_TAG(cubos::engine::drawToGBufferTag);
+
+void cubos::engine::gBufferPlugin(Cubos& cubos)
+{
+    cubos.addComponent<GBuffer>();
+
+    cubos.tag(createGBufferTag).after(resizeRenderTargetTag);
+    cubos.tag(drawToGBufferTag).after(createGBufferTag);
+
+    cubos.system("resize GBuffers")
+        .tagged(createGBufferTag)
+        .call([](const Window& window, Query<const RenderTarget&, GBuffer&> query) {
+            for (auto [target, gBuffer] : query)
+            {
+                if (target.size != gBuffer.size)
+                {
+                    gBuffer.size = target.size;
+
+                    // Prepare common texture description.
+                    Texture2DDesc desc{};
+                    desc.width = gBuffer.size.x;
+                    desc.height = gBuffer.size.y;
+                    desc.usage = Usage::Dynamic;
+
+                    auto& rd = window->renderDevice();
+
+                    // Create position and normal textures.
+                    desc.format = TextureFormat::RGB32Float;
+                    gBuffer.position = rd.createTexture2D(desc);
+                    gBuffer.normal = rd.createTexture2D(desc);
+
+                    // Create albedo texture.
+                    desc.format = TextureFormat::RGBA8UNorm;
+                    gBuffer.albedo = rd.createTexture2D(desc);
+
+                    CUBOS_INFO("Resized GBuffer to {}x{}", gBuffer.size.x, gBuffer.size.y);
+                }
+            }
+        });
+}


### PR DESCRIPTION
# Description

Adds the `gBufferPlugin`, which adds and manages the `GBuffer` component.
Also adds a placeholder `RenderTarget` component to make this implementable (still missing the actual plugin and logic).

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
