### PR TITLE
feat(ecs): add Cubos::start and Cubos::update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - UI canvas, elements, and color rects. (#1116, **@DiogoMendonc-a**)
 - Implemented file-based logging (#1154, **@roby2014**).
+- Start and update methods to the Cubos class (#1213, **@RiscadoA**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -78,7 +78,7 @@ namespace cubos::core::ecs
         /// @brief Used to create new observers.
         class ObserverBuilder;
 
-        ~Cubos() = default;
+        ~Cubos();
 
         /// @brief Constructs an empty application without arguments.
         Cubos();
@@ -203,10 +203,16 @@ namespace cubos::core::ecs
         /// @return Builder used to configure the observer.
         ObserverBuilder observer(std::string name);
 
-        /// @brief Runs the engine.
+        /// @brief Runs the application's startup systems.
+        void start();
+
+        /// @brief Runs the application's main systems.
+        /// @return Whether the application should continue running, based on the @ref ShouldQuit resource.
+        bool update();
+
+        /// @brief Runs the application's main loop.
         ///
-        /// Initially, dispatches all of the startup systems.
-        /// Then, while @ref ShouldQuit is false, dispatches all other systems.
+        /// Equivalent to calling @ref start() followed by @ref update() until it returns false.
         void run();
 
     private:
@@ -248,6 +254,9 @@ namespace cubos::core::ecs
             Plugin plugin;
         };
 
+        /// @brief Stores runtime application state.
+        struct State;
+
         /// @brief Checks if the given type was registered by the current plugin, its dependencies or sub-plugins.
         /// @param type Type.
         /// @return Whether the type was registered.
@@ -279,6 +288,7 @@ namespace cubos::core::ecs
 
         World mWorld;
         SystemRegistry mSystemRegistry;
+        State* mState{nullptr};
 
         /// @brief Planner for systems which run before the main loop starts.
         Planner mStartupPlanner;


### PR DESCRIPTION
# Description

Splits the existing run method into two methods, `start` and `update`:
- `start` initializes the application and runs the startup systems;
- `update` runs the main systems once, and returns whether the application has finished.

This is necessary for the standalone Tesseratos app, as we need to be able to run a single frame of the game inside a system of the Tesseratos application. This will probably look something like:

```cpp
cubos.system("update Game").call([](Game& game) {
  if (!game.paused)
  {
    if (!game.cubos.update())
    {
      // Game stopped
    }
  }
});
```

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage (already covered by the run method).
- [x] ~~Write new samples~~ (seems unnecessary ?).
- [x] Add entry to the changelog's unreleased section.
