### PR TITLE
Allow importing plugins from shared libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Start and update methods to the Cubos class (#1213, **@RiscadoA**).
 - Reset method to the Cubos class (#1225, **@RiscadoA**).
 - Plugin injection to the Cubos class (#1214, **@RiscadoA**).
+- Utility class used to load plugins from shared libraries (#1035, **@RiscadoA**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -128,6 +128,7 @@ set(CUBOS_CORE_SOURCE
 	"src/ecs/plugin_queue.cpp"
 	"src/ecs/types.cpp"
 	"src/ecs/cubos.cpp"
+	"src/ecs/dynamic.cpp"
 
     "src/geom/box.cpp"
     "src/geom/capsule.cpp"

--- a/core/include/cubos/core/ecs/blueprint.hpp
+++ b/core/include/cubos/core/ecs/blueprint.hpp
@@ -20,6 +20,7 @@ namespace cubos::core::ecs
     /// @param map Map of old entities to new entities.
     /// @param type Value type.
     /// @param value Value.
+    /// @ingroup core-ecs
     CUBOS_CORE_API void convertEntities(const std::unordered_map<Entity, Entity, EntityHash>& map,
                                         const reflection::Type& type, void* value);
 

--- a/core/include/cubos/core/ecs/dynamic.hpp
+++ b/core/include/cubos/core/ecs/dynamic.hpp
@@ -1,0 +1,41 @@
+/// @file
+/// @brief Class @ref cubos::core::ecs::DynamicPlugin.
+/// @ingroup core-ecs
+
+#pragma once
+
+#include <string>
+
+#include <cubos/core/ecs/plugin_queue.hpp>
+
+namespace cubos::core::ecs
+{
+    /// @brief Manages the loading and unloading of a plugin from a shared library.
+    /// @ingroup core-ecs
+    class CUBOS_CORE_API DynamicPlugin
+    {
+    public:
+        ~DynamicPlugin();
+
+        /// @brief Loads the plugin from a shared library with the given name.
+        /// @param name Shared library name.
+        /// @return Whether the plugin was loaded successfully.
+        bool load(const std::string& name);
+
+        /// @brief Unloads the plugin.
+        ///
+        /// Does nothing if the plugin was not loaded.
+        void unload();
+
+        /// @brief Gets the plugin function pointer.
+        ///
+        /// Aborts if the plugin was not loaded.
+        ///
+        /// @return Plugin function pointer.
+        Plugin function() const;
+
+    private:
+        void* mHandle{nullptr};
+        Plugin mPlugin;
+    };
+} // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/name.hpp
+++ b/core/include/cubos/core/ecs/name.hpp
@@ -11,6 +11,7 @@
 namespace cubos::core::ecs
 {
     /// @brief Component which stores the name of an entity.
+    /// @ingroup core-ecs
     struct CUBOS_CORE_API Name
     {
         CUBOS_REFLECT;

--- a/core/include/cubos/core/ecs/plugin_queue.hpp
+++ b/core/include/cubos/core/ecs/plugin_queue.hpp
@@ -14,6 +14,7 @@ namespace cubos::core::ecs
     class Cubos;
 
     /// @brief Function pointer type representing a plugin.
+    /// @ingroup core-ecs
     using Plugin = void (*)(Cubos&);
 
     /// @brief Stores plugin operations to be executed later.

--- a/core/include/cubos/core/ecs/types.hpp
+++ b/core/include/cubos/core/ecs/types.hpp
@@ -14,6 +14,7 @@
 namespace cubos::core::ecs
 {
     /// @brief Identifies a data type registered in the world.
+    /// @ingroup core-ecs
     struct CUBOS_CORE_API DataTypeId
     {
         uint32_t inner; ///< Data type identifier.
@@ -27,12 +28,14 @@ namespace cubos::core::ecs
     };
 
     /// @brief Hash functor for @ref DataTypeId.
+    /// @ingroup core-ecs
     struct CUBOS_CORE_API DataTypeIdHash
     {
         std::size_t operator()(const DataTypeId& id) const;
     };
 
     /// @brief Registry of all data types used in an ECS world.
+    /// @ingroup core-ecs
     class CUBOS_CORE_API Types final
     {
     public:

--- a/core/src/ecs/dynamic.cpp
+++ b/core/src/ecs/dynamic.cpp
@@ -1,0 +1,83 @@
+#include <cubos/core/ecs/dynamic.hpp>
+#include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+using cubos::core::ecs::DynamicPlugin;
+using cubos::core::ecs::Plugin;
+
+DynamicPlugin::~DynamicPlugin()
+{
+    this->unload();
+}
+
+bool DynamicPlugin::load(const std::string& name)
+{
+    CUBOS_ASSERT(mHandle == nullptr, "Plugin already loaded");
+
+    // Load the shared library.
+#ifdef _WIN32
+    mHandle = static_cast<void*>(LoadLibrary(name.c_str()));
+#else
+    mHandle = dlopen(name.c_str(), RTLD_LAZY);
+#endif
+
+    // Check if the shared library was loaded successfully.
+    if (mHandle == nullptr)
+    {
+#ifdef _WIN32
+        CUBOS_ERROR("Failed to load plugin {}: error {}", name, GetLastError());
+#else
+        CUBOS_ERROR("Failed to load plugin {}: {}", name, dlerror());
+#endif
+        return false;
+    }
+
+    // Get entry plugin function in the shared library.
+#ifdef _WIN32
+    mPlugin = reinterpret_cast<Plugin>(GetProcAddress(static_cast<HMODULE>(mHandle), "plugin"));
+#else
+    mPlugin = reinterpret_cast<Plugin>(dlsym(mHandle, "plugin"));
+#endif
+
+    // Check if the plugin function was found.
+    if (mPlugin == nullptr)
+    {
+#ifdef _WIN32
+        CUBOS_ERROR("Failed to get plugin function from {}: error {}", name, GetLastError());
+#else
+        CUBOS_ERROR("Failed to get plugin function from {}: {}", name, dlerror());
+#endif
+
+        this->unload();
+        return false;
+    }
+
+    return true;
+}
+
+void DynamicPlugin::unload()
+{
+    if (mHandle != nullptr)
+    {
+#ifdef _WIN32
+        FreeLibrary(static_cast<HMODULE>(mHandle));
+#else
+        dlclose(mHandle);
+#endif
+
+        mHandle = nullptr;
+    }
+}
+
+Plugin DynamicPlugin::function() const
+{
+    CUBOS_ASSERT(mHandle != nullptr, "Plugin not loaded");
+    return mPlugin;
+}


### PR DESCRIPTION
# Description

This is the first step towards having a standalone editor application!
This PR just adds a new class, `DynamicPlugin`, which is used to load shared libraries and import plugins from them, in a cross-platform manner.

For example, you could do something like:
```cpp
DynamicPlugin plugin{};
plugin.load("game.dll"); // would have a different name in linux, probably "game.so" or smth
cubos.plugin(plugin.function());
```

This isn't meant to be used directly by the user - it will be mostly used internally by the Tesseratos application.

Also included a small commit adding some missing `@ingroup` tags.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~ Cumbersome to do it in a cross-platform way; I think we can leave this to a later stage.
- [x] ~~Write new samples.~~ Same as above.
- [x] Add entry to the changelog's unreleased section.
