### PR TITLE
feat(ui): draw ui through commands

### DIFF
--- a/core/include/cubos/core/ecs/query/opt.hpp
+++ b/core/include/cubos/core/ecs/query/opt.hpp
@@ -197,7 +197,7 @@ CUBOS_REFLECT_TEMPLATE_IMPL((typename T), (cubos::core::ecs::Opt<T>))
     using namespace cubos::core::reflection;
     using cubos::core::ecs::Opt;
 
-    return Type::create("cubos::core::ecs::Opt<" + reflect<T>().name() + ">")
+    return reflection::Type::create("cubos::core::ecs::Opt<" + reflect<T>().name() + ">")
         .with(ConstructibleTrait::typed<Opt<T>>().withDefaultConstructor().withCopyConstructor().build())
         .with(NullableTrait{[](const void* obj) -> bool { return static_cast<const Opt<T>*>(obj)->contains(); },
                             [](void* obj) { static_cast<Opt<T>*>(obj)->reset(); }});

--- a/docs/pages/3_examples/2_engine/main.md
+++ b/docs/pages/3_examples/2_engine/main.md
@@ -9,6 +9,7 @@ multiple plugins of the engine:
 - @subpage examples-engine-settings - @copybrief examples-engine-settings
 - @subpage examples-engine-renderer - @copybrief examples-engine-renderer
 - @subpage examples-engine-gizmos - @copybrief examples-engine-gizmos
