### PR TITLE
Allow uninstalling and installing plugins dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow filtering by entity names in the World Inspector (#1106, **@diogomsmiranda**).
 - Possibility of building the core library as a shared library (#1052, **@RiscadoA**).
 - Possibility of building the engine library as a shared library (#1053, **@RiscadoA**).
+- Plugins system argument, which can be used to dynamically add and remove plugins (#1034, **@RiscadoA**).
 
 ### Changed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -103,6 +103,7 @@ set(CUBOS_CORE_SOURCE
 	"src/ecs/system/system.cpp"
 	"src/ecs/system/options.cpp"
 	"src/ecs/system/arguments/commands.cpp"
+	"src/ecs/system/arguments/plugins.cpp"
 	"src/ecs/system/arguments/query.cpp"
 	"src/ecs/system/arguments/resources.cpp"
 	"src/ecs/system/arguments/world.cpp"
@@ -124,6 +125,7 @@ set(CUBOS_CORE_SOURCE
     "src/ecs/name.cpp"
 	"src/ecs/world.cpp"
 	"src/ecs/command_buffer.cpp"
+	"src/ecs/plugin_queue.cpp"
 	"src/ecs/types.cpp"
 	"src/ecs/cubos.cpp"
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -8,6 +8,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <cubos/core/ecs/observer/id.hpp>
+#include <cubos/core/ecs/plugin_queue.hpp>
 #include <cubos/core/ecs/system/arguments/event/pipe.hpp>
 #include <cubos/core/ecs/system/planner.hpp>
 #include <cubos/core/ecs/system/system.hpp>
@@ -67,9 +69,6 @@ namespace cubos::core::ecs
     class CUBOS_CORE_API Cubos final
     {
     public:
-        /// @brief Function pointer type representing a plugin.
-        using Plugin = void (*)(Cubos&);
-
         /// @brief Used to create new tags or configure existing ones.
         class TagBuilder;
 
@@ -222,6 +221,18 @@ namespace cubos::core::ecs
 
             /// @brief Plugins which were added by this plugin.
             std::unordered_set<Plugin> subPlugins;
+
+            /// @brief Systems which were added by this plugin.
+            std::vector<SystemId> systems;
+
+            /// @brief Conditions which were added by this plugin.
+            std::vector<ConditionId> conditions;
+
+            /// @brief Main tags which were added by this plugin.
+            std::vector<Planner::TagId> tags;
+
+            /// @brief Observers which were added by this plugin.
+            std::vector<ObserverId> observers;
         };
 
         /// @brief Stores information regarding a tag.
@@ -258,9 +269,21 @@ namespace cubos::core::ecs
         /// @param basePlugin Plugin which may include.
         bool isKnownPlugin(Plugin plugin, Plugin basePlugin) const;
 
+        /// @brief Installs a plugin dynamically.
+        /// @param plugin Plugin.
+        void install(Plugin plugin);
+
+        /// @brief Uninstalls a plugin dynamically.
+        /// @param plugin Plugin.
+        void uninstall(Plugin plugin);
+
         World mWorld;
         SystemRegistry mSystemRegistry;
+
+        /// @brief Planner for systems which run before the main loop starts.
         Planner mStartupPlanner;
+
+        /// @brief Planner for systems which run every frame.
         Planner mMainPlanner;
 
         /// @brief Stack with the plugins currently being configured.

--- a/core/include/cubos/core/ecs/module.dox
+++ b/core/include/cubos/core/ecs/module.dox
@@ -37,6 +37,7 @@ namespace cubos::core::ecs
     /// - @ref EventReader "EventReader<E>" - reads events of type @p E sent from other systems.
     /// - @ref EventWriter "EventWriter<E>" - sends events of type @p E to other systems.
     /// - @ref Query "Query<Args...>" - queries the world for entities which match its arguments.
+    /// - @ref Plugins - used to add and remove plugins dynamically.
     ///
     /// ## Query argument types
     /// - `const C&` - matches entities with the component @p C, read-only access.

--- a/core/include/cubos/core/ecs/plugin_queue.hpp
+++ b/core/include/cubos/core/ecs/plugin_queue.hpp
@@ -1,0 +1,27 @@
+/// @file
+/// @brief Class @ref cubos::core::ecs::PluginQueue.
+/// @ingroup core-ecs
+
+#pragma once
+
+#include <mutex>
+#include <vector>
+
+#include <cubos/core/api.hpp>
+
+namespace cubos::core::ecs
+{
+    class Cubos;
+
+    /// @brief Function pointer type representing a plugin.
+    using Plugin = void (*)(Cubos&);
+
+    /// @brief Stores plugin operations to be executed later.
+    /// @ingroup core-ecs
+    struct CUBOS_CORE_API PluginQueue final
+    {
+        std::vector<Plugin> toAdd;
+        std::vector<Plugin> toRemove;
+        std::mutex mutex;
+    };
+} // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/system/arguments/plugins.hpp
+++ b/core/include/cubos/core/ecs/system/arguments/plugins.hpp
@@ -1,0 +1,59 @@
+/// @file
+/// @brief Class @ref cubos::core::ecs::Plugins.
+/// @ingroup core-ecs-system-arguments
+
+#pragma once
+
+#include <cubos/core/ecs/plugin_queue.hpp>
+#include <cubos/core/ecs/system/fetcher.hpp>
+
+namespace cubos::core::ecs
+{
+    /// @brief System argument used to add or remove Cubos plugins at runtime.
+    /// @ingroup core-ecs-system-arguments
+    class CUBOS_CORE_API Plugins final
+    {
+    public:
+        /// @brief Constructs.
+        /// @param queue Plugin queue.
+        Plugins(PluginQueue* queue);
+
+        /// @brief Adds a plugin to the application. Will be executed on the next frame.
+        ///
+        /// The plugin's startup systems will run before the frame begins.
+        ///
+        /// @param plugin Plugin.
+        void add(Plugin plugin);
+
+        /// @brief Removes a plugin from the application. Will be executed on the next frame.
+        ///
+        /// This will revert all configuration changes made by the plugin. It won't revert any effects caused by the
+        /// plugin on the world, such as adding or removing entities.
+        ///
+        /// @param plugin Plugin.
+        void remove(Plugin plugin);
+
+    private:
+        PluginQueue* mQueue;
+    };
+
+    template <>
+    class SystemFetcher<Plugins>
+    {
+    public:
+        static inline constexpr bool ConsumesOptions = false;
+
+        SystemFetcher(World& /*world*/, const SystemOptions& /*options*/)
+        {
+        }
+
+        void analyze(SystemAccess& /*access*/) const
+        {
+        }
+
+        static Plugins fetch(const SystemContext& ctx)
+        {
+            return {ctx.pluginQueue};
+        }
+    };
+} // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/system/fetcher.hpp
+++ b/core/include/cubos/core/ecs/system/fetcher.hpp
@@ -8,8 +8,10 @@
 
 namespace cubos::core::ecs
 {
+    class Cubos;
     class World;
     class CommandBuffer;
+    struct PluginQueue;
     struct SystemOptions;
     struct SystemAccess;
 
@@ -18,6 +20,9 @@ namespace cubos::core::ecs
     {
         /// @brief Command buffer to record commands to.
         CommandBuffer& cmdBuffer;
+
+        /// @brief Plugin queue to add or remove plugins from.
+        PluginQueue* pluginQueue = nullptr;
 
         /// @brief Entity which triggered the system, if it's an observer.
         Entity observedEntity{};

--- a/core/include/cubos/core/ecs/system/planner.hpp
+++ b/core/include/cubos/core/ecs/system/planner.hpp
@@ -33,6 +33,9 @@ namespace cubos::core::ecs
             };
         };
 
+        /// @brief Resets the planner to its initial state.
+        void clear();
+
         /// @brief Adds a new unnamed tag to the planner.
         /// @return Tag identifier.
         TagId add();

--- a/core/include/cubos/core/ecs/table/sparse_relation/registry.hpp
+++ b/core/include/cubos/core/ecs/table/sparse_relation/registry.hpp
@@ -99,16 +99,9 @@ namespace cubos::core::ecs
         /// @return Type index.
         const TypeIndex& type(DataTypeId type) const;
 
-        /// @brief Moves all relations of an entity from an archetype to another.
-        /// @param source Old archetype.
-        /// @param target New archetype.
-        /// @param index Entity index.
-        void move(ArchetypeId source, ArchetypeId target, uint32_t index);
-
-        /// @brief Removes all relations of an entity.
-        /// @param archetype Entity archetype.
-        /// @param index Entity index.
-        void erase(ArchetypeId archetype, uint32_t index);
+        /// @brief Removes all relations of the given type.
+        /// @param type Type identifier.
+        void erase(DataTypeId type);
 
         /// @brief Calls the given function for each new table.
         /// @param counter Counter previously returned by this function. Zero should be used for the first call.

--- a/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
+++ b/core/include/cubos/core/ecs/table/sparse_relation/table.hpp
@@ -59,6 +59,9 @@ namespace cubos::core::ecs
         /// @param relationType Relation type.
         SparseRelationTable(const reflection::Type& relationType);
 
+        /// @brief Removes all relations from the table.
+        void clear();
+
         /// @brief Adds a relation between the given indices. If it already exists, overwrites it.
         /// @param from From index.
         /// @param to To index.

--- a/core/include/cubos/core/ecs/types.hpp
+++ b/core/include/cubos/core/ecs/types.hpp
@@ -48,6 +48,11 @@ namespace cubos::core::ecs
         /// @param type Relation type.
         void addRelation(const reflection::Type& type);
 
+        /// @brief Unregisters a data type.
+        /// @param type Data type.
+        /// @return Type identifier.
+        DataTypeId remove(const reflection::Type& type);
+
         /// @brief Gets the identifier of a data type.
         ///
         /// Aborts if the data type is not registered.

--- a/core/include/cubos/core/ecs/types.hpp
+++ b/core/include/cubos/core/ecs/types.hpp
@@ -50,8 +50,7 @@ namespace cubos::core::ecs
 
         /// @brief Unregisters a data type.
         /// @param type Data type.
-        /// @return Type identifier.
-        DataTypeId remove(const reflection::Type& type);
+        void remove(const reflection::Type& type);
 
         /// @brief Gets the identifier of a data type.
         ///

--- a/core/include/cubos/core/ecs/world.hpp
+++ b/core/include/cubos/core/ecs/world.hpp
@@ -88,6 +88,10 @@ namespace cubos::core::ecs
             this->registerRelation(reflection::reflect<T>());
         }
 
+        /// @brief Unregisters a type.
+        /// @param type Rype
+        void unregister(const reflection::Type& type);
+
         /// @brief Returns the types registry of the world.
         /// @return Types registry.
         Types& types();

--- a/core/src/ecs/observer/observers.cpp
+++ b/core/src/ecs/observer/observers.cpp
@@ -21,7 +21,7 @@ bool Observers::notifyAdd(CommandBuffer& commandBuffer, Entity entity, ColumnId 
         auto* observer = mObservers[it->second.inner];
         if (observer != nullptr)
         {
-            observer->run({commandBuffer, entity});
+            observer->run({.cmdBuffer = commandBuffer, .observedEntity = entity});
             triggered = true;
         }
     }
@@ -39,7 +39,7 @@ bool Observers::notifyRemove(CommandBuffer& commandBuffer, Entity entity, Column
         auto* observer = mObservers[it->second.inner];
         if (observer != nullptr)
         {
-            observer->run({commandBuffer, entity});
+            observer->run({.cmdBuffer = commandBuffer, .observedEntity = entity});
             triggered = true;
         }
     }

--- a/core/src/ecs/plugin_queue.cpp
+++ b/core/src/ecs/plugin_queue.cpp
@@ -1,0 +1,1 @@
+#include <cubos/core/ecs/plugin_queue.hpp>

--- a/core/src/ecs/system/arguments/plugins.cpp
+++ b/core/src/ecs/system/arguments/plugins.cpp
@@ -1,0 +1,22 @@
+#include <cubos/core/ecs/system/arguments/plugins.hpp>
+#include <cubos/core/log.hpp>
+
+using cubos::core::ecs::Plugins;
+
+Plugins::Plugins(PluginQueue* queue)
+    : mQueue(queue)
+{
+    CUBOS_ASSERT(queue != nullptr, "Plugins system argument is not valid in this context");
+}
+
+void Plugins::add(Plugin plugin)
+{
+    std::lock_guard guard(mQueue->mutex);
+    mQueue->toAdd.push_back(plugin);
+}
+
+void Plugins::remove(Plugin plugin)
+{
+    std::lock_guard guard(mQueue->mutex);
+    mQueue->toRemove.push_back(plugin);
+}

--- a/core/src/ecs/system/planner.cpp
+++ b/core/src/ecs/system/planner.cpp
@@ -10,6 +10,11 @@ std::size_t Planner::TagId::Hash::operator()(const TagId& tagId) const
     return tagId.inner;
 }
 
+void Planner::clear()
+{
+    mTags.clear();
+}
+
 auto Planner::add() -> TagId
 {
     return this->add("unnamed" + std::to_string(mTags.size()));

--- a/core/src/ecs/table/sparse_relation/registry.cpp
+++ b/core/src/ecs/table/sparse_relation/registry.cpp
@@ -57,6 +57,29 @@ const SparseRelationTableRegistry::TypeIndex& SparseRelationTableRegistry::type(
     return it->second;
 }
 
+void SparseRelationTableRegistry::erase(DataTypeId type)
+{
+    auto it = mTypeIndices.find(type);
+    if (it != mTypeIndices.end())
+    {
+        for (auto [archetype, tables] : it->second.from())
+        {
+            for (auto id : tables)
+            {
+                mTables.at(id).clear();
+            }
+        }
+
+        for (auto [archetype, tables] : it->second.to())
+        {
+            for (auto id : tables)
+            {
+                mTables.at(id).clear();
+            }
+        }
+    }
+}
+
 void SparseRelationTableRegistry::TypeIndex::insert(SparseRelationTableId id)
 {
     mSparseRelationTableIdsByFrom[id.from].emplace_back(id);

--- a/core/src/ecs/table/sparse_relation/table.cpp
+++ b/core/src/ecs/table/sparse_relation/table.cpp
@@ -20,6 +20,15 @@ SparseRelationTable::SparseRelationTable(const reflection::Type& relationType)
     mConstructibleTrait = &relationType.get<reflection::ConstructibleTrait>();
 }
 
+void SparseRelationTable::clear()
+{
+    mRows.clear();
+    mRelations.clear();
+    mPairRows.clear();
+    mFromRows.clear();
+    mToRows.clear();
+}
+
 std::size_t SparseRelationTable::size() const
 {
     return mRelations.size();

--- a/core/src/ecs/types.cpp
+++ b/core/src/ecs/types.cpp
@@ -49,7 +49,7 @@ void Types::add(const reflection::Type& type, Kind kind)
     CUBOS_ASSERT(!mEntries.back().isTree || !mEntries.back().isSymmetric, "Symmetric tree relations are not supported");
 }
 
-DataTypeId Types::remove(const reflection::Type& type)
+void Types::remove(const reflection::Type& type)
 {
     CUBOS_ASSERT(mTypes.contains(type), "Type {} not registered", type.name());
 
@@ -57,7 +57,6 @@ DataTypeId Types::remove(const reflection::Type& type)
     mTypes.erase(type);
     mNames.erase(type.name());
     mEntries[id.inner].type = nullptr;
-    return id;
 }
 
 DataTypeId Types::id(const reflection::Type& type) const

--- a/core/src/ecs/types.cpp
+++ b/core/src/ecs/types.cpp
@@ -49,6 +49,17 @@ void Types::add(const reflection::Type& type, Kind kind)
     CUBOS_ASSERT(!mEntries.back().isTree || !mEntries.back().isSymmetric, "Symmetric tree relations are not supported");
 }
 
+DataTypeId Types::remove(const reflection::Type& type)
+{
+    CUBOS_ASSERT(mTypes.contains(type), "Type {} not registered", type.name());
+
+    auto id = mTypes.at(type);
+    mTypes.erase(type);
+    mNames.erase(type.name());
+    mEntries[id.inner].type = nullptr;
+    return id;
+}
+
 DataTypeId Types::id(const reflection::Type& type) const
 {
     CUBOS_ASSERT(mTypes.contains(type), "Type {} not registered", type.name());
@@ -106,7 +117,7 @@ TypeRegistry Types::resources() const
     TypeRegistry registry{};
     for (const auto& entry : mEntries)
     {
-        if (entry.kind == Kind::Resource)
+        if (entry.kind == Kind::Resource && entry.type != nullptr)
         {
             registry.insert(*entry.type);
         }
@@ -119,7 +130,7 @@ TypeRegistry Types::components() const
     TypeRegistry registry{};
     for (const auto& entry : mEntries)
     {
-        if (entry.kind == Kind::Component)
+        if (entry.kind == Kind::Component && entry.type != nullptr)
         {
             registry.insert(*entry.type);
         }
@@ -132,7 +143,7 @@ TypeRegistry Types::relations() const
     TypeRegistry registry{};
     for (const auto& entry : mEntries)
     {
-        if (entry.kind == Kind::Relation)
+        if (entry.kind == Kind::Relation && entry.type != nullptr)
         {
             registry.insert(*entry.type);
         }

--- a/core/src/ecs/world.cpp
+++ b/core/src/ecs/world.cpp
@@ -41,7 +41,7 @@ void World::registerRelation(const reflection::Type& type)
 
 void World::unregister(const reflection::Type& type)
 {
-    auto dataTypeId = mTypes.remove(type);
+    auto dataTypeId = mTypes.id(type);
     if (mTypes.isResource(dataTypeId))
     {
         CUBOS_TRACE("Unregistered resource {}", type.name());
@@ -73,6 +73,8 @@ void World::unregister(const reflection::Type& type)
         CUBOS_TRACE("Unregistered relation {}", type.name());
         mTables.sparseRelation().erase(dataTypeId);
     }
+
+    mTypes.remove(type);
 }
 
 void World::insertResource(memory::AnyValue value)

--- a/core/tests/ecs/types.cpp
+++ b/core/tests/ecs/types.cpp
@@ -57,4 +57,44 @@ TEST_CASE("ecs::Types")
     REQUIRE(types.isResource({.inner = 3}));
     REQUIRE_FALSE(types.isComponent({.inner = 3}));
     REQUIRE_FALSE(types.isRelation({.inner = 3}));
+
+    auto components = types.components();
+    REQUIRE(components.size() == 1);
+    REQUIRE(components.contains<int>());
+    types.remove(reflect<int>());
+    REQUIRE_FALSE(types.contains(reflect<int>()));
+    REQUIRE_FALSE(types.contains("int"));
+    components = types.components();
+    REQUIRE(components.size() == 0);
+
+    auto relations = types.relations();
+    REQUIRE(relations.size() == 2);
+    REQUIRE(relations.contains<SymmetricRelation>());
+    REQUIRE(relations.contains<TreeRelation>());
+    types.remove(reflect<SymmetricRelation>());
+    REQUIRE_FALSE(types.contains(reflect<SymmetricRelation>()));
+    REQUIRE_FALSE(types.contains("SymmetricRelation"));
+    relations = types.relations();
+    REQUIRE(relations.size() == 1);
+    REQUIRE_FALSE(relations.contains<SymmetricRelation>());
+    REQUIRE(relations.contains<TreeRelation>());
+
+    auto resources = types.resources();
+    REQUIRE(resources.size() == 1);
+    REQUIRE(resources.contains<float>());
+    types.remove(reflect<float>());
+    REQUIRE_FALSE(types.contains(reflect<float>()));
+    REQUIRE_FALSE(types.contains("float"));
+    resources = types.resources();
+    REQUIRE(resources.size() == 0);
+
+    types.addComponent(reflect<int>());
+    REQUIRE(types.contains(reflect<int>()));
+    REQUIRE(types.contains("int"));
+    REQUIRE(types.id("int").inner == 4);
+    REQUIRE(types.id(reflect<int>()).inner == 4);
+    REQUIRE(types.type({.inner = 4}).is<int>());
+    REQUIRE_FALSE(types.isResource({.inner = 4}));
+    REQUIRE(types.isComponent({.inner = 4}));
+    REQUIRE_FALSE(types.isRelation({.inner = 4}));
 }

--- a/engine/include/cubos/engine/prelude.hpp
+++ b/engine/include/cubos/engine/prelude.hpp
@@ -15,6 +15,9 @@ namespace cubos::engine
     /// @copydoc cubos::core::ecs::Tag
     using Tag = core::ecs::Tag;
 
+    /// @copydoc cubos::core::ecs::Plugin
+    using Plugin = core::ecs::Plugin;
+
     /// @copydoc cubos::core::ecs::Cubos
     using Cubos = core::ecs::Cubos;
 


### PR DESCRIPTION
Blocked on #1117.

# Description

Adds a new system argument `Plugins`, through which systems can add and remove plugins at runtime.
When a new plugin is added, its startup systems are run before starting the next frame.
Its main systems are added to the existing schedule.
When removing a plugin, all of its resources, components, relations, tags, systems are removed.
Any created entity remains, but without the removed component types.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
