### PR TITLE
Split reflect method into two and implement automatic empty reflection for non-implemented types

### DIFF
--- a/.github/workflows/clang-tidy-lint.yml
+++ b/.github/workflows/clang-tidy-lint.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Remove duplicate clang-tidy diagnostics
       uses: mikefarah/yq@master
       with:
-        cmd: yq -i '.Diagnostics = (.Diagnostics | unique_by(.DiagnosticMessage))' clang-tidy-fixes.yaml
+        cmd: yq -i 'select(has("Diagnostics")).Diagnostics |= unique_by(.DiagnosticMessage)' clang-tidy-fixes.yaml
 
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rotated box Gizmo (#878, **@DiogoMendonc-a**).
 - Shader asset and bridge (#1058, **@tomas7770**).
 
+### Changed
+
+- Make reflection work for all types, even those without reflection implemented (#1092, **@RiscadoA**).
+
 ### Fixed
 
 - Crash in multiple samples due to missing plugin dependencies (**@RiscadoA**).

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CUBOS_CORE_SOURCE
 	"src/memory/any_value.cpp"
 	"src/memory/any_vector.cpp"
 
+	"src/reflection/reflect.cpp"
 	"src/reflection/type.cpp"
 	"src/reflection/comparison.cpp"
 	"src/reflection/type_registry.cpp"

--- a/core/include/cubos/core/ecs/blueprint.hpp
+++ b/core/include/cubos/core/ecs/blueprint.hpp
@@ -66,7 +66,7 @@ namespace cubos::core::ecs
         /// @tparam Ts Component types.
         /// @param entity Entity.
         /// @param components Components to move.
-        template <reflection::Reflectable... Ts>
+        template <typename... Ts>
         void add(Entity entity, Ts... components)
         {
             ([&]() { this->add(entity, memory::AnyValue::moveConstruct(reflection::reflect<Ts>(), &components)); }(),
@@ -84,7 +84,7 @@ namespace cubos::core::ecs
         /// @param fromEntity From entity.
         /// @param toEntity To entity.
         /// @param relation Relation to move.
-        template <reflection::Reflectable T>
+        template <typename T>
         void relate(Entity fromEntity, Entity toEntity, T relation)
         {
             this->relate(fromEntity, toEntity, memory::AnyValue::moveConstruct(reflection::reflect<T>(), &relation));

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -238,7 +238,7 @@ namespace cubos::core::ecs
 
         /// @copydoc with(const reflection::Type&, int)
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         SystemBuilder&& with(int target = -1) &&
         {
             return std::move(*this).with(reflection::reflect<T>(), target);
@@ -252,7 +252,7 @@ namespace cubos::core::ecs
 
         /// @copydoc without(const reflection::Type&, int)
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         SystemBuilder&& without(int target = -1) &&
         {
             return std::move(*this).without(reflection::reflect<T>(), target);
@@ -267,7 +267,7 @@ namespace cubos::core::ecs
 
         /// @copydoc related(const reflection::Type&, int, int)
         /// @tparam T Relation type.
-        template <reflection::Reflectable T>
+        template <typename T>
         SystemBuilder&& related(int fromTarget = -1, int toTarget = -1) &&
         {
             return std::move(*this).related(reflection::reflect<T>(), fromTarget, toTarget);
@@ -284,7 +284,7 @@ namespace cubos::core::ecs
 
         /// @copydoc related(const reflection::Type&, Traversal, int, int)
         /// @tparam T Relation type.
-        template <reflection::Reflectable T>
+        template <typename T>
         SystemBuilder&& related(Traversal traversal, int fromTarget = -1, int toTarget = -1) &&
         {
             return std::move(*this).related(reflection::reflect<T>(), traversal, fromTarget, toTarget);
@@ -347,7 +347,7 @@ namespace cubos::core::ecs
 
         /// @copydoc onAdd(const reflection::Type&, int)
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         ObserverBuilder&& onAdd(int target = -1) &&
         {
             return std::move(*this).onAdd(reflection::reflect<T>(), target);
@@ -362,7 +362,7 @@ namespace cubos::core::ecs
 
         /// @copydoc onRemove(const reflection::Type&, int)
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         ObserverBuilder&& onRemove(int target = -1) &&
         {
             return std::move(*this).onRemove(reflection::reflect<T>(), target);
@@ -381,7 +381,7 @@ namespace cubos::core::ecs
 
         /// @copydoc with(const reflection::Type&, int)
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         ObserverBuilder&& with(int target = -1) &&
         {
             return std::move(*this).with(reflection::reflect<T>(), target);
@@ -395,7 +395,7 @@ namespace cubos::core::ecs
 
         /// @copydoc without(const reflection::Type&, int)
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         ObserverBuilder&& without(int target = -1) &&
         {
             return std::move(*this).without(reflection::reflect<T>(), target);
@@ -410,7 +410,7 @@ namespace cubos::core::ecs
 
         /// @copydoc related(const reflection::Type&, int, int)
         /// @tparam T Relation type.
-        template <reflection::Reflectable T>
+        template <typename T>
         ObserverBuilder&& related(int fromTarget = -1, int toTarget = -1) &&
         {
             return std::move(*this).related(reflection::reflect<T>(), fromTarget, toTarget);
@@ -427,7 +427,7 @@ namespace cubos::core::ecs
 
         /// @copydoc related(const reflection::Type&, Traversal, int, int)
         /// @tparam T Relation type.
-        template <reflection::Reflectable T>
+        template <typename T>
         ObserverBuilder&& related(Traversal traversal, int fromTarget = -1, int toTarget = -1) &&
         {
             return std::move(*this).related(reflection::reflect<T>(), traversal, fromTarget, toTarget);

--- a/core/include/cubos/core/ecs/query/fetcher.hpp
+++ b/core/include/cubos/core/ecs/query/fetcher.hpp
@@ -105,7 +105,7 @@ namespace cubos::core::ecs
         int mTarget;
     };
 
-    template <reflection::Reflectable T>
+    template <typename T>
     class QueryFetcher<T&>
     {
     public:
@@ -184,7 +184,7 @@ namespace cubos::core::ecs
         bool mIsSymmetric;
     };
 
-    template <reflection::Reflectable T>
+    template <typename T>
     class QueryFetcher<const T&>
     {
     public:
@@ -263,7 +263,7 @@ namespace cubos::core::ecs
         bool mIsSymmetric;
     };
 
-    template <reflection::Reflectable T>
+    template <typename T>
     class QueryFetcher<Opt<T&>>
     {
     public:
@@ -312,7 +312,7 @@ namespace cubos::core::ecs
         int mTarget;
     };
 
-    template <reflection::Reflectable T>
+    template <typename T>
     class QueryFetcher<Opt<const T&>>
     {
     public:

--- a/core/include/cubos/core/ecs/system/arguments/commands.hpp
+++ b/core/include/cubos/core/ecs/system/arguments/commands.hpp
@@ -62,7 +62,7 @@ namespace cubos::core::ecs
         /// @param entity Entity identifier.
         /// @param value Component value.
         /// @return Commands.
-        template <reflection::Reflectable T>
+        template <typename T>
         Commands& add(Entity entity, T value)
         {
             return this->add(entity, reflection::reflect<T>(), &value);
@@ -78,7 +78,7 @@ namespace cubos::core::ecs
         /// @tparam T Component type.
         /// @param entity Entity identifier.
         /// @return Commands.
-        template <reflection::Reflectable T>
+        template <typename T>
         Commands& remove(Entity entity)
         {
             return this->remove(entity, reflection::reflect<T>());
@@ -104,7 +104,7 @@ namespace cubos::core::ecs
         /// @param to To entity.
         /// @param value Relation value.
         /// @return Commands.
-        template <reflection::Reflectable T>
+        template <typename T>
         Commands& relate(Entity from, Entity to, T value)
         {
             return this->relate(from, to, reflection::reflect<T>(), &value);
@@ -122,7 +122,7 @@ namespace cubos::core::ecs
         /// @param from From entity.
         /// @param to To entity.
         /// @return Commands.
-        template <reflection::Reflectable T>
+        template <typename T>
         Commands& unrelate(Entity from, Entity to)
         {
             return this->unrelate(from, to, reflection::reflect<T>());
@@ -159,7 +159,7 @@ namespace cubos::core::ecs
         /// @tparam T Component type.
         /// @param value Component value.
         /// @return Reference to this builder, for chaining.
-        template <reflection::Reflectable T>
+        template <typename T>
         EntityBuilder& add(T value)
         {
             return this->add(reflection::reflect<T>(), &value);
@@ -204,7 +204,7 @@ namespace cubos::core::ecs
         /// @param name Entity name.
         /// @param value Component value.
         /// @return Reference to this builder, for chaining.
-        template <reflection::Reflectable T>
+        template <typename T>
         BlueprintBuilder& add(const std::string& name, T value)
         {
             return this->add(name, reflection::reflect<T>(), &value);

--- a/core/include/cubos/core/ecs/types.hpp
+++ b/core/include/cubos/core/ecs/types.hpp
@@ -58,7 +58,7 @@ namespace cubos::core::ecs
         ///
         /// @tparam T Data type.
         /// @return Data type identifier.
-        template <reflection::Reflectable T>
+        template <typename T>
         DataTypeId id() const
         {
             return this->id(reflection::reflect<T>());

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -61,7 +61,7 @@ namespace cubos::core::ecs
         /// @brief Registers a component type.
         /// @note Should be called before other non-registering operations.
         /// @tparam T Component type.
-        template <reflection::Reflectable T>
+        template <typename T>
         void registerComponent()
         {
             this->registerComponent(reflection::reflect<T>());
@@ -73,7 +73,7 @@ namespace cubos::core::ecs
 
         /// @brief Registers a relation type.
         /// @tparam T Relation type.
-        template <reflection::Reflectable T>
+        template <typename T>
         void registerRelation()
         {
             this->registerRelation(reflection::reflect<T>());
@@ -211,7 +211,7 @@ namespace cubos::core::ecs
         /// @param from From entity.
         /// @param to To entity.
         /// @param value Relation value.
-        template <reflection::Reflectable T>
+        template <typename T>
         void relate(Entity from, Entity to, T value)
         {
             this->relate(from, to, reflection::reflect<T>(), &value);
@@ -227,7 +227,7 @@ namespace cubos::core::ecs
         /// @tparam T Relation type.
         /// @param from From entity.
         /// @param to To entity.
-        template <reflection::Reflectable T>
+        template <typename T>
         void unrelate(Entity from, Entity to)
         {
             this->unrelate(from, to, reflection::reflect<T>());
@@ -337,7 +337,7 @@ namespace cubos::core::ecs
         /// @brief Checks if the given component is present.
         /// @tparam T Component type.
         /// @return Whether the component is present.
-        template <reflection::Reflectable T>
+        template <typename T>
         bool has() const
         {
             return this->has(reflection::reflect<T>());
@@ -358,7 +358,7 @@ namespace cubos::core::ecs
         ///
         /// @tparam T Component type.
         /// @return Reference to component.
-        template <reflection::Reflectable T>
+        template <typename T>
         T& get()
         {
             return *static_cast<T*>(this->get(reflection::reflect<T>()));
@@ -388,7 +388,7 @@ namespace cubos::core::ecs
         /// @tparam T Component type.
         /// @param value Component value to move.
         /// @return Reference to this.
-        template <reflection::Reflectable T>
+        template <typename T>
         Components& add(T&& value)
         {
             return this->add(reflection::reflect<T>(), &value);
@@ -408,7 +408,7 @@ namespace cubos::core::ecs
         ///
         /// @tparam T Component type.
         /// @return Reference to this.
-        template <reflection::Reflectable T>
+        template <typename T>
         Components& remove()
         {
             return this->remove(reflection::reflect<T>());
@@ -438,7 +438,7 @@ namespace cubos::core::ecs
         /// @brief Checks if the given component is present.
         /// @tparam T Component type.
         /// @return Whether the component is present.
-        template <reflection::Reflectable T>
+        template <typename T>
         bool has() const
         {
             return this->has(reflection::reflect<T>());
@@ -459,7 +459,7 @@ namespace cubos::core::ecs
         ///
         /// @tparam T Component type.
         /// @return Reference to component.
-        template <reflection::Reflectable T>
+        template <typename T>
         const T& get() const
         {
             return *static_cast<const T*>(this->get(reflection::reflect<T>()));
@@ -500,7 +500,7 @@ namespace cubos::core::ecs
         /// @tparam T Relation type.
         /// @param entity Entity.
         /// @return Whether the relation is present.
-        template <reflection::Reflectable T>
+        template <typename T>
         bool has(Entity entity) const
         {
             return this->has(reflection::reflect<T>(), entity);
@@ -524,7 +524,7 @@ namespace cubos::core::ecs
         /// @tparam T Relation type.
         /// @param entity Entity.
         /// @return Relation.
-        template <reflection::Reflectable T>
+        template <typename T>
         T& get(Entity entity)
         {
             return *static_cast<T*>(this->get(reflection::reflect<T>(), entity));
@@ -566,7 +566,7 @@ namespace cubos::core::ecs
         /// @tparam T Relation type.
         /// @param entity Entity.
         /// @return Whether the relation is present.
-        template <reflection::Reflectable T>
+        template <typename T>
         bool has(Entity entity) const
         {
             return this->has(reflection::reflect<T>(), entity);
@@ -590,7 +590,7 @@ namespace cubos::core::ecs
         /// @tparam T Relation type.
         /// @param entity Entity.
         /// @return Relation.
-        template <reflection::Reflectable T>
+        template <typename T>
         const T& get(Entity entity)
         {
             return *static_cast<const T*>(this->get(reflection::reflect<T>(), entity));

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -331,7 +331,7 @@ namespace cubos::core
         /// @param location Code location.
         /// @param format Message format string.
         /// @param args Message format arguments.
-        template <reflection::Reflectable... TArgs>
+        template <typename... TArgs>
         static void writeFormat(Level level, Location location, const char* format, TArgs... args)
         {
             memory::BufferStream stream{};

--- a/core/include/cubos/core/memory/type_map.hpp
+++ b/core/include/cubos/core/memory/type_map.hpp
@@ -30,7 +30,7 @@ namespace cubos::core::memory
         /// @note If an entry already exists, it is replaced.
         /// @tparam K Type.
         /// @param value Value.
-        template <reflection::Reflectable K>
+        template <typename K>
         void insert(V value)
         {
             this->insert(reflection::reflect<K>(), std::move(value));
@@ -47,7 +47,7 @@ namespace cubos::core::memory
         /// @brief Removes the entry associated to the given type.
         /// @tparam K Type.
         /// @return Whether the entry was removed.
-        template <reflection::Reflectable K>
+        template <typename K>
         bool erase()
         {
             return this->erase(reflection::reflect<K>());
@@ -64,7 +64,7 @@ namespace cubos::core::memory
         /// @brief Checks if there's a an entry with the given type.
         /// @tparam K Type.
         /// @return Whether there's an entry with the given type.
-        template <reflection::Reflectable K>
+        template <typename K>
         bool contains() const
         {
             return this->contains(reflection::reflect<K>());
@@ -83,7 +83,7 @@ namespace cubos::core::memory
         /// @note Aborts if @ref contains returns false.
         /// @tparam K Type.
         /// @return Reference to the value.
-        template <reflection::Reflectable K>
+        template <typename K>
         V& at()
         {
             return this->at(reflection::reflect<K>());
@@ -96,7 +96,7 @@ namespace cubos::core::memory
         }
 
         /// @copydoc at()
-        template <reflection::Reflectable K>
+        template <typename K>
         const V& at() const
         {
             return this->at(reflection::reflect<K>());

--- a/core/include/cubos/core/reflection/reflect.hpp
+++ b/core/include/cubos/core/reflection/reflect.hpp
@@ -24,7 +24,8 @@ namespace cubos::core::reflection
     /// @param alignment Type alignment in bytes.
     /// @param destructor Type destructor.
     /// @ingroup core-reflection
-    const Type& makeUnnamedType(unsigned long id, std::size_t size, std::size_t alignment, void (*destructor)(void*));
+    const Type& makeUnnamedType(unsigned long long id, std::size_t size, std::size_t alignment,
+                                void (*destructor)(void*));
 
     /// @brief Defines the reflection function for the given type @p T.
     ///
@@ -73,8 +74,9 @@ namespace cubos::core::reflection
                 // This variable is unused, but since there is one for each type, its address is
                 // guaranteed to be unique for each type. Thus, we use it as an identifier.
                 static const bool Var = false;
-                static const Type& type = makeUnnamedType(reinterpret_cast<unsigned long>(&Var), sizeof(T), alignof(T),
-                                                          [](void* value) { static_cast<T*>(value)->~T(); });
+                static const Type& type =
+                    makeUnnamedType(reinterpret_cast<unsigned long long>(&Var), sizeof(T), alignof(T),
+                                    [](void* value) { static_cast<T*>(value)->~T(); });
                 return type;
             }
         }

--- a/core/include/cubos/core/reflection/reflect.hpp
+++ b/core/include/cubos/core/reflection/reflect.hpp
@@ -82,16 +82,6 @@ namespace cubos::core::reflection
     {
         return Reflect<T>::get();
     }
-
-    /// @cond See #765
-    /// @brief Checks whether the given type @p T is reflectable.
-    /// @tparam T %Type to check.
-    template <typename T>
-    concept Reflectable = requires
-    {
-        reflect<T>();
-    };
-    /// @endcond
 } // namespace cubos::core::reflection
 
 /// @brief Helper macro used to pass arguments with commas to other macros, wrapped in parentheses.

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -36,7 +36,7 @@ namespace cubos::core::reflection
         ///
         /// @param id Type identifier.
         /// @return Reference to the type.
-        static Type& unnamed(unsigned long id);
+        static Type& unnamed(unsigned long long id);
 
         /// @brief Destroys the given type.
         /// @param type Type to destroy.

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -30,6 +30,14 @@ namespace cubos::core::reflection
         /// @return Reference to the type.
         static Type& create(std::string name);
 
+        /// @brief Constructs an unnamed type with the given identifier.
+        ///
+        /// The type is also marked as not being implemented.
+        ///
+        /// @param id Type identifier.
+        /// @return Reference to the type.
+        static Type& unnamed(unsigned long id);
+
         /// @brief Destroys the given type.
         /// @param type Type to destroy.
         static void destroy(Type& type);
@@ -87,6 +95,9 @@ namespace cubos::core::reflection
         /// @return Whether the objects have the same address, which indicates equality.
         bool operator==(const Type& other) const;
 
+        /// @brief Checks whether the type had reflection implemented for it.
+        bool implemented() const;
+
     private:
         ~Type();
 
@@ -137,6 +148,7 @@ namespace cubos::core::reflection
         };
 
         std::string mName;
+        bool mImplemented{true};
         std::vector<Trait> mTraits;
     };
 } // namespace cubos::core::reflection

--- a/core/include/cubos/core/reflection/type_registry.hpp
+++ b/core/include/cubos/core/reflection/type_registry.hpp
@@ -32,7 +32,7 @@ namespace cubos::core::reflection
 
         /// @copydoc insert(const Type&)
         /// @tparam T Type to register.
-        template <Reflectable T>
+        template <typename T>
         void insert()
         {
             this->insert(reflect<T>());
@@ -45,7 +45,7 @@ namespace cubos::core::reflection
 
         /// @copydoc contains(const Type&)
         /// @tparam T Type to check.
-        template <Reflectable T>
+        template <typename T>
         bool contains() const
         {
             return this->contains(reflect<T>());

--- a/core/samples/logging/main.cpp
+++ b/core/samples/logging/main.cpp
@@ -11,6 +11,10 @@
 #include <cubos/core/reflection/external/unordered_map.hpp>
 /// [External reflection includes]
 
+struct TypeWithoutReflection
+{
+};
+
 int main()
 {
     /// [Set logging level]
@@ -30,5 +34,6 @@ int main()
     CUBOS_INFO("An integer: {}", 1);
     CUBOS_INFO("A glm::vec3: {}", glm::vec3(0.0F, 1.0F, 2.0F));
     CUBOS_INFO("An std::unordered_map: {}", std::unordered_map<int, const char*>{{1, "one"}, {2, "two"}});
+    CUBOS_INFO("A type without reflection: {}", TypeWithoutReflection{});
 }
 /// [Logging macros with arguments]

--- a/core/samples/reflection/traits/enum/main.cpp
+++ b/core/samples/reflection/traits/enum/main.cpp
@@ -11,6 +11,7 @@ enum class Color
     Blue
 };
 
+CUBOS_REFLECT_EXTERNAL_DECL(Color);
 /// [Enum declaration]
 
 /// [Reflection definition]
@@ -20,7 +21,6 @@ enum class Color
 using cubos::core::reflection::EnumTrait;
 using cubos::core::reflection::Type;
 
-template <>
 CUBOS_REFLECT_EXTERNAL_IMPL(Color)
 {
     return Type::create("Color").with(

--- a/core/samples/reflection/traits/mask/main.cpp
+++ b/core/samples/reflection/traits/mask/main.cpp
@@ -13,6 +13,8 @@ enum class Permissions
     Execute = 4
 };
 
+CUBOS_REFLECT_EXTERNAL_DECL(Permissions);
+
 inline Permissions operator~(Permissions p)
 {
     return static_cast<Permissions>(~static_cast<int>(p));
@@ -36,7 +38,6 @@ inline Permissions operator&(Permissions a, Permissions b)
 using cubos::core::reflection::MaskTrait;
 using cubos::core::reflection::Type;
 
-template <>
 CUBOS_REFLECT_EXTERNAL_IMPL(Permissions)
 {
     return Type::create("Permissions")

--- a/core/src/log.cpp
+++ b/core/src/log.cpp
@@ -5,6 +5,7 @@
 
 #include <cubos/core/data/ser/debug.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/enum.hpp>
 
 using cubos::core::Logger;
@@ -193,7 +194,17 @@ const char* Logger::streamFormat(memory::Stream& stream, const char* format, con
             }
 
             foundArgument = true;
-            data::DebugSerializer{stream}.write(type, value);
+            if (!type.implemented())
+            {
+                CUBOS_WARN("You tried to print a type ({}) which doesn't implement reflection. Did you forget to "
+                           "include its reflection definition?",
+                           type.name());
+                stream.print("(no reflection)");
+            }
+            else
+            {
+                data::DebugSerializer{stream}.write(type, value);
+            }
             ++format;
         }
         else

--- a/core/src/reflection/reflect.cpp
+++ b/core/src/reflection/reflect.cpp
@@ -1,9 +1,11 @@
 #include <cstdint>
 
 #include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-auto cubos::core::reflection::makeUnnamedType(unsigned long id) -> const Type&
+auto cubos::core::reflection::makeUnnamedType(unsigned long id, std::size_t size, std::size_t alignment,
+                                              void (*destructor)(void*)) -> const Type&
 {
-    return Type::unnamed(id);
+    return Type::unnamed(id).with(ConstructibleTrait{size, alignment, destructor});
 }

--- a/core/src/reflection/reflect.cpp
+++ b/core/src/reflection/reflect.cpp
@@ -1,0 +1,9 @@
+#include <cstdint>
+
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+auto cubos::core::reflection::makeUnnamedType(unsigned long id) -> const Type&
+{
+    return Type::unnamed(id);
+}

--- a/core/src/reflection/reflect.cpp
+++ b/core/src/reflection/reflect.cpp
@@ -4,7 +4,7 @@
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-auto cubos::core::reflection::makeUnnamedType(unsigned long id, std::size_t size, std::size_t alignment,
+auto cubos::core::reflection::makeUnnamedType(unsigned long long id, std::size_t size, std::size_t alignment,
                                               void (*destructor)(void*)) -> const Type&
 {
     return Type::unnamed(id).with(ConstructibleTrait{size, alignment, destructor});

--- a/core/src/reflection/type.cpp
+++ b/core/src/reflection/type.cpp
@@ -9,7 +9,7 @@ Type& Type::create(std::string name)
     return *(new Type(std::move(name)));
 }
 
-Type& Type::unnamed(unsigned long id)
+Type& Type::unnamed(unsigned long long id)
 {
     auto& type = Type::create("unnamed" + std::to_string(id));
     type.mImplemented = false;

--- a/core/src/reflection/type.cpp
+++ b/core/src/reflection/type.cpp
@@ -9,6 +9,13 @@ Type& Type::create(std::string name)
     return *(new Type(std::move(name)));
 }
 
+Type& Type::unnamed(unsigned long id)
+{
+    auto& type = Type::create("unnamed" + std::to_string(id));
+    type.mImplemented = false;
+    return type;
+}
+
 void Type::destroy(Type& type)
 {
     delete &type;
@@ -67,6 +74,11 @@ bool Type::operator==(const Type& other) const
 
     CUBOS_ASSERT(this->mName != other.mName, "Two types should never have the same name");
     return false;
+}
+
+bool Type::implemented() const
+{
+    return mImplemented;
 }
 
 Type::~Type()

--- a/core/tests/data/des/json.cpp
+++ b/core/tests/data/des/json.cpp
@@ -26,10 +26,7 @@ namespace
 {
     struct NonConstructible
     {
-        CUBOS_REFLECT
-        {
-            return Type::create("NonConstructible");
-        }
+        CUBOS_REFLECT;
 
         int operator<=>(const NonConstructible& /*unused*/) const
         {
@@ -39,10 +36,7 @@ namespace
 
     struct Empty
     {
-        CUBOS_REFLECT
-        {
-            return Type::create("Empty").with(autoConstructibleTrait<Empty>());
-        }
+        CUBOS_REFLECT;
 
         int operator<=>(const Empty& /*unused*/) const
         {
@@ -52,10 +46,7 @@ namespace
 
     struct Wrapper
     {
-        CUBOS_REFLECT
-        {
-            return Type::create("Wrapper").with(FieldsTrait{}.withField("inner", &Wrapper::inner));
-        }
+        CUBOS_REFLECT;
 
         bool operator==(const Wrapper& /*unused*/) const = default;
 
@@ -69,6 +60,21 @@ namespace
         Blue
     };
 } // namespace
+
+CUBOS_REFLECT_IMPL(NonConstructible)
+{
+    return Type::create("NonConstructible");
+}
+
+CUBOS_REFLECT_IMPL(Empty)
+{
+    return Type::create("Empty").with(autoConstructibleTrait<Empty>());
+}
+
+CUBOS_REFLECT_IMPL(Wrapper)
+{
+    return Type::create("Wrapper").with(FieldsTrait{}.withField("inner", &Wrapper::inner));
+}
 
 CUBOS_REFLECT_EXTERNAL_DECL(Color);
 CUBOS_REFLECT_EXTERNAL_IMPL(Color)

--- a/core/tests/data/ser/debug.cpp
+++ b/core/tests/data/ser/debug.cpp
@@ -22,12 +22,14 @@ namespace
 {
     struct Empty
     {
-        CUBOS_REFLECT
-        {
-            return Type::create("Empty");
-        }
+        CUBOS_REFLECT;
     };
 } // namespace
+
+CUBOS_REFLECT_IMPL(Empty)
+{
+    return Type::create("Empty");
+}
 
 #define AUTO_TEST(type, value, expected, success)                                                                      \
     stream.seek(0, SeekOrigin::Begin);                                                                                 \

--- a/core/tests/data/ser/json.cpp
+++ b/core/tests/data/ser/json.cpp
@@ -26,14 +26,8 @@ namespace
 {
     struct ExampleStruct
     {
-        CUBOS_REFLECT
-        {
-            return Type::create("ExampleStruct")
-                .with(FieldsTrait{}
-                          .withField("a", &ExampleStruct::a)
-                          .withField("b", &ExampleStruct::b)
-                          .withField("c", &ExampleStruct::c));
-        }
+        CUBOS_REFLECT;
+
         int a;
         float b;
         std::string c;
@@ -46,6 +40,15 @@ namespace
         Blue
     };
 } // namespace
+
+CUBOS_REFLECT_IMPL(ExampleStruct)
+{
+    return Type::create("ExampleStruct")
+        .with(FieldsTrait{}
+                  .withField("a", &ExampleStruct::a)
+                  .withField("b", &ExampleStruct::b)
+                  .withField("c", &ExampleStruct::c));
+}
 
 CUBOS_REFLECT_EXTERNAL_DECL(Color);
 CUBOS_REFLECT_EXTERNAL_IMPL(Color)

--- a/core/tests/reflection/comparison.cpp
+++ b/core/tests/reflection/comparison.cpp
@@ -35,8 +35,8 @@ TEST_CASE("reflection::compare")
     const auto fo = FieldsObject{1, 0.3F};
     const auto foEqual = FieldsObject{1, 0.3F};
     const auto foDifferent = FieldsObject{2, 0.3F};
-    CHECK(compare(fo.reflect(), (void*)&fo, (void*)&foEqual));
-    CHECK_FALSE(compare(fo.reflect(), (void*)&fo, (void*)&foDifferent));
+    CHECK(compare(reflect<FieldsObject>(), (void*)&fo, (void*)&foEqual));
+    CHECK_FALSE(compare(reflect<FieldsObject>(), (void*)&fo, (void*)&foDifferent));
 
     std::vector<std::unordered_map<int, glm::vec3>> vec = {
         std::unordered_map<int, glm::vec3>{{1, {1.2, 2.3, 4.5}}, {2, {1.2, 1.3, 4.5}}, {560, {1.2, 2.3, 4.5}}},

--- a/core/tests/reflection/reflect.cpp
+++ b/core/tests/reflection/reflect.cpp
@@ -1,7 +1,9 @@
 #include <doctest/doctest.h>
 
+#include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
+using cubos::core::reflection::ConstructibleTrait;
 using cubos::core::reflection::reflect;
 using cubos::core::reflection::Type;
 
@@ -61,4 +63,7 @@ TEST_CASE("reflection::reflect")
 
     CHECK_FALSE(reflect<Unreflected>().implemented());
     CHECK(reflect<Unreflected>().is<Unreflected>());
+    CHECK(reflect<Unreflected>().has<ConstructibleTrait>());
+    CHECK(reflect<Unreflected>().get<ConstructibleTrait>().size() == sizeof(Unreflected));
+    CHECK(reflect<Unreflected>().get<ConstructibleTrait>().alignment() == alignof(Unreflected));
 }

--- a/core/tests/reflection/reflect.cpp
+++ b/core/tests/reflection/reflect.cpp
@@ -38,16 +38,27 @@ CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename T), (Templated<T>))
     return Type::create("Templated<" + reflect<T>().name() + ">");
 }
 
+/// @brief Type without reflection.
+struct Unreflected
+{
+};
+
 TEST_CASE("reflection::reflect")
 {
+    CHECK(reflect<Internal>().implemented());
     CHECK(reflect<Internal>().name() == "Internal");
     CHECK(reflect<Internal>().is<Internal>());
 
+    CHECK(reflect<External>().implemented());
     CHECK(reflect<External>().name() == "External");
     CHECK(reflect<External>().is<External>());
     CHECK_FALSE(reflect<External>().is<Internal>());
 
+    CHECK(reflect<Templated<Internal>>().implemented());
     CHECK(reflect<Templated<Internal>>().name() == "Templated<Internal>");
     CHECK(reflect<Templated<External>>().name() == "Templated<External>");
     CHECK(reflect<Templated<Templated<Internal>>>().name() == "Templated<Templated<Internal>>");
+
+    CHECK_FALSE(reflect<Unreflected>().implemented());
+    CHECK(reflect<Unreflected>().is<Unreflected>());
 }

--- a/core/tests/reflection/traits/enum.cpp
+++ b/core/tests/reflection/traits/enum.cpp
@@ -17,7 +17,7 @@ namespace
     };
 } // namespace
 
-template <>
+CUBOS_REFLECT_EXTERNAL_DECL(Color);
 CUBOS_REFLECT_EXTERNAL_IMPL(Color)
 {
     return Type::create("Color").with(

--- a/core/tests/reflection/traits/fields.cpp
+++ b/core/tests/reflection/traits/fields.cpp
@@ -9,11 +9,13 @@ using cubos::core::reflection::Type;
 
 struct SimpleType
 {
-    CUBOS_REFLECT
-    {
-        return Type::create("SimpleType");
-    }
+    CUBOS_REFLECT;
 };
+
+CUBOS_REFLECT_IMPL(SimpleType)
+{
+    return Type::create("SimpleType");
+}
 
 struct ObjectType
 {

--- a/core/tests/reflection/traits/mask.cpp
+++ b/core/tests/reflection/traits/mask.cpp
@@ -33,7 +33,7 @@ namespace
     }
 } // namespace
 
-template <>
+CUBOS_REFLECT_EXTERNAL_DECL(Permissions);
 CUBOS_REFLECT_EXTERNAL_IMPL(Permissions)
 {
     return Type::create("Permissions")

--- a/engine/include/cubos/engine/assets/asset.hpp
+++ b/engine/include/cubos/engine/assets/asset.hpp
@@ -135,10 +135,7 @@ namespace cubos::engine
     class Asset : public AnyAsset
     {
     public:
-        CUBOS_REFLECT
-        {
-            return AnyAsset::makeType("cubos::engine::Asset<" + core::reflection::reflect<T>().name() + ">");
-        }
+        CUBOS_REFLECT;
 
         using AnyAsset::AnyAsset;
 
@@ -180,5 +177,10 @@ namespace cubos::engine
         asset.mVersion = mVersion;
         asset.incRef();
         return asset;
+    }
+
+    CUBOS_REFLECT_TEMPLATE_IMPL((core::reflection::Reflectable T), (Asset<T>))
+    {
+        return AnyAsset::makeType("cubos::engine::Asset<" + core::reflection::reflect<T>().name() + ">");
     }
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/assets/asset.hpp
+++ b/engine/include/cubos/engine/assets/asset.hpp
@@ -16,7 +16,7 @@ namespace cubos::core::data::old
 
 namespace cubos::engine
 {
-    template <core::reflection::Reflectable T>
+    template <typename T>
     class Asset;
 
     /// @brief Handle to an asset of any type. May either be weak or strong.
@@ -98,7 +98,7 @@ namespace cubos::engine
         /// @brief Converts this handle to a handle of a specific type.
         /// @tparam T Type of the asset.
         /// @return Handle to the same asset, but of the specified type.
-        template <core::reflection::Reflectable T>
+        template <typename T>
         inline operator Asset<T>() const;
 
         void serialize(core::data::old::Serializer& ser, const char* name) const;
@@ -131,7 +131,7 @@ namespace cubos::engine
     /// @see AnyAsset
     /// @tparam T Type of the asset.
     /// @ingroup assets-plugin
-    template <core::reflection::Reflectable T>
+    template <typename T>
     class Asset : public AnyAsset
     {
     public:
@@ -167,7 +167,7 @@ namespace cubos::engine
 
     // Implementation.
 
-    template <core::reflection::Reflectable T>
+    template <typename T>
     inline AnyAsset::operator Asset<T>() const
     {
         Asset<T> asset;
@@ -179,7 +179,7 @@ namespace cubos::engine
         return asset;
     }
 
-    CUBOS_REFLECT_TEMPLATE_IMPL((core::reflection::Reflectable T), (Asset<T>))
+    CUBOS_REFLECT_TEMPLATE_IMPL((typename T), (Asset<T>))
     {
         return AnyAsset::makeType("cubos::engine::Asset<" + core::reflection::reflect<T>().name() + ">");
     }


### PR DESCRIPTION
# Description

Splits the reflect method into get and make.
Will be necessary to import and export types correctly from shared libraries later on. This way, if the class is being imported, the reflection type is also being imported, instead of a duplicate being created.

Also changes `reflect` to work for types which don't implement reflection, in which case it returns an unnamed type with an empty `ConstructibleTrait`.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
