### PR TITLE
Setup file structure and cmake for the core and engine API libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - UI canvas, elements, and color rects. (#1116, **@DiogoMendonc-a**)
+- Implemented file-based logging (#1154, **@roby2014**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ endif ()
 add_subdirectory(core)
 add_subdirectory(tools)
 add_subdirectory(engine)
+add_subdirectory(api)
 
 # Add doxygen documentation
 

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(core)
+add_subdirectory(engine)

--- a/api/core/CMakeLists.txt
+++ b/api/core/CMakeLists.txt
@@ -1,0 +1,29 @@
+option(BUILD_API_CORE_SAMPLES "Build cubos core c api samples" OFF)
+option(BUILD_API_CORE_SHARED "Build cubos core c api as shared library?" ON)
+
+message("# Building core c api samples: " ${BUILD_API_CORE_SAMPLES})
+message("# Building core c api as shared library: " ${BUILD_API_CORE_SHARED})
+
+set(CUBOS_API_CORE_SOURCE
+    "src/api.cpp"
+)
+
+# Create core c api library
+if(BUILD_CORE_SHARED)
+    add_library(cubos-api-core SHARED ${CUBOS_API_CORE_SOURCE})
+    target_compile_definitions(cubos-api-core
+        PRIVATE -DCUBOS_CORE_C_EXPORT
+        PUBLIC -DCUBOS_CORE_C_IMPORT
+    )
+else()
+    add_library(cubos-api-core STATIC ${CUBOS_API_CORE_SOURCE})
+endif()
+
+target_include_directories(cubos-api-core PUBLIC "include")
+target_link_libraries(cubos-api-core PRIVATE cubos-core)
+cubos_common_target_options(cubos-api-core)
+
+# Add core c api samples
+if(BUILD_API_CORE_SAMPLES)
+    add_subdirectory(samples)
+endif()

--- a/api/core/CMakeLists.txt
+++ b/api/core/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CUBOS_API_CORE_SOURCE
 )
 
 # Create core c api library
-if(BUILD_CORE_SHARED)
+if(BUILD_API_CORE_SHARED)
     add_library(cubos-api-core SHARED ${CUBOS_API_CORE_SOURCE})
     target_compile_definitions(cubos-api-core
         PRIVATE -DCUBOS_CORE_C_EXPORT

--- a/api/core/include/cubos/api/core/api.h
+++ b/api/core/include/cubos/api/core/api.h
@@ -1,11 +1,11 @@
 /// @file
 /// @brief Macro @ref CUBOS_CORE_C_API.
-/// @ingroup core
+/// @ingroup core-api
 
 #pragma once
 
 /// @brief Macro used to export and import symbols from the library.
-/// @addtogroup core
+/// @addtogroup core-api
 /// @{
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/api/core/include/cubos/api/core/api.h
+++ b/api/core/include/cubos/api/core/api.h
@@ -1,0 +1,23 @@
+/// @file
+/// @brief Macro @ref CUBOS_CORE_C_API.
+/// @ingroup core
+
+#pragma once
+
+/// @brief Macro used to export and import symbols from the library.
+/// @addtogroup core
+/// @{
+
+#if defined(_WIN32) || defined(_WIN64)
+#if defined(CUBOS_CORE_C_EXPORT)
+#define CUBOS_CORE_C_API __declspec(dllexport)
+#elif defined(CUBOS_CORE_C_IMPORT)
+#define CUBOS_CORE_C_API __declspec(dllimport)
+#else
+#define CUBOS_CORE_C_API
+#endif
+#else
+#define CUBOS_CORE_C_API
+#endif
+
+/// @}

--- a/api/core/include/cubos/api/core/module.dox
+++ b/api/core/include/cubos/api/core/module.dox
@@ -1,0 +1,5 @@
+/// @dir
+/// @brief @ref core-api module.
+
+/// @defgroup core-api
+/// @brief C API for the @b Cubos core library.

--- a/api/core/samples/CMakeLists.txt
+++ b/api/core/samples/CMakeLists.txt
@@ -1,7 +1,6 @@
 # api/core/samples/CMakeLists.txt
 # Core C API samples build configuration
 
-
 # Macro used to reduce the boilerplate code
 macro(make_sample)
     set(oneValueArgs DIR)

--- a/api/core/samples/CMakeLists.txt
+++ b/api/core/samples/CMakeLists.txt
@@ -1,0 +1,27 @@
+# api/core/samples/CMakeLists.txt
+# Core C API samples build configuration
+
+
+# Macro used to reduce the boilerplate code
+macro(make_sample)
+    set(oneValueArgs DIR)
+    set(multiValueArgs SOURCES)
+    cmake_parse_arguments(MAKE_SAMPLE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Get the target name from the sample directory path
+    message(STATUS "Adding sample: ${MAKE_SAMPLE_DIR}")
+    string(REPLACE "_" "-" target "${MAKE_SAMPLE_DIR}")
+    string(REPLACE "/" "." target "${MAKE_SAMPLE_DIR}")
+    set(target "api-core-sample.${target}")
+
+    # Get the source files
+    set(sources "${CMAKE_CURRENT_SOURCE_DIR}/${MAKE_SAMPLE_DIR}/main.cpp")
+    foreach(source IN LISTS MAKE_SAMPLE_SOURCES)
+        list(APPEND sources "${CMAKE_CURRENT_SOURCE_DIR}/${MAKE_SAMPLE_DIR}/${source}")
+    endforeach()
+
+    # Add the sample target
+    add_executable(${target} ${sources})
+    target_link_libraries(${target} cubos-api-core)
+    cubos_common_target_options(${target})
+endmacro()

--- a/api/core/src/api.cpp
+++ b/api/core/src/api.cpp
@@ -1,0 +1,1 @@
+#include <cubos/api/core/api.h>

--- a/api/engine/CMakeLists.txt
+++ b/api/engine/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(CUBOS_API_ENGINE_SOURCE
+    "src/api.cpp"
+)
+
+
+option(BUILD_API_ENGINE_SAMPLES "Build cubos engine c api samples" OFF)
+option(BUILD_API_ENGINE_SHARED "Build cubos engine c api as shared library?" ON)
+
+message("# Building engine c api samples: " ${BUILD_API_ENGINE_SAMPLES})
+message("# Building engine c api as shared library: " ${BUILD_API_ENGINE_SHARED})
+
+# Create core c api library
+if(BUILD_CORE_SHARED)
+    add_library(cubos-api-engine SHARED ${CUBOS_API_ENGINE_SOURCE})
+    target_compile_definitions(cubos-api-engine
+        PRIVATE -DCUBOS_ENGINE_C_EXPORT
+        PUBLIC -DCUBOS_ENGINE_C_IMPORT
+    )
+else()
+    add_library(cubos-api-engine STATIC ${CUBOS_API_ENGINE_SOURCE})
+endif()
+
+target_include_directories(cubos-api-engine PUBLIC "include")
+target_link_libraries(cubos-api-engine PRIVATE cubos-engine)
+cubos_common_target_options(cubos-api-engine)
+
+# Add core c api samples
+if(BUILD_API_ENGINE_SAMPLES)
+    add_subdirectory(samples)
+endif()

--- a/api/engine/CMakeLists.txt
+++ b/api/engine/CMakeLists.txt
@@ -2,7 +2,6 @@ set(CUBOS_API_ENGINE_SOURCE
     "src/api.cpp"
 )
 
-
 option(BUILD_API_ENGINE_SAMPLES "Build cubos engine c api samples" OFF)
 option(BUILD_API_ENGINE_SHARED "Build cubos engine c api as shared library?" ON)
 

--- a/api/engine/CMakeLists.txt
+++ b/api/engine/CMakeLists.txt
@@ -8,8 +8,8 @@ option(BUILD_API_ENGINE_SHARED "Build cubos engine c api as shared library?" ON)
 message("# Building engine c api samples: " ${BUILD_API_ENGINE_SAMPLES})
 message("# Building engine c api as shared library: " ${BUILD_API_ENGINE_SHARED})
 
-# Create core c api library
-if(BUILD_CORE_SHARED)
+# Create engine c api library
+if(BUILD_API_ENGINE_SHARED)
     add_library(cubos-api-engine SHARED ${CUBOS_API_ENGINE_SOURCE})
     target_compile_definitions(cubos-api-engine
         PRIVATE -DCUBOS_ENGINE_C_EXPORT

--- a/api/engine/include/cubos/api/engine/api.h
+++ b/api/engine/include/cubos/api/engine/api.h
@@ -1,0 +1,23 @@
+/// @file
+/// @brief Macro @ref CUBOS_ENGINE_C_API.
+/// @ingroup engine
+
+#pragma once
+
+/// @brief Macro used to export and import symbols from the library.
+/// @addtogroup engine
+/// @{
+
+#if defined(_WIN32) || defined(_WIN64)
+#if defined(CUBOS_ENGINE_C_EXPORT)
+#define CUBOS_ENGINE_C_API __declspec(dllexport)
+#elif defined(CUBOS_ENGINE_C_IMPORT)
+#define CUBOS_ENGINE_C_API __declspec(dllimport)
+#else
+#define CUBOS_ENGINE_C_API
+#endif
+#else
+#define CUBOS_ENGINE_C_API
+#endif
+
+/// @}

--- a/api/engine/include/cubos/api/engine/api.h
+++ b/api/engine/include/cubos/api/engine/api.h
@@ -1,11 +1,11 @@
 /// @file
 /// @brief Macro @ref CUBOS_ENGINE_C_API.
-/// @ingroup engine
+/// @ingroup engine-api
 
 #pragma once
 
 /// @brief Macro used to export and import symbols from the library.
-/// @addtogroup engine
+/// @addtogroup engine-api
 /// @{
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/api/engine/include/cubos/api/engine/module.dox
+++ b/api/engine/include/cubos/api/engine/module.dox
@@ -1,5 +1,5 @@
 /// @dir
 /// @brief @ref engine-api module.
 
-/// @defgroup engine-api
+/// @defgroup engine-api Engine API
 /// @brief C API for the @b Cubos engine library.

--- a/api/engine/include/cubos/api/engine/module.dox
+++ b/api/engine/include/cubos/api/engine/module.dox
@@ -1,0 +1,5 @@
+/// @dir
+/// @brief @ref engine-api module.
+
+/// @defgroup engine-api
+/// @brief C API for the @b Cubos engine library.

--- a/api/engine/samples/CMakeLists.txt
+++ b/api/engine/samples/CMakeLists.txt
@@ -1,0 +1,27 @@
+# api/engine/samples/CMakeLists.txt
+# Engine C API samples build configuration
+
+
+# Macro used to reduce the boilerplate code
+macro(make_sample)
+    set(oneValueArgs DIR)
+    set(multiValueArgs SOURCES)
+    cmake_parse_arguments(MAKE_SAMPLE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Get the target name from the sample directory path
+    message(STATUS "Adding sample: ${MAKE_SAMPLE_DIR}")
+    string(REPLACE "_" "-" target "${MAKE_SAMPLE_DIR}")
+    string(REPLACE "/" "." target "${MAKE_SAMPLE_DIR}")
+    set(target "api-engine-sample.${target}")
+
+    # Get the source files
+    set(sources "${CMAKE_CURRENT_SOURCE_DIR}/${MAKE_SAMPLE_DIR}/main.cpp")
+    foreach(source IN LISTS MAKE_SAMPLE_SOURCES)
+        list(APPEND sources "${CMAKE_CURRENT_SOURCE_DIR}/${MAKE_SAMPLE_DIR}/${source}")
+    endforeach()
+
+    # Add the sample target
+    add_executable(${target} ${sources})
+    target_link_libraries(${target} cubos-api-engine)
+    cubos_common_target_options(${target})
+endmacro()

--- a/api/engine/src/api.cpp
+++ b/api/engine/src/api.cpp
@@ -1,0 +1,1 @@
+#include <cubos/api/engine/api.h>

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -319,6 +319,18 @@ namespace cubos::core
         /// @return Log level.
         static Level level();
 
+        /// @brief Sets a file path where logs will be saved.
+        /// @note Previous logs are also dumped to the file.
+        /// @param filePath Path to file in the virtual file system.
+        /// @return Whether the file could be opened for logging.
+        static bool logToFile(const std::string& filePath);
+
+        /// @brief Mounts a standard archive on the `/logs/` directory, and calls `logToFile` to a timestamped log file
+        /// on that directory.
+        /// @note Previous logs are also dumped to the file.
+        /// @return Whether the file could be mounted and opened for logging.
+        static bool logToFile();
+
         /// @brief Creates a new entry in the logs, as long as the log level is high enough.
         /// @param level Log level.
         /// @param location Code location.

--- a/core/samples/logging/main.cpp
+++ b/core/samples/logging/main.cpp
@@ -21,6 +21,10 @@ int main()
     cubos::core::Logger::level(cubos::core::Logger::Level::Trace);
     /// [Set logging level]
 
+    /// [Log to file]
+    cubos::core::Logger::logToFile();
+    /// [Log to file]
+
     /// [Logging macros]
     CUBOS_TRACE("Trace message");
     CUBOS_DEBUG("Debug message");
@@ -29,6 +33,10 @@ int main()
     CUBOS_ERROR("Error message");
     CUBOS_CRITICAL("Critical message");
     /// [Logging macros]
+
+    /// [Set logging file]
+    cubos::core::Logger::logToFile("/logs/sample_logs.txt");
+    /// [Set logging file]
 
     /// [Logging macros with arguments]
     CUBOS_INFO("An integer: {}", 1);

--- a/core/samples/logging/page.md
+++ b/core/samples/logging/page.md
@@ -19,6 +19,53 @@ this sample, to demonstrate @ref CUBOS_TRACE, we set it to @ref cubos::core::Log
 
 @snippet logging/main.cpp Set logging level
 
+The logger also supports logging to a file, which will by default be named to `cubos_<timestamp>.log`.
+
+@snippet logging/main.cpp Log to file
+
+@note The logger will by default store logs inside `/logs`.
+
+Or, if you want, you can set the file manually:
+
+@snippet logging/main.cpp Set logging file
+
+@note The logger will **always** dump previous logs to the file.
+
+```sh
+$ cat /home/cubos/build/logs/cubos_15:25:30.191.log
+[15:25:30.192] [file.cpp:124 mount] info: Mounted archive at ""/"logs"
+[15:25:30.192] [file.cpp:322 create] trace: Created "file" "/logs/cubos_15:25:30.191"
+[15:25:30.192] [main.cpp:29 main] trace: Trace message
+[15:25:30.192] [main.cpp:30 main] debug: Debug message
+[15:25:30.192] [main.cpp:31 main] info: Info message
+[15:25:30.192] [main.cpp:32 main] warn: Warning message
+[15:25:30.193] [main.cpp:33 main] error: Error message
+[15:25:30.193] [main.cpp:34 main] critical: Critical message
+[15:25:30.193] [file.cpp:85 mount] error: Could not mount archive at "/logs"/"": "/logs" is already part of an archive
+[15:25:30.193] [main.cpp:42 main] info: An integer: 1
+[15:25:30.193] [main.cpp:43 main] info: A glm::vec3: (x: 0.0000, y: 1.0000, z: 2.0000)
+[15:25:30.194] [main.cpp:44 main] info: An std::unordered_map: {2: "two", 1: "one"}
+[15:25:30.194] [log.cpp:248 streamFormat] warn: You tried to print a type ("unnamed102322537939356") which doesn't implement reflection. Did you forget to include its reflection definition?
+[15:25:30.194] [main.cpp:45 main] info: A type without reflection: (no reflection)
+```
+
+```sh
+$ cat /home/cubos/build/logs/sample_logs.txt 
+[15:23:03.737] [file.cpp:124 mount] info: Mounted archive at ""/"logs"
+[15:23:03.737] [main.cpp:29 main] trace: Trace message
+[15:23:03.737] [main.cpp:30 main] debug: Debug message
+[15:23:03.737] [main.cpp:31 main] info: Info message
+[15:23:03.737] [main.cpp:32 main] warn: Warning message
+[15:23:03.737] [main.cpp:33 main] error: Error message
+[15:23:03.738] [main.cpp:34 main] critical: Critical message
+[15:23:03.738] [main.cpp:38 main] info: An integer: 1
+[15:23:03.738] [main.cpp:39 main] info: A glm::vec3: (x: 0.0000, y: 1.0000, z: 2.0000)
+[15:23:03.738] [main.cpp:40 main] info: An std::unordered_map: {2: "two", 1: "one"}
+[15:23:03.738] [log.cpp:248 streamFormat] warn: You tried to print a type ("unnamed108664291041692") which doesn't implement reflection. Did you forget to include its reflection definition?
+[15:23:03.738] [main.cpp:41 main] info: A type without reflection: (no reflection)
+t reflection: (no reflection)
+```
+
 @note By default, on debug builds all logging calls are compiled, while on release builds only
 messages with severity level @ref CUBOS_LOG_LEVEL_INFO or higher are compiled. This can be changed
 by defining @ref CUBOS_LOG_LEVEL to the desired level.

--- a/core/src/ecs/system/tag.cpp
+++ b/core/src/ecs/system/tag.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+
 #include <cubos/core/ecs/system/tag.hpp>
 
 using cubos::core::ecs::Tag;

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -11,10 +11,17 @@ INPUT = @DOXYGEN_PROJECT_ROOT@/docs/pages \
         @DOXYGEN_PROJECT_ROOT@/engine/include \
         @DOXYGEN_PROJECT_ROOT@/engine/samples \
         @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/include \
-        @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples
+        @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples \
+        @DOXYGEN_PROJECT_ROOT@/api/core/include \
+        @DOXYGEN_PROJECT_ROOT@/api/core/samples \
+        @DOXYGEN_PROJECT_ROOT@/api/engine/include \
+        @DOXYGEN_PROJECT_ROOT@/api/engine/samples
+
 EXAMPLE_PATH = @DOXYGEN_PROJECT_ROOT@/core/samples \
                @DOXYGEN_PROJECT_ROOT@/engine/samples \
-               @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples
+               @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples \
+               @DOXYGEN_PROJECT_ROOT@/api/core/samples \
+               @DOXYGEN_PROJECT_ROOT@/api/engine/samples
 EXTRACT_ALL = YES
 EXTRACT_PRIVATE = YES
 EXTRACT_PRIV_VIRTUAL = YES
@@ -23,7 +30,9 @@ OUTPUT_DIRECTORY = @DOXYGEN_OUTPUT_DIRECTORY@
 IMAGE_PATH = @DOXYGEN_PROJECT_ROOT@/docs/images \
              @DOXYGEN_PROJECT_ROOT@/core/samples \
              @DOXYGEN_PROJECT_ROOT@/engine/samples \
-             @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples
+             @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples \
+             @DOXYGEN_PROJECT_ROOT@/api/core/samples \
+             @DOXYGEN_PROJECT_ROOT@/api/engine/samples
 
 # Ignore sample source files
 EXCLUDE_PATTERNS = */samples/*.hpp \
@@ -37,6 +46,10 @@ STRIP_FROM_PATH = @DOXYGEN_PROJECT_ROOT@/core/include/cubos \
                   @DOXYGEN_PROJECT_ROOT@/engine/samples \
                   @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/include \
                   @DOXYGEN_PROJECT_ROOT@/tools/tesseratos/samples \
+                  @DOXYGEN_PROJECT_ROOT@/api/core/include \
+                  @DOXYGEN_PROJECT_ROOT@/api/core/samples \
+                  @DOXYGEN_PROJECT_ROOT@/api/engine/include \
+                  @DOXYGEN_PROJECT_ROOT@/api/engine/samples \
                   @DOXYGEN_PROJECT_ROOT@
 
 # We use m.css to generate the html documentation, so we only need XML output


### PR DESCRIPTION
# Description

Creates a new directory `api/` with two projects for the core and engine C API libraries. Both have their own CMakeLists.txt file and a samples directory which will probably be needed later for testing these new libraries.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
