### PR TITLE
feat(ecs): add Cubos::inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented file-based logging (#1154, **@roby2014**).
 - Start and update methods to the Cubos class (#1213, **@RiscadoA**).
 - Reset method to the Cubos class (#1225, **@RiscadoA**).
+- Plugin injection to the Cubos class (#1214, **@RiscadoA**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -110,6 +110,15 @@ namespace cubos::core::ecs
         /// @return Cubos.
         Cubos& depends(Plugin plugin);
 
+        /// @brief Marks the target plugin so that when it is added, it is replaced by the given plugin.
+        ///
+        /// Aborts if the target plugin has already been added.
+        ///
+        /// @param target Target plugin.
+        /// @param plugin Plugin.
+        /// @return Cubos.
+        Cubos& inject(Plugin target, Plugin plugin);
+
         /// @brief Registers a new resource type, without initializing it.
         /// @param type Type.
         /// @return Cubos.
@@ -308,6 +317,9 @@ namespace cubos::core::ecs
 
         /// @brief Maps installed plugins to their information.
         std::unordered_map<Plugin, PluginInfo> mInstalledPlugins{{nullptr, {}}};
+
+        /// @brief Maps plugins to their injected counterparts.
+        std::unordered_map<Plugin, Plugin> mInjectedPlugins;
 
         /// @brief Maps registered types to the plugin they were registered in.
         memory::TypeMap<Plugin> mTypeToPlugin;

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -64,6 +64,11 @@ Cubos::Cubos(int argc, char** argv)
 
 Cubos& Cubos::plugin(Plugin plugin)
 {
+    if (mInjectedPlugins.contains(plugin))
+    {
+        plugin = mInjectedPlugins.at(plugin);
+    }
+
     CUBOS_ASSERT(!mInstalledPlugins.contains(plugin), "Plugin has already been added by another plugin");
 
     mInstalledPlugins.at(mPluginStack.back()).subPlugins.emplace(plugin);
@@ -78,11 +83,26 @@ Cubos& Cubos::plugin(Plugin plugin)
 
 Cubos& Cubos::depends(Plugin plugin)
 {
+    if (mInjectedPlugins.contains(plugin))
+    {
+        plugin = mInjectedPlugins.at(plugin);
+    }
+
     CUBOS_ASSERT(mInstalledPlugins.contains(plugin),
                  "Plugin dependency wasn't fulfilled. Did you forget to add a plugin?");
 
     mInstalledPlugins.at(plugin).dependentCount += 1;
     mInstalledPlugins.at(mPluginStack.back()).dependencies.emplace(plugin);
+
+    return *this;
+}
+
+Cubos& Cubos::inject(Plugin target, Plugin plugin)
+{
+    CUBOS_ASSERT(!mInstalledPlugins.contains(target), "Target plugin has already been added");
+    CUBOS_ASSERT(!mInjectedPlugins.contains(target), "Target plugin has already been injected into");
+
+    mInjectedPlugins.insert({target, plugin});
 
     return *this;
 }

--- a/core/tests/ecs/cubos.cpp
+++ b/core/tests/ecs/cubos.cpp
@@ -24,6 +24,21 @@ TEST_CASE("ecs::Cubos")
         CHECK(count == 1);
     }
 
+    SUBCASE("plugin is injected")
+    {
+        static int count = 1;
+        auto target = [](Cubos&) { count *= 2; };
+        auto plugin = [](Cubos&) { count *= 3; };
+
+        CHECK(count == 1);
+        cubos.inject(target, plugin);
+        CHECK(count == 1);
+        cubos.plugin(target);
+        CHECK(count == 3);
+        cubos.depends(target);
+        CHECK(count == 3);
+    }
+
     SUBCASE("systems are called")
     {
         CUBOS_DEFINE_TAG(middle);


### PR DESCRIPTION
# Description

Adds a method to the `Cubos` class which allows the dev to inject a plugin into another plugin's place.
This will be useful to make Tesseratos a standalone app, as we'll need to make a 'fake window plugin' for the game to run properly - we want the game to be shown within the existing Tesseratos window.
The goal is to be able do this: `game.cubos.inject(windowPlugin, fakeWindowPlugin)`.
Then, when the game calls `cubos.plugin(windowPlugin)`, `fakeWindowPlugin` will be added instead, seamlessly.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
- [x] Add entry to the changelog's unreleased section.
