### PR TITLE
Add split screen to new renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GBuffer Rasterizer plugin (#1062, **@RiscadoA**).
 - Deferred Shading plugin (#1086, **@RiscadoA**).
 - SSAO plugin (#1088, **@RiscadoA**).
+- Split screen for the new renderer (#1149, **@tomas7770**).
 
 ### Changed
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -137,6 +137,8 @@ set(CUBOS_ENGINE_SOURCE
 	"src/render/ssao/ssao.cpp"
 	"src/render/deferred_shading/plugin.cpp"
 	"src/render/deferred_shading/deferred_shading.cpp"
+	"src/render/split_screen/plugin.cpp"
+	"src/render/split_screen/split_screen.cpp"
 )
 
 # Create cubos engine

--- a/engine/assets/render/deferred_shading.fs
+++ b/engine/assets/render/deferred_shading.fs
@@ -7,6 +7,9 @@ uniform sampler2D normalTexture;
 uniform sampler2D albedoTexture;
 uniform sampler2D ssaoTexture;
 
+uniform vec2 viewportOffset;
+uniform vec2 viewportSize;
+
 struct DirectionalLight
 {
     vec4 direction;
@@ -111,7 +114,9 @@ vec3 rayDir(vec2 uv)
 
 void main()
 {
-    vec3 normal = texture(normalTexture, fragUv).xyz;
+    vec2 uv = fragUv * viewportSize + viewportOffset;
+
+    vec3 normal = texture(normalTexture, uv).xyz;
     if (normal == vec3(0.0))
     {
         // If the normal is zero, then we are rendering the sky.
@@ -120,9 +125,9 @@ void main()
     }
     else
     {
-        vec3 albedo = texture(albedoTexture, fragUv).rgb;
-        vec3 position = texture(positionTexture, fragUv).xyz;
-        float ssao = texture(ssaoTexture, fragUv).r;
+        vec3 albedo = texture(albedoTexture, uv).rgb;
+        vec3 position = texture(positionTexture, uv).xyz;
+        float ssao = texture(ssaoTexture, uv).r;
 
         // Calculate lighting from each light source.
         vec3 lighting = ambientLight.rgb * ssao;

--- a/engine/assets/render/ssao_base.fs
+++ b/engine/assets/render/ssao_base.fs
@@ -8,6 +8,9 @@ uniform sampler2D positionTexture;
 uniform sampler2D normalTexture;
 uniform sampler2D noiseTexture;
 
+uniform vec2 viewportOffset;
+uniform vec2 viewportSize;
+
 layout(std140) uniform PerScene
 {
     mat4 view;
@@ -22,13 +25,15 @@ layout (location = 0) out float color;
 
 vec3 getViewPosition(vec2 fragUv)
 {
-    vec3 worldPosition = texture(positionTexture, fragUv).xyz;
+    vec2 uv = fragUv * viewportSize + viewportOffset;
+    vec3 worldPosition = texture(positionTexture, uv).xyz;
     return (view * vec4(worldPosition, 1.0)).xyz;
 }
 
 vec3 getViewNormal(vec2 fragUv)
 {
-    vec3 worldNormal = texture(normalTexture, fragUv).xyz;
+    vec2 uv = fragUv * viewportSize + viewportOffset;
+    vec3 worldNormal = texture(normalTexture, uv).xyz;
     return normalize(view * vec4(worldNormal, 0.0)).xyz;
 }
 

--- a/engine/assets/render/ssao_blur.fs
+++ b/engine/assets/render/ssao_blur.fs
@@ -4,9 +4,13 @@ in vec2 fragUv;
 
 uniform sampler2D ssaoTexture;
 
+uniform vec2 viewportOffset;
+uniform vec2 viewportSize;
+
 layout (location = 0) out float color;
 
 void main() {
+    vec2 uv = fragUv * viewportSize + viewportOffset;
     vec2 texelSize = 1.0 / vec2(textureSize(ssaoTexture, 0));
     float result = 0.0;
     for (int x = -2; x < 2; ++x)
@@ -14,7 +18,7 @@ void main() {
         for (int y = -2; y < 2; ++y)
         {
             vec2 offset = vec2(float(x), float(y)) * texelSize;
-            result += texture(ssaoTexture, fragUv + offset).r;
+            result += texture(ssaoTexture, uv + offset).r;
         }
     }
     color = result / (4.0 * 4.0);

--- a/engine/include/cubos/engine/render/camera/draws_to.hpp
+++ b/engine/include/cubos/engine/render/camera/draws_to.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <glm/vec2.hpp>
+
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
@@ -15,5 +17,11 @@ namespace cubos::engine
     struct CUBOS_ENGINE_API DrawsTo
     {
         CUBOS_REFLECT;
+
+        /// @brief Offset of the viewport, in normalized coordinates.
+        glm::vec2 viewportOffset = {0, 0};
+
+        /// @brief Size of the viewport, in normalized coordinates.
+        glm::vec2 viewportSize = {1, 1};
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/render/split_screen/plugin.hpp
+++ b/engine/include/cubos/engine/render/split_screen/plugin.hpp
@@ -1,0 +1,31 @@
+/// @dir
+/// @brief @ref render-split-screen-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup render-split-screen-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+namespace cubos::engine
+{
+    /// @defgroup render-split-screen-plugin Splitscreen
+    /// @ingroup render-plugins
+    /// @brief Adjusts the viewport in @ref DrawsTo relations to achieve a splitscreen layout.
+    ///
+    /// ## Dependencies
+    /// - @ref render-target-plugin
+    /// - @ref render-camera-plugin
+    /// - @ref transform-plugin
+
+    /// @brief Tags the system which adjusts the viewports.
+    /// @ingroup render-split-screen-plugin
+    CUBOS_ENGINE_API extern Tag splitScreenTag;
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b CUBOS. main class
+    /// @ingroup render-split-screen-plugin
+    CUBOS_ENGINE_API void splitScreenPlugin(Cubos& cubos);
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/split_screen/split_screen.hpp
+++ b/engine/include/cubos/engine/render/split_screen/split_screen.hpp
@@ -1,0 +1,19 @@
+/// @file
+/// @brief Component @ref cubos::engine::SplitScreen.
+/// @ingroup render-split-screen-plugin
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which enables splitscreen in a render target.
+    /// @ingroup render-split-screen-plugin
+    struct CUBOS_ENGINE_API SplitScreen
+    {
+        CUBOS_REFLECT;
+    };
+} // namespace cubos::engine

--- a/engine/samples/render/assets/main.cubos
+++ b/engine/samples/render/assets/main.cubos
@@ -9,7 +9,8 @@
             "cubos::engine::GBuffer": {},
             "cubos::engine::GBufferRasterizer": {},
             "cubos::engine::SSAO": {},
-            "cubos::engine::DeferredShading": {}
+            "cubos::engine::DeferredShading": {},
+            "cubos::engine::SplitScreen": {}
         },
         "camera": {
             "cubos::engine::PerspectiveCamera": {},
@@ -17,6 +18,24 @@
             "cubos::engine::Position": {
                 "x": 0,
                 "y": 0,
+                "z": 0
+            }
+        },
+        "camera2": {
+            "cubos::engine::PerspectiveCamera": {},
+            "cubos::engine::DrawsTo@render-target": {},
+            "cubos::engine::Position": {
+                "x": 3,
+                "y": 5,
+                "z": 0
+            }
+        },
+        "camera3": {
+            "cubos::engine::PerspectiveCamera": {},
+            "cubos::engine::DrawsTo@render-target": {},
+            "cubos::engine::Position": {
+                "x": -3,
+                "y": -5,
                 "z": 0
             }
         },

--- a/engine/samples/render/main.cpp
+++ b/engine/samples/render/main.cpp
@@ -12,6 +12,7 @@
 #include <cubos/engine/render/mesh/plugin.hpp>
 #include <cubos/engine/render/picker/plugin.hpp>
 #include <cubos/engine/render/shader/plugin.hpp>
+#include <cubos/engine/render/split_screen/plugin.hpp>
 #include <cubos/engine/render/ssao/plugin.hpp>
 #include <cubos/engine/render/target/plugin.hpp>
 #include <cubos/engine/render/tone_mapping/plugin.hpp>
@@ -52,6 +53,7 @@ int main()
     cubos.plugin(ssaoPlugin);
     cubos.plugin(deferredShadingPlugin);
     cubos.plugin(toneMappingPlugin);
+    cubos.plugin(splitScreenPlugin);
     /// [Adding the plugins]
 
     cubos.plugin(scenePlugin);

--- a/engine/src/render/camera/draws_to.cpp
+++ b/engine/src/render/camera/draws_to.cpp
@@ -1,8 +1,12 @@
 #include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
 
 #include <cubos/engine/render/camera/draws_to.hpp>
 
 CUBOS_REFLECT_IMPL(cubos::engine::DrawsTo)
 {
-    return core::ecs::TypeBuilder<DrawsTo>("cubos::engine::DrawsTo").build();
+    return core::ecs::TypeBuilder<DrawsTo>("cubos::engine::DrawsTo")
+        .withField("viewportOffset", &DrawsTo::viewportOffset)
+        .withField("viewportSize", &DrawsTo::viewportSize)
+        .build();
 }

--- a/engine/src/render/split_screen/plugin.cpp
+++ b/engine/src/render/split_screen/plugin.cpp
@@ -1,0 +1,109 @@
+#include <glm/vec2.hpp>
+
+#include <cubos/engine/render/camera/draws_to.hpp>
+#include <cubos/engine/render/camera/perspective_camera.hpp>
+#include <cubos/engine/render/camera/plugin.hpp>
+#include <cubos/engine/render/split_screen/plugin.hpp>
+#include <cubos/engine/render/split_screen/split_screen.hpp>
+#include <cubos/engine/render/target/plugin.hpp>
+#include <cubos/engine/render/target/target.hpp>
+#include <cubos/engine/transform/local_to_world.hpp>
+#include <cubos/engine/transform/plugin.hpp>
+
+using namespace cubos::engine;
+
+CUBOS_DEFINE_TAG(cubos::engine::splitScreenTag);
+
+/// @brief Splits the viewport recursively for the given cameras.
+/// @param position Viewport position.
+/// @param size Viewport size.
+/// @param count How many cameras need to be fitted in to the given viewport.
+/// @param activeCameras Output array where the viewports will be set.
+static void setViewportCameras(glm::ivec2 position, glm::ivec2 size, int count,
+                               std::vector<glm::ivec2>::iterator positions, std::vector<glm::ivec2>::iterator sizes)
+{
+    if (count == 1)
+    {
+        positions[0] = position;
+        sizes[0] = size;
+    }
+    else if (count >= 2)
+    {
+        glm::ivec2 splitSize;
+        glm::ivec2 splitOffset;
+
+        // Split along the largest axis.
+        if (size.x > size.y)
+        {
+            splitSize = {size.x / 2, size.y};
+            splitOffset = {size.x / 2, 0};
+        }
+        else
+        {
+            splitSize = {size.x, size.y / 2};
+            splitOffset = {0, size.y / 2};
+        }
+
+        setViewportCameras(position, splitSize, count / 2, positions, sizes);
+        setViewportCameras(position + splitOffset, splitSize, (count + 1) / 2, positions + (count / 2),
+                           sizes + (count / 2));
+    }
+}
+
+void cubos::engine::splitScreenPlugin(Cubos& cubos)
+{
+    cubos.depends(renderTargetPlugin);
+    cubos.depends(cameraPlugin);
+    cubos.depends(transformPlugin);
+
+    cubos.component<SplitScreen>();
+
+    cubos.tag(splitScreenTag).after(resizeRenderTargetTag);
+
+    cubos.system("split screen for each DrawsTo relation")
+        .tagged(splitScreenTag)
+        .call(
+            [](Query<Entity, const RenderTarget&> targets,
+               Query<const LocalToWorld&, const PerspectiveCamera&, DrawsTo&, const SplitScreen&> perspectiveCameras) {
+                for (auto [targetEnt, target] : targets)
+                {
+                    int cameraCount = 0;
+
+                    // Find the cameras that draw to the target.
+                    for (auto [localToWorld, camera, drawsTo, splitScreen] : perspectiveCameras.pin(1, targetEnt))
+                    {
+                        // Ignore unused argument warnings
+                        (void)splitScreen;
+
+                        if (!camera.active)
+                        {
+                            continue;
+                        }
+
+                        cameraCount += 1;
+                    }
+
+                    std::vector<glm::ivec2> positions(static_cast<unsigned long>(cameraCount));
+                    std::vector<glm::ivec2> sizes(static_cast<unsigned long>(cameraCount));
+
+                    setViewportCameras({0, 0}, target.size, cameraCount, positions.begin(), sizes.begin());
+
+                    unsigned long i = 0;
+                    for (auto [localToWorld, camera, drawsTo, splitScreen] : perspectiveCameras.pin(1, targetEnt))
+                    {
+                        // Ignore unused argument warnings
+                        (void)splitScreen;
+
+                        if (!camera.active)
+                        {
+                            continue;
+                        }
+
+                        drawsTo.viewportOffset =
+                            static_cast<glm::vec2>(positions[i]) / static_cast<glm::vec2>(target.size);
+                        drawsTo.viewportSize = static_cast<glm::vec2>(sizes[i]) / static_cast<glm::vec2>(target.size);
+                        i++;
+                    }
+                }
+            });
+}

--- a/engine/src/render/split_screen/split_screen.cpp
+++ b/engine/src/render/split_screen/split_screen.cpp
@@ -1,0 +1,8 @@
+#include <cubos/core/ecs/reflection.hpp>
+
+#include <cubos/engine/render/split_screen/split_screen.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::SplitScreen)
+{
+    return core::ecs::TypeBuilder<SplitScreen>("cubos::engine::SplitScreen").build();
+}


### PR DESCRIPTION
# Description

Ports the splitscreen plugin to the new renderer. For each `DrawsTo` relation with a target that has a `SplitScreen` component, the plugin sets the viewport in the relation. Plugins which draw to the target should use this viewport.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [x] Write new samples.
- [x] Add entry to the changelog's unreleased section.
