### PR TITLE
Add Render Target plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for untyped resources (#1057, **@RiscadoA**).
 - Addition and removal of resources through Commands (#325, **@RiscadoA**).
 - Access to unscaled delta time for utilities like the debug camera (#1020, **@RiscadoA**).
+- RenderTarget plugin (#1059, **@tomas7770**).
 
 ### Changed
 

--- a/core/include/cubos/core/io/window.hpp
+++ b/core/include/cubos/core/io/window.hpp
@@ -181,11 +181,11 @@ namespace cubos::core::io
 
         /// @brief Gets the window size, which may differ from the framebuffer size.
         /// @return Window size, in screen coordinates.
-        virtual glm::ivec2 size() const = 0;
+        virtual glm::uvec2 size() const = 0;
 
         /// @brief Gets the window framebuffer size, which may differ from the window size.
         /// @return Window framebuffer size, in pixels.
-        virtual glm::ivec2 framebufferSize() const = 0;
+        virtual glm::uvec2 framebufferSize() const = 0;
 
         /// @brief Gets the window content scale, commonly known as "DPI scale".
         /// @return Ratio between the current DPI and the platform's default DPI.

--- a/core/samples/gl/compute/main.cpp
+++ b/core/samples/gl/compute/main.cpp
@@ -122,7 +122,7 @@ int main()
 
             renderDevice.memoryBarrier(gl::MemoryBarriers::TextureAccess);
 
-            renderDevice.setViewport(0, 0, size.x, size.y);
+            renderDevice.setViewport(0, 0, static_cast<int>(size.x), static_cast<int>(size.y));
             renderDevice.setShaderPipeline(drawPp);
             renderDevice.setVertexArray(va);
             renderDevice.setIndexBuffer(ib);

--- a/core/samples/gl/debug_renderer/main.cpp
+++ b/core/samples/gl/debug_renderer/main.cpp
@@ -27,7 +27,7 @@ int main()
 
         auto sz = window->framebufferSize();
         renderDevice.clearColor(0.0, 0.0, 0.0, 0.0F);
-        renderDevice.setViewport(0, 0, sz.x, sz.y);
+        renderDevice.setViewport(0, 0, static_cast<int>(sz.x), static_cast<int>(sz.y));
 
         auto vp = glm::perspective(glm::radians(70.0F), float(sz.x) / float(sz.y), 0.1F, 1000.0F) *
                   glm::lookAt(glm::vec3{3 * sinf((float)t), 3, 3 * cosf((float)t)}, glm::vec3{0.0F, 0.0F, 0.0F},

--- a/core/samples/gl/quad/main.cpp
+++ b/core/samples/gl/quad/main.cpp
@@ -111,7 +111,7 @@ int main()
         while (!window->shouldClose())
         {
             auto sz = window->framebufferSize();
-            renderDevice.setViewport(0, 0, sz.x, sz.y);
+            renderDevice.setViewport(0, 0, static_cast<int>(sz.x), static_cast<int>(sz.y));
 
             renderDevice.clearColor(0.894F, 0.592F, 0.141F, 0.0F);
 

--- a/core/src/io/glfw_window.cpp
+++ b/core/src/io/glfw_window.cpp
@@ -138,7 +138,7 @@ gl::RenderDevice& GLFWWindow::renderDevice() const
 #endif
 }
 
-glm::ivec2 GLFWWindow::size() const
+glm::uvec2 GLFWWindow::size() const
 {
 #ifdef WITH_GLFW
     int width;
@@ -150,7 +150,7 @@ glm::ivec2 GLFWWindow::size() const
 #endif
 }
 
-glm::ivec2 GLFWWindow::framebufferSize() const
+glm::uvec2 GLFWWindow::framebufferSize() const
 {
 #ifdef WITH_GLFW
     int width;

--- a/core/src/io/glfw_window.hpp
+++ b/core/src/io/glfw_window.hpp
@@ -27,8 +27,8 @@ namespace cubos::core::io
         void pollEvents() override;
         void swapBuffers() override;
         gl::RenderDevice& renderDevice() const override;
-        glm::ivec2 size() const override;
-        glm::ivec2 framebufferSize() const override;
+        glm::uvec2 size() const override;
+        glm::uvec2 framebufferSize() const override;
         float contentScale() const override;
         bool shouldClose() const override;
         double time() const override;

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -106,6 +106,9 @@ set(CUBOS_ENGINE_SOURCE
 
 	"src/render/g_buffer/plugin.cpp"
 	"src/render/g_buffer/g_buffer.cpp"
+
+	"src/render/target/plugin.cpp"
+	"src/render/target/target.cpp"
 )
 
 # Create cubos engine

--- a/engine/include/cubos/engine/render/g_buffer/plugin.hpp
+++ b/engine/include/cubos/engine/render/g_buffer/plugin.hpp
@@ -19,9 +19,6 @@ namespace cubos::engine
     /// - @ref window-plugin
     /// - @ref render-target-plugin
 
-    // TODO move this to render target plugin when that's done
-    extern Tag resizeRenderTargetTag;
-
     /// @brief Recreates the GBuffer if necessary - for example, due to a render target resize.
     extern Tag createGBufferTag;
 

--- a/engine/include/cubos/engine/render/target/plugin.hpp
+++ b/engine/include/cubos/engine/render/target/plugin.hpp
@@ -1,0 +1,28 @@
+/// @dir
+/// @brief @ref render-target-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup render-target-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+namespace cubos::engine
+{
+    /// @defgroup render-target-plugin Render Target
+    /// @ingroup render-plugins
+    /// @brief Adds and manages @ref RenderTarget components.
+    ///
+    /// ## Dependencies
+    /// - @ref window-plugin
+
+    /// @brief Resizes the Render Target if necessary - for example, due to a window resize.
+    extern Tag resizeRenderTargetTag;
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class.
+    /// @ingroup render-target-plugin
+    void renderTargetPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/src/render/g_buffer/plugin.cpp
+++ b/engine/src/render/g_buffer/plugin.cpp
@@ -3,19 +3,23 @@
 
 #include <cubos/engine/render/g_buffer/g_buffer.hpp>
 #include <cubos/engine/render/g_buffer/plugin.hpp>
+#include <cubos/engine/render/target/plugin.hpp>
 #include <cubos/engine/render/target/target.hpp>
+#include <cubos/engine/window/plugin.hpp>
 
 using cubos::core::gl::Texture2DDesc;
 using cubos::core::gl::TextureFormat;
 using cubos::core::gl::Usage;
 using cubos::core::io::Window;
 
-CUBOS_DEFINE_TAG(cubos::engine::resizeRenderTargetTag);
 CUBOS_DEFINE_TAG(cubos::engine::createGBufferTag);
 CUBOS_DEFINE_TAG(cubos::engine::drawToGBufferTag);
 
 void cubos::engine::gBufferPlugin(Cubos& cubos)
 {
+    cubos.depends(windowPlugin);
+    cubos.depends(renderTargetPlugin);
+
     cubos.component<GBuffer>();
 
     cubos.tag(createGBufferTag).after(resizeRenderTargetTag);

--- a/engine/src/render/target/plugin.cpp
+++ b/engine/src/render/target/plugin.cpp
@@ -1,0 +1,33 @@
+#include <cubos/core/io/window.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/render/target/plugin.hpp>
+#include <cubos/engine/render/target/target.hpp>
+#include <cubos/engine/window/plugin.hpp>
+
+using cubos::core::io::Window;
+
+CUBOS_DEFINE_TAG(cubos::engine::resizeRenderTargetTag);
+
+void cubos::engine::renderTargetPlugin(Cubos& cubos)
+{
+    cubos.depends(windowPlugin);
+
+    cubos.component<RenderTarget>();
+
+    cubos.tag(resizeRenderTargetTag);
+
+    cubos.system("resize render targets")
+        .tagged(resizeRenderTargetTag)
+        .call([](const Window& window, Query<RenderTarget&> query) {
+            for (auto [target] : query)
+            {
+                if (target.framebuffer == nullptr && window->framebufferSize() != target.size)
+                {
+                    target.size = window->framebufferSize();
+
+                    CUBOS_INFO("Resized RenderTarget to {}x{}", target.size.x, target.size.y);
+                }
+            }
+        });
+}

--- a/engine/src/render/target/target.cpp
+++ b/engine/src/render/target/target.cpp
@@ -1,0 +1,12 @@
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/render/target/target.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::RenderTarget)
+{
+    return core::ecs::TypeBuilder<RenderTarget>("cubos::engine::RenderTarget")
+        .withField("size", &RenderTarget::size)
+        .build();
+}


### PR DESCRIPTION
# Description

Adds a new `renderTargetPlugin` in the `cubos/engine/render` directory, which registers a new component named `RenderTarget`, and a system which automatically resizes render targets with a null framebuffer to the current window size.

Also changes window `framebufferSize()` and `size()` return types to unsigned values, because the window size shouldn't be negative.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
