### PR TITLE
fix(imgui): handle BeginTable return value on DataInspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Free camera controller angle not being bounded (#1016, **@diogomsmiranda**).
 - Crash when meshing an empty voxel grid (**@RiscadoA**).
 - Double destruction in AnyVector::swapErase (**@RiscadoA**).
+- Crash due to DataInspector BeginTable calls being unchecked (#1036, **@RiscadoA**).
 
 ## [v0.1.0] - 2024-02-17
 

--- a/engine/src/imgui/data_inspector.cpp
+++ b/engine/src/imgui/data_inspector.cpp
@@ -37,17 +37,23 @@ static bool nullifyMenu(const Type& type, void* value);
 
 void DataInspector::show(const core::reflection::Type& type, const void* value)
 {
-    ImGui::BeginTable("inspector", 2);
-    this->inspect("", type, const_cast<void*>(value), true);
-    ImGui::EndTable();
+    if (ImGui::BeginTable("inspector", 2))
+    {
+        this->inspect("", type, const_cast<void*>(value), true);
+        ImGui::EndTable();
+    }
 }
 
 bool DataInspector::edit(const core::reflection::Type& type, void* value)
 {
-    ImGui::BeginTable("inspector", 2);
-    auto changed = this->inspect("", type, value, false);
-    ImGui::EndTable();
-    return changed;
+    if (ImGui::BeginTable("inspector", 2))
+    {
+        auto changed = this->inspect("", type, value, false);
+        ImGui::EndTable();
+        return changed;
+    }
+
+    return false;
 }
 
 bool DataInspector::inspect(const std::string& name, const Type& type, void* value, bool readOnly)
@@ -213,10 +219,12 @@ bool DataInspector::inspect(const std::string& name, const Type& type, void* val
 
                 if (ImGui::BeginPopupModal("DictPopup", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
                 {
-                    ImGui::BeginTable("DictPopupInsert", 2);
-                    inspect("key", trait.keyType(), mKey.get(), readOnly);
-                    inspect("value", trait.valueType(), mValue.get(), readOnly);
-                    ImGui::EndTable();
+                    if (ImGui::BeginTable("DictPopupInsert", 2))
+                    {
+                        inspect("key", trait.keyType(), mKey.get(), readOnly);
+                        inspect("value", trait.valueType(), mValue.get(), readOnly);
+                        ImGui::EndTable();
+                    }
 
                     if (mKeyExists)
                     {


### PR DESCRIPTION
# Description

It wasn't being checked, and thus the program crashed sometimes when you scrolled past stuff which used the data inspector.

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
