### PR TITLE
Add Camera plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RenderDepth plugin (#1082, **@RiscadoA**).
 - Task class, for use in asynchronous code (#1111, **@RiscadoA**).
 - HDR plugin (#1085, **@RiscadoA**).
+- Camera plugin (#1063, **@tomas7770**).
 
 ### Changed
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -118,6 +118,10 @@ set(CUBOS_ENGINE_SOURCE
 
 	"src/render/depth/plugin.cpp"
 	"src/render/depth/depth.cpp"
+
+	"src/render/camera/plugin.cpp"
+	"src/render/camera/perspective_camera.cpp"
+	"src/render/camera/draws_to.cpp"
 )
 
 # Create cubos engine

--- a/engine/include/cubos/engine/render/camera/draws_to.hpp
+++ b/engine/include/cubos/engine/render/camera/draws_to.hpp
@@ -1,0 +1,17 @@
+/// @file
+/// @brief Relation @ref cubos::engine::DrawsTo.
+/// @ingroup render-camera-plugin
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Relation which indicates the 'from' entity is a camera that draws to the 'to' target.
+    /// @ingroup render-camera-plugin
+    struct DrawsTo
+    {
+        CUBOS_REFLECT;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/camera/perspective_camera.hpp
+++ b/engine/include/cubos/engine/render/camera/perspective_camera.hpp
@@ -1,0 +1,30 @@
+/// @file
+/// @brief Component @ref cubos::engine::PerspectiveCamera.
+/// @ingroup render-camera-plugin
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which defines parameters of a perspective camera used to render the world.
+    /// @note Should be used with @ref LocalToWorld.
+    /// @ingroup render-camera-plugin
+    struct PerspectiveCamera
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Whether the camera is drawing to a target.
+        bool active = true;
+
+        /// @brief Vertical field of view in degrees.
+        float fovY = 60.0F;
+
+        /// @brief Near clipping plane.
+        float zNear = 0.1F;
+
+        /// @brief Far clipping plane.
+        float zFar = 1000.0F;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/camera/plugin.hpp
+++ b/engine/include/cubos/engine/render/camera/plugin.hpp
@@ -1,0 +1,22 @@
+/// @dir
+/// @brief @ref render-camera-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup render-camera-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+namespace cubos::engine
+{
+    /// @defgroup render-camera-plugin Camera
+    /// @ingroup render-plugins
+    /// @brief Adds @ref PerspectiveCamera components and the @ref DrawsTo relation.
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class.
+    /// @ingroup render-camera-plugin
+    void cameraPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/src/render/camera/draws_to.cpp
+++ b/engine/src/render/camera/draws_to.cpp
@@ -1,0 +1,8 @@
+#include <cubos/core/ecs/reflection.hpp>
+
+#include <cubos/engine/render/camera/draws_to.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::DrawsTo)
+{
+    return core::ecs::TypeBuilder<DrawsTo>("cubos::engine::DrawsTo").build();
+}

--- a/engine/src/render/camera/perspective_camera.cpp
+++ b/engine/src/render/camera/perspective_camera.cpp
@@ -1,0 +1,14 @@
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/render/camera/perspective_camera.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::PerspectiveCamera)
+{
+    return core::ecs::TypeBuilder<PerspectiveCamera>("cubos::engine::PerspectiveCamera")
+        .withField("active", &PerspectiveCamera::active)
+        .withField("fovY", &PerspectiveCamera::fovY)
+        .withField("zNear", &PerspectiveCamera::zNear)
+        .withField("zFar", &PerspectiveCamera::zFar)
+        .build();
+}

--- a/engine/src/render/camera/plugin.cpp
+++ b/engine/src/render/camera/plugin.cpp
@@ -1,0 +1,10 @@
+#include <cubos/engine/render/camera/draws_to.hpp>
+#include <cubos/engine/render/camera/perspective_camera.hpp>
+#include <cubos/engine/render/camera/plugin.hpp>
+
+void cubos::engine::cameraPlugin(Cubos& cubos)
+{
+    cubos.component<PerspectiveCamera>();
+
+    cubos.relation<DrawsTo>();
+}


### PR DESCRIPTION
# Description

Add a new `cameraPlugin`, which adds the `PerspectiveCamera` component (same fields as old `Camera`, plus a new `active` field to support multiple cameras per `RenderTarget`) and the `DrawsTo` relation, which has no fields.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
