### PR TITLE
Add threading Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Access to unscaled delta time for utilities like the debug camera (#1020, **@RiscadoA**).
 - RenderTarget plugin (#1059, **@tomas7770**).
 - RenderPicker plugin (#1060, **@tomas7770**).
+- Task class, for use in asynchronous code (#1111, **@RiscadoA**).
 
 ### Changed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -23,7 +23,7 @@ message("# Building core tests: " ${BUILD_CORE_TESTS})
 # Set core source files
 set(CUBOS_CORE_SOURCE
 	"src/log.cpp"
-	"src/thread_pool.cpp"
+	"src/thread/pool.cpp"
 
 	"src/memory/stream.cpp"
 	"src/memory/standard_stream.cpp"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -23,7 +23,9 @@ message("# Building core tests: " ${BUILD_CORE_TESTS})
 # Set core source files
 set(CUBOS_CORE_SOURCE
 	"src/log.cpp"
+
 	"src/thread/pool.cpp"
+	"src/thread/task.cpp"
 
 	"src/memory/stream.cpp"
 	"src/memory/standard_stream.cpp"

--- a/core/include/cubos/core/thread/module.dox
+++ b/core/include/cubos/core/thread/module.dox
@@ -1,0 +1,13 @@
+/// @dir
+/// @brief @ref core-thread module.
+
+/// @namespace cubos::core::thread
+/// @brief @ref core-thread module.
+/// @ingroup core-thread
+
+namespace cubos::core::thread
+{
+    /// @defgroup core-thread Threading
+    /// @ingroup core
+    /// @brief Provides threading and asynchronous related utilities.
+} // namespace cubos::core::thread

--- a/core/include/cubos/core/thread/pool.hpp
+++ b/core/include/cubos/core/thread/pool.hpp
@@ -1,6 +1,6 @@
 /// @file
-/// @brief Class @ref cubos::core::ThreadPool.
-/// @ingroup core
+/// @brief Class @ref cubos::core::thread::ThreadPool.
+/// @ingroup core-thread
 
 #pragma once
 
@@ -11,11 +11,11 @@
 #include <thread>
 #include <vector>
 
-namespace cubos::core
+namespace cubos::core::thread
 {
     /// @brief Manages a pool of threads, to which tasks can be submitted.
     /// @note Blocks on tasks to finish on destruction.
-    /// @ingroup core
+    /// @ingroup core-thread
     class ThreadPool final
     {
     public:
@@ -49,4 +49,4 @@ namespace cubos::core
         std::atomic<std::size_t> mNumTasks; ///< Number of tasks currently being executed.
         bool mStop;                         ///< Set to true when the thread pool is being destroyed.
     };
-} // namespace cubos::core
+} // namespace cubos::core::thread

--- a/core/include/cubos/core/thread/task.hpp
+++ b/core/include/cubos/core/thread/task.hpp
@@ -1,0 +1,159 @@
+/// @file
+/// @brief Class @ref cubos::core::thread::Task.
+/// @ingroup core-thread
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+#include <cubos/core/log.hpp>
+
+namespace cubos::core::thread
+{
+    /// @brief Provides a mechanism to access the results of asynchronous operations.
+    /// @tparam T Result type.
+    /// @ingroup core-thread
+    template <typename T>
+    class Task final
+    {
+    public:
+        ~Task()
+        {
+            this->discard();
+        }
+
+        /// @brief Constructs.
+        Task()
+        {
+            mData = new Data();
+        }
+
+        /// @brief Copy constructs.
+        /// @param other Task.
+        Task(const Task& other)
+            : mData{other.mData}
+        {
+            std::unique_lock lock{mData->mMutex};
+            mData->mRefCount += 1;
+        }
+
+        /// @brief Move constructs.
+        /// @param other Task.
+        Task(Task&& other) noexcept
+            : mData{other.mData}
+        {
+            other.mData = nullptr;
+        }
+
+        /// @brief Copy assigns.
+        /// @param other Task.
+        Task& operator=(const Task& other)
+        {
+            this->discard();
+            mData = other.mData;
+            std::unique_lock lock{mData->mMutex};
+            mData->mRefCount += 1;
+        }
+
+        /// @brief Move assigns.
+        /// @param other Task.
+        Task& operator=(Task&& other) noexcept
+        {
+            this->discard();
+            mData = other.mData;
+            other.mData = nullptr;
+        }
+
+        /// @brief Finishes the task, setting its result and notifying a waiting thread.
+        /// @param value Task result.
+        void finish(T value)
+        {
+            CUBOS_ASSERT(mData != nullptr, "Task has been discarded");
+
+            // Set the result and notify one waiting thread.
+            std::unique_lock lock(mData->mMutex);
+            CUBOS_ASSERT(!mData->mDone, "Task has already been finished");
+
+            new (&mData->mValue) T(std::move(value));
+            mData->mDone = true;
+            mData->mCondition.notify_all();
+        }
+
+        /// @brief Discards any result eventually received. The task is left in an invalid state.
+        void discard()
+        {
+            if (mData != nullptr)
+            {
+                std::unique_lock lock{mData->mMutex};
+                mData->mRefCount -= 1;
+                if (mData->mRefCount == 0)
+                {
+                    lock.unlock();
+                    delete mData;
+                }
+                mData = nullptr;
+            }
+        }
+
+        /// @brief Returns whether the task has finished.
+        /// @return Whether the task has finished.
+        bool isDone() const
+        {
+            CUBOS_ASSERT(mData != nullptr, "Task has been discarded");
+            std::unique_lock lock(mData->mMutex);
+            return mData->mDone;
+        }
+
+        /// @brief Blocks until the task finishes and then returns its result.
+        /// @return Task result.
+        T result()
+        {
+            CUBOS_ASSERT(mData != nullptr, "Task has been discarded");
+
+            // Wait until a result is obtained. When it is, consume it.
+            {
+                std::unique_lock lock(mData->mMutex);
+                mData->mCondition.wait(lock, [this]() { return mData->mDone; });
+                CUBOS_ASSERT(!mData->mConsumed, "Task result has already been consumed");
+                mData->mConsumed = true;
+            }
+
+            // Move the result and reset the task.
+            T result = std::move(mData->mValue);
+            this->discard();
+            return result;
+        }
+
+    private:
+        /// @brief Tracks the eventual result of the task, and is used to deliver it.
+        struct Data
+        {
+            int mRefCount{1};
+            bool mDone{false};
+            bool mConsumed{false};
+            union {
+                T mValue;
+            };
+
+            std::mutex mMutex;
+            std::condition_variable mCondition;
+
+            // NOLINTBEGIN(modernize-use-equals-default)
+            Data()
+            {
+            }
+            // NOLINTEND(modernize-use-equals-default)
+
+            ~Data()
+            {
+                if (mDone)
+                {
+                    mValue.~T();
+                }
+            }
+        };
+
+        Data* mData;
+    };
+} // namespace cubos::core::thread

--- a/core/src/thread/pool.cpp
+++ b/core/src/thread/pool.cpp
@@ -1,6 +1,6 @@
-#include <cubos/core/thread_pool.hpp>
+#include <cubos/core/thread/pool.hpp>
 
-using namespace cubos::core;
+using cubos::core::thread::ThreadPool;
 
 ThreadPool::ThreadPool(std::size_t numThreads)
 {

--- a/core/src/thread/task.cpp
+++ b/core/src/thread/task.cpp
@@ -1,0 +1,1 @@
+#include <cubos/core/thread/task.hpp>

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -65,6 +65,8 @@ add_executable(
 
 	geom/box.cpp
 	geom/capsule.cpp
+
+	thread/task.cpp
 )
 
 target_link_libraries(cubos-core-tests cubos-core doctest::doctest)

--- a/core/tests/thread/task.cpp
+++ b/core/tests/thread/task.cpp
@@ -1,0 +1,62 @@
+#include <thread>
+
+#include <doctest/doctest.h>
+
+#include <cubos/core/thread/task.hpp>
+
+#include "../utils.hpp"
+
+using cubos::core::thread::Task;
+
+TEST_CASE("thread::Task")
+{
+    SUBCASE("task which produces an int")
+    {
+        Task<int> task{};
+
+        REQUIRE_FALSE(task.isDone());
+
+        auto thread = std::thread{[&task]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+            task.finish(42);
+        }};
+
+        SUBCASE("join before")
+        {
+            thread.join();
+            REQUIRE(task.isDone());
+            REQUIRE(task.result() == 42);
+        }
+
+        SUBCASE("join after")
+        {
+            task.isDone(); // May return either true or false.
+            REQUIRE(task.result() == 42);
+            thread.join();
+        }
+    }
+
+    SUBCASE("check if task is destroyed properly")
+    {
+        Task<DetectDestructor> task{};
+        bool destroyed = false;
+
+        // A copy of the task is finished.
+        {
+            Task<DetectDestructor> task2{task};
+            REQUIRE_FALSE(task.isDone());
+            REQUIRE_FALSE(task2.isDone());
+            task2.finish({&destroyed});
+            REQUIRE_FALSE(destroyed);
+            REQUIRE(task2.isDone());
+        }
+        REQUIRE(task.isDone());
+
+        // Value isn't destroyed yet.
+        REQUIRE_FALSE(destroyed);
+
+        // Value is destroyed only after being accessed.
+        task.result();
+        REQUIRE(destroyed);
+    }
+}


### PR DESCRIPTION
# Description

Utility class which can be used to wait for results which come from asynchronous code.
This will be really useful to implement stuff like waiting for a given voxel object to be loaded and meshed, instead of just blocking the entire application. With this we'll able to implement stuff like smooth terrain loading and loading screens.

Since this doesn't really fit in the other existing modules, created a new dir `core/thread` and also moved the thread pool class there.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