+- @subpage examples-engine-ui - @copybrief examples-engine-ui
 - @subpage examples-engine-scene - @copybrief examples-engine-scene
 - @subpage examples-engine-input - @copybrief examples-engine-input
 - @subpage examples-engine-assets - @copybrief examples-engine-assets

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -87,6 +87,7 @@ set(CUBOS_ENGINE_SOURCE
 
 	"src/ui/canvas/plugin.cpp"
 	"src/ui/canvas/canvas.cpp"
+	"src/ui/canvas/draw_list.cpp"
 	"src/ui/canvas/element.cpp"
 	"src/ui/canvas/vertical_stretch.cpp"
 	"src/ui/canvas/horizontal_stretch.cpp"

--- a/engine/assets/ui/color_rect.fs
+++ b/engine/assets/ui/color_rect.fs
@@ -1,6 +1,13 @@
 #version 330 core
 
-uniform vec4 color;
+layout(std140) uniform PerElement
+{
+    vec2 xRange;
+    vec2 yRange;
+    vec4 color;
+    int depth;
+};
+
 out vec4 out_color;
 
 void main()

--- a/engine/assets/ui/element.vs
+++ b/engine/assets/ui/element.vs
@@ -2,10 +2,11 @@
 
 in vec3 position;
 
-uniform PerElement
+layout(std140) uniform PerElement
 {
     vec2 xRange;
     vec2 yRange;
+    vec4 color;
     int depth;
 };
 

--- a/engine/include/cubos/engine/ui/canvas/draw_list.hpp
+++ b/engine/include/cubos/engine/ui/canvas/draw_list.hpp
@@ -1,0 +1,142 @@
+/// @file
+/// @brief Class @ref cubos::engine::UIDrawList.
+/// @ingroup ui-canvas-plugin
+
+#pragma once
+#include <vector>
+
+#include <cubos/core/gl/render_device.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Holds a collections of draw commands and their data.
+    /// @note See the @ref ui-canvas-plugin documentation page for more information.
+    /// @ingroup ui-canvas-plugin
+    class CUBOS_ENGINE_API UIDrawList final
+    {
+    public:
+        /// @brief Describes a UI draw call type.
+        /// @ingroup ui-canvas-plugin
+        struct CUBOS_ENGINE_API Type
+        {
+            static constexpr int MaxTextures = 4;
+
+            cubos::core::gl::ShaderPipeline pipeline; ///< Handle to shader pipeline.
+            cubos::core::gl::ConstantBuffer
+                constantBuffer; ///< Handle to the constant buffer to hold the per element data.
+            cubos::core::gl::ShaderBindingPoint constantBufferBindingPoint; ///< Binding point of the element data.
+            size_t perElementSize; ///< Size of the struct holding the element data.
+            cubos::core::gl::ShaderBindingPoint texBindingPoint[MaxTextures]; ///< Textures binding points.
+
+            /// @brief Constructs.
+            Type();
+        };
+
+        /// @brief Describes a UI draw instruction.
+        /// @ingroup ui-canvas-plugin
+        struct CUBOS_ENGINE_API Command
+        {
+            cubos::core::gl::VertexArray vertexArray;                    ///< Vertex array handle.
+            size_t vertexOffset;                                         ///< Index of the first vertex to be drawn.
+            size_t vertexCount;                                          ///< Number of vertexes to draw.
+            cubos::core::gl::Sampler samplers[Type::MaxTextures] = {};   ///< Samplers.
+            cubos::core::gl::Texture2D textures[Type::MaxTextures] = {}; ///< Textures.
+        };
+
+        /// @brief Describes a draw commands and how it fits into the draw list carrying it.
+        /// @ingroup ui-canvas-plugin
+        struct CUBOS_ENGINE_API Entry
+        {
+            /// @brief Constructs.
+            /// @param commandType Command type.
+            explicit Entry(const Type& commandType);
+
+            /// @brief Constructs.
+            /// @param commandType Command type.
+            /// @param drawCommand UI draw command.
+            /// @param dataOffset Position of the command data in the draw list.
+            Entry(const Type& commandType, Command drawCommand, size_t dataOffset);
+
+            const Type& type; ///< Command type.
+            Command command;  ///< UI draw command.
+            size_t offset;    ///< Position of the command data in the draw list.
+        };
+
+        /// @brief Builds an Entry.
+        /// @ingroup ui-canvas-plugin
+        class CUBOS_ENGINE_API EntryBuilder
+        {
+        public:
+            /// @brief Constructs builder with required data.
+            /// @param entry Reference to the associated entry.
+            EntryBuilder(Entry& entry);
+
+            /// @brief Adds a texture to the entry.
+            /// @param texIndex Index of the texture to add.
+            /// @param texture Texture to add.
+            /// @param sampler Sampler to be used with the texture.
+            /// @returns The builder.
+            EntryBuilder withTexture(int texIndex, cubos::core::gl::Texture2D texture,
+                                     cubos::core::gl::Sampler sampler = nullptr);
+
+        private:
+            Entry& mEntry;
+        };
+
+        /// @brief Constructs a draw list.
+        UIDrawList();
+
+        /// @brief Move constructs.
+        /// @param other Other draw list.
+        UIDrawList(UIDrawList&& other) noexcept;
+
+        /// @brief Copy constructs.
+        /// @param other Other draw list.
+        UIDrawList(const UIDrawList& other) noexcept;
+
+        ~UIDrawList();
+
+        /// @brief Adds entry to the draw list.
+        /// @param type Command type.
+        /// @param command UI draw command.
+        /// @param data Command data.
+        /// @return A builder for the created entry.
+        EntryBuilder push(const Type& type, const Command& command, const void* data);
+
+        /// @brief Creates a new entry in the draw list.
+        /// @param type Command type.
+        /// @param vertexArray Vertex array handle.
+        /// @param vertexOffset Index of the first vertex to be drawn.
+        /// @param vertexCount Number of vertexes to draw.
+        /// @param data Command data.
+        /// @return A builder for the created entry.
+        EntryBuilder push(const Type& type, core::gl::VertexArray vertexArray, size_t vertexOffset, size_t vertexCount,
+                          const void* data);
+
+        /// @brief Empties draw list.
+        void clear();
+
+        /// @brief Gets list size.
+        /// @return Number of elements in the list.
+        std::size_t size() const;
+
+        /// @brief Gets an entry from the list.
+        /// @param i Entry index.
+        /// @return A list entry.
+        const Entry& entry(std::size_t i) const;
+
+        /// @brief Gets the data of an entry.
+        /// @param i Entry index.
+        /// @return A pointer to the entry's data.
+        const void* data(std::size_t i) const;
+
+    private:
+        std::vector<Entry> mEntries; ///< List holding the draw commands of this element and all its children.
+
+        void* mData;                 ///< Buffer holding the data for all the draw commands.
+        size_t mDataCapacity = 1024; ///< How much data the data buffer can hold.
+        size_t mDataSize = 0;        ///< How much data the data buffer is holding.
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/ui/canvas/element.hpp
+++ b/engine/include/cubos/engine/ui/canvas/element.hpp
@@ -10,6 +10,7 @@
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
+#include <cubos/engine/ui/canvas/draw_list.hpp>
 
 using namespace cubos::core::gl;
 
@@ -20,7 +21,6 @@ namespace cubos::engine
     struct CUBOS_ENGINE_API UIElement
     {
         CUBOS_REFLECT;
-
         glm::vec2 offset = {0.0F, 0.0F}; ///< Offset of the pivot.
         glm::vec2 size = {0.0F, 0.0F};   ///< Size of the element.
         glm::vec2 pivot = {0.5F, 0.5F};  ///< Relative position of the pivot to the element itself.
@@ -28,9 +28,10 @@ namespace cubos::engine
         int layer = 0;                   ///< Rendering order layer.
 
         glm::vec2 position = {0.0F, 0.0F}; ///< Global position of the pivot.
-        glm::mat4 vp = {};                 ///< View matrix provided by the canvas.
 
         int hierarchyDepth = 0; ///< Depth in hierarchy. Used for depth sorting.
+
+        UIDrawList drawList = {}; ///< Draw list holding draw commands from this element.
 
         /// @brief Gets global position of the bottom left corner of the element.
         /// @return Position value in global coordinates.
@@ -39,5 +40,30 @@ namespace cubos::engine
         /// @brief Gets global position of the top right corner of the element.
         /// @return Position value in global coordinates.
         glm::vec2 topRightCorner() const;
+
+        /// @brief Adds new entry to the draw list, with undefined data type.
+        /// @param type Command type.
+        /// @param vertexArray Vertex array handle.
+        /// @param vertexOffset Index of the first vertex to be drawn.
+        /// @param vertexCount Number of vertexes to draw.
+        /// @param data Untyped command data.
+        /// @return A builder for the created entry.
+        UIDrawList::EntryBuilder drawUntyped(const UIDrawList::Type& type, const core::gl::VertexArray& vertexArray,
+                                             size_t vertexOffset, size_t vertexCount, const void* data);
+
+        /// @brief Adds new entry to the draw list, with a defined data type.
+        /// @tparam T Command data type.
+        /// @param type Command type.
+        /// @param vertexArray Vertex array handle.
+        /// @param vertexOffset Index of the first vertex to be drawn.
+        /// @param vertexCount Number of vertexes to draw.
+        /// @param data Typed command data.
+        /// @return A builder for the created entry.
+        template <typename T>
+        UIDrawList::EntryBuilder draw(const UIDrawList::Type& type, const core::gl::VertexArray& vertexArray,
+                                      size_t vertexOffset, size_t vertexCount, const T& data)
+        {
+            return this->drawUntyped(type, vertexArray, vertexOffset, vertexCount, &data);
+        }
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/ui/canvas/plugin.hpp
+++ b/engine/include/cubos/engine/ui/canvas/plugin.hpp
@@ -12,16 +12,32 @@
 namespace cubos::engine
 {
     /// @defgroup ui-canvas-plugin Canvas
-    /// @ingroup engine
-    /// @brief Adds UI canvas and elements.
+    /// @ingroup ui-plugins
+    /// @brief Adds the core UI functionality and rendering logic.
+    ///
+    /// # Architecture
+    ///
+    /// The two main UI components are @ref UIElement and @ref UICanvas.
+    /// For it to work properly, each UIElement must be a child of a UICanvas, or of another UIElement.
+    ///
+    /// Each UIElement generates a list of drawing commands, @ref UIDrawList, that are then pooled together by the
+    /// UICanvas at the root of the hierarchy.
+    ///
+    /// Each entry in a draw list contains a @ref UIDrawList::Type and a @ref UIDrawList::Command. The Type holds
+    /// information that is common for all similar commands, and the Command contains the specifics to that one command.
+    /// Each entry also has a raw data buffer to hold the data the command needs to pass to the shaders.
+    ///
+    /// After aggregating the draw commands, the UICanvas draws them, grouped by type.
+    ///
+    /// Check out @ref examples-engine-ui for the an example of the UI plugin in use.
 
     /// @brief @ref UICanvas components' information is passed to related @ref UIElement components.
     /// @ingroup canvas-target-plugin
-    CUBOS_ENGINE_API extern Tag elementVPUpdateTag;
+    CUBOS_ENGINE_API extern Tag uiCanvasChildrenUpdateTag;
 
     /// @brief The @ref UIElement components are updated with information from their parents.
     /// @ingroup canvas-target-plugin
-    CUBOS_ENGINE_API extern Tag elementPropagateTag;
+    CUBOS_ENGINE_API extern Tag uiElementPropagateTag;
 
     /// @brief Readies canvas for drawing.
     /// @ingroup canvas-target-plugin
@@ -30,6 +46,10 @@ namespace cubos::engine
     /// @brief Systems which draw to canvas should be tagged with this.
     /// @ingroup canvas-target-plugin
     CUBOS_ENGINE_API extern Tag uiDrawTag;
+
+    /// @brief All queued draw commands are collected and executed to the render targets.
+    /// @ingroup canvas-target-plugin
+    CUBOS_ENGINE_API extern Tag uiEndTag;
 
     /// @brief Plugin entry function.
     /// @param cubos @b CUBOS. main class

--- a/engine/include/cubos/engine/ui/color_rect/plugin.hpp
+++ b/engine/include/cubos/engine/ui/color_rect/plugin.hpp
@@ -11,8 +11,8 @@
 
 namespace cubos::engine
 {
-    /// @defgroup ui-color-rect-plugin Canvas
-    /// @ingroup engine
+    /// @defgroup ui-color-rect-plugin Color Rect
+    /// @ingroup ui-plugins
     /// @brief Adds color rectangle elements.
 
     /// @brief Plugin entry function.

--- a/engine/include/cubos/engine/ui/module.dox
+++ b/engine/include/cubos/engine/ui/module.dox
@@ -1,0 +1,9 @@
+/// @dir
+/// @brief @ref ui-plugins module.
+
+namespace cubos::engine
+{
+    /// @defgroup ui-plugins UI
+    /// @ingroup engine
+    /// @brief Provides plugins for graphical user interfaces.
+} // namespace cubos::engine

--- a/engine/samples/ui/main.cpp
+++ b/engine/samples/ui/main.cpp
@@ -43,12 +43,12 @@ int main(int argc, char** argv)
                              .entity();
         commands.relate(elementBg, canvas, ChildOf{});
         /// [Set up Background]
-
         /// [Set up Panel]
-        auto elementPanel = commands.create()
-                                .add(UIElement{{0, -50}, {200, 600}, {1, 0.5F}, {1, 0.5F}})
-                                .add(UIColorRect{{1, 0, 0, 1}})
-                                .entity();
+        auto elementPanel =
+            commands.create()
+                .add(UIElement{.offset = {-50, 0}, .size = {200, 600}, .pivot = {1, 0.5F}, .anchor = {1, 0.5F}})
+                .add(UIColorRect{{1, 0, 0, 1}})
+                .entity();
         commands.relate(elementPanel, elementBg, ChildOf{});
         /// [Set up Panel]
     });

--- a/engine/src/ui/canvas/draw_list.cpp
+++ b/engine/src/ui/canvas/draw_list.cpp
@@ -1,0 +1,125 @@
+#include <cstring>
+#include <utility>
+
+#include <cubos/core/log.hpp>
+
+#include <cubos/engine/ui/canvas/draw_list.hpp>
+
+cubos::engine::UIDrawList::Type::Type()
+{
+    for (auto& i : texBindingPoint)
+    {
+        i = nullptr;
+    }
+}
+
+cubos::engine::UIDrawList::Entry::Entry(const Type& commandType)
+    : type(commandType)
+{
+}
+
+cubos::engine::UIDrawList::Entry::Entry(const Type& commandType, Command drawCommand, size_t dataOffset)
+    : type(commandType)
+    , command(std::move(drawCommand))
+    , offset(dataOffset)
+{
+}
+
+cubos::engine::UIDrawList::EntryBuilder::EntryBuilder(Entry& entry)
+    : mEntry(entry)
+{
+}
+
+cubos::engine::UIDrawList::EntryBuilder cubos::engine::UIDrawList::EntryBuilder::withTexture(
+    int texIndex, cubos::core::gl::Texture2D texture, cubos::core::gl::Sampler sampler)
+{
+    if (texIndex >= Type::MaxTextures)
+    {
+        CUBOS_WARN("Invalid texture index, texture will be dropped");
+        return *this;
+    }
+    mEntry.command.samplers[texIndex] = std::move(sampler);
+    mEntry.command.textures[texIndex] = std::move(texture);
+    return *this;
+}
+
+cubos::engine::UIDrawList::UIDrawList()
+{
+    mData = operator new(sizeof(char) * mDataCapacity);
+}
+
+cubos::engine::UIDrawList::UIDrawList(UIDrawList&& other) noexcept
+    : mEntries(std::move(other.mEntries))
+    , mData(other.mData)
+    , mDataCapacity(other.mDataCapacity)
+    , mDataSize(other.mDataSize)
+{
+    other.mData = nullptr;
+    other.mDataSize = 0;
+    other.mDataCapacity = 0;
+}
+
+cubos::engine::UIDrawList::UIDrawList(const UIDrawList& other) noexcept
+    : mEntries(other.mEntries)
+    , mDataCapacity(other.mDataSize)
+    , mDataSize(other.mDataSize)
+{
+    mData = operator new(sizeof(char) * other.mDataSize);
+    std::memcpy(mData, other.mData, sizeof(char) * other.mDataSize);
+}
+
+cubos::engine::UIDrawList::~UIDrawList()
+{
+    operator delete(mData);
+}
+
+cubos::engine::UIDrawList::EntryBuilder cubos::engine::UIDrawList::push(const Type& type, const Command& command,
+                                                                        const void* data)
+{
+    auto entry = Entry{type, command, mDataSize};
+    entry.offset = mDataSize;
+    mEntries.push_back(entry);
+    if (mDataSize + entry.type.perElementSize > mDataCapacity)
+    {
+        mDataCapacity += entry.type.perElementSize;
+        mDataCapacity *= 2;
+        void* temp = operator new(sizeof(char) * mDataCapacity);
+        std::memcpy(temp, mData, mDataSize);
+        operator delete(mData);
+        mData = temp;
+    }
+    std::memcpy(static_cast<char*>(mData) + mDataSize, data, entry.type.perElementSize);
+    mDataSize += entry.type.perElementSize;
+    return {mEntries[mEntries.size() - 1]};
+}
+
+cubos::engine::UIDrawList::EntryBuilder cubos::engine::UIDrawList::push(const Type& type,
+                                                                        core::gl::VertexArray vertexArray,
+                                                                        size_t vertexOffset, size_t vertexCount,
+                                                                        const void* data)
+{
+    auto command =
+        Command{.vertexArray = std::move(vertexArray), .vertexOffset = vertexOffset, .vertexCount = vertexCount};
+    return push(type, command, data);
+}
+
+void cubos::engine::UIDrawList::clear()
+{
+    mDataSize = 0;
+    mEntries.clear();
+}
+
+std::size_t cubos::engine::UIDrawList::size() const
+{
+    return mEntries.size();
+}
+
+const cubos::engine::UIDrawList::Entry& cubos::engine::UIDrawList::entry(std::size_t i) const
+{
+    return mEntries[i];
+}
+
+const void* cubos::engine::UIDrawList::data(std::size_t i) const
+{
+    return static_cast<void*>(static_cast<char*>(mData) + mEntries[i].offset);
+}

--- a/engine/src/ui/canvas/element.cpp
+++ b/engine/src/ui/canvas/element.cpp
@@ -2,6 +2,7 @@
 #include <cubos/core/reflection/external/glm.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 
+#include <cubos/engine/ui/canvas/draw_list.hpp>
 #include <cubos/engine/ui/canvas/element.hpp>
 
 CUBOS_REFLECT_IMPL(cubos::engine::UIElement)
@@ -23,4 +24,12 @@ glm::vec2 cubos::engine::UIElement::bottomLeftCorner() const
 glm::vec2 cubos::engine::UIElement::topRightCorner() const
 {
     return glm::vec2{position.x + size.x * (1.0F - pivot.x), position.y + size.y * (1.0F - pivot.y)};
+}
+
+cubos::engine::UIDrawList::EntryBuilder cubos::engine::UIElement::drawUntyped(const UIDrawList::Type& type,
+                                                                              const core::gl::VertexArray& vertexArray,
+                                                                              size_t vertexOffset, size_t vertexCount,
+                                                                              const void* data)
+{
+    return drawList.push(type, vertexArray, vertexOffset, vertexCount, data);
 }


### PR DESCRIPTION
# Description

The two main UI components are UIElement and UICanvas.
For it to work properly, each UIElement must be a child of a UICanvas, or of another UIElement.

Each UIElement generates a list of drawing commands, UIDrawList, that are then pooled together by the UICanvas at the root of the hierarchy.

Each entry in a draw list contains a UIDrawList::Type and a UIDrawList::Command. The Type holds information that is common for all similar commands, and the Command contains the specifics to that one command.
Each entry also has a raw data buffer to hold the data the command needs to pass to the shaders.

After aggregating the draw commands, the UICanvas draws them, grouped by type.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section. **No need, this is altering stuff that will be added this version**
