### PR TITLE
Implement file logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - UI canvas, elements, and color rects. (#1116, **@DiogoMendonc-a**)
+- Implemented file-based logging (#1154, **@roby2014**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -319,6 +319,18 @@ namespace cubos::core
         /// @return Log level.
         static Level level();
 
+        /// @brief Sets a file path where logs will be saved.
+        /// @note Previous logs are also dumped to the file.
+        /// @param filePath Path to file in the virtual file system.
+        /// @return Whether the file could be opened for logging.
+        static bool logToFile(const std::string& filePath);
+
+        /// @brief Mounts a standard archive on the `/logs/` directory, and calls `logToFile` to a timestamped log file
+        /// on that directory.
+        /// @note Previous logs are also dumped to the file.
+        /// @return Whether the file could be mounted and opened for logging.
+        static bool logToFile();
+
         /// @brief Creates a new entry in the logs, as long as the log level is high enough.
         /// @param level Log level.
         /// @param location Code location.

--- a/core/samples/logging/main.cpp
+++ b/core/samples/logging/main.cpp
@@ -21,6 +21,10 @@ int main()
     cubos::core::Logger::level(cubos::core::Logger::Level::Trace);
     /// [Set logging level]
 
+    /// [Log to file]
+    cubos::core::Logger::logToFile();
+    /// [Log to file]
+
     /// [Logging macros]
     CUBOS_TRACE("Trace message");
     CUBOS_DEBUG("Debug message");
@@ -29,6 +33,10 @@ int main()
     CUBOS_ERROR("Error message");
     CUBOS_CRITICAL("Critical message");
     /// [Logging macros]
+
+    /// [Set logging file]
+    cubos::core::Logger::logToFile("/logs/sample_logs.txt");
+    /// [Set logging file]
 
     /// [Logging macros with arguments]
     CUBOS_INFO("An integer: {}", 1);

--- a/core/samples/logging/page.md
+++ b/core/samples/logging/page.md
@@ -19,6 +19,53 @@ this sample, to demonstrate @ref CUBOS_TRACE, we set it to @ref cubos::core::Log
 
 @snippet logging/main.cpp Set logging level
 
+The logger also supports logging to a file, which will by default be named to `cubos_<timestamp>.log`.
+
+@snippet logging/main.cpp Log to file
+
+@note The logger will by default store logs inside `/logs`.
+
+Or, if you want, you can set the file manually:
+
+@snippet logging/main.cpp Set logging file
+
+@note The logger will **always** dump previous logs to the file.
+
+```sh
+$ cat /home/cubos/build/logs/cubos_15:25:30.191.log
+[15:25:30.192] [file.cpp:124 mount] info: Mounted archive at ""/"logs"
+[15:25:30.192] [file.cpp:322 create] trace: Created "file" "/logs/cubos_15:25:30.191"
+[15:25:30.192] [main.cpp:29 main] trace: Trace message
+[15:25:30.192] [main.cpp:30 main] debug: Debug message
+[15:25:30.192] [main.cpp:31 main] info: Info message
+[15:25:30.192] [main.cpp:32 main] warn: Warning message
+[15:25:30.193] [main.cpp:33 main] error: Error message
+[15:25:30.193] [main.cpp:34 main] critical: Critical message
+[15:25:30.193] [file.cpp:85 mount] error: Could not mount archive at "/logs"/"": "/logs" is already part of an archive
+[15:25:30.193] [main.cpp:42 main] info: An integer: 1
+[15:25:30.193] [main.cpp:43 main] info: A glm::vec3: (x: 0.0000, y: 1.0000, z: 2.0000)
+[15:25:30.194] [main.cpp:44 main] info: An std::unordered_map: {2: "two", 1: "one"}
+[15:25:30.194] [log.cpp:248 streamFormat] warn: You tried to print a type ("unnamed102322537939356") which doesn't implement reflection. Did you forget to include its reflection definition?
+[15:25:30.194] [main.cpp:45 main] info: A type without reflection: (no reflection)
+```
+
+```sh
+$ cat /home/cubos/build/logs/sample_logs.txt 
+[15:23:03.737] [file.cpp:124 mount] info: Mounted archive at ""/"logs"
+[15:23:03.737] [main.cpp:29 main] trace: Trace message
+[15:23:03.737] [main.cpp:30 main] debug: Debug message
+[15:23:03.737] [main.cpp:31 main] info: Info message
+[15:23:03.737] [main.cpp:32 main] warn: Warning message
+[15:23:03.737] [main.cpp:33 main] error: Error message
+[15:23:03.738] [main.cpp:34 main] critical: Critical message
+[15:23:03.738] [main.cpp:38 main] info: An integer: 1
+[15:23:03.738] [main.cpp:39 main] info: A glm::vec3: (x: 0.0000, y: 1.0000, z: 2.0000)
+[15:23:03.738] [main.cpp:40 main] info: An std::unordered_map: {2: "two", 1: "one"}
+[15:23:03.738] [log.cpp:248 streamFormat] warn: You tried to print a type ("unnamed108664291041692") which doesn't implement reflection. Did you forget to include its reflection definition?
+[15:23:03.738] [main.cpp:41 main] info: A type without reflection: (no reflection)
+t reflection: (no reflection)
+```
+
 @note By default, on debug builds all logging calls are compiled, while on release builds only
 messages with severity level @ref CUBOS_LOG_LEVEL_INFO or higher are compiled. This can be changed
 by defining @ref CUBOS_LOG_LEVEL to the desired level.

--- a/core/src/ecs/system/tag.cpp
+++ b/core/src/ecs/system/tag.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+
 #include <cubos/core/ecs/system/tag.hpp>
 
 using cubos::core::ecs::Tag;


### PR DESCRIPTION
# Description

The implementation is: when logging (with cubos_debug, etc..), if the file was set, it also prints to the file stream.
this means: data logged before setting the file, wont be logged

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [x] Write new samples.
- [x] Add entry to the changelog's unreleased section.
