### PR TITLE
Add Game plugin to Tesseratos

### DIFF
--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -229,6 +229,10 @@ namespace cubos::core::ecs
         /// Equivalent to calling @ref start() followed by @ref update() until it returns false.
         void run();
 
+        /// @brief Returns whether the application has been started.
+        /// @return Whether the application has been started.
+        bool isStarted() const;
+
     private:
         /// @brief Stores information regarding a plugin.
         struct PluginInfo

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -18,7 +18,6 @@
 
 namespace cubos::core::ecs
 {
-
     /// @brief Resource which stores the time since the last iteration of the main loop started.
     ///
     /// This resource is added and updated by the @ref Cubos class.
@@ -232,6 +231,10 @@ namespace cubos::core::ecs
         /// @brief Returns whether the application has been started.
         /// @return Whether the application has been started.
         bool isStarted() const;
+
+        /// @brief Gets a reference to the application's world.
+        /// @return World.
+        World& world();
 
     private:
         /// @brief Stores information regarding a plugin.

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -15,6 +15,7 @@ using cubos::core::ecs::Cubos;
 using cubos::core::ecs::DeltaTime;
 using cubos::core::ecs::Name;
 using cubos::core::ecs::ShouldQuit;
+using cubos::core::ecs::World;
 
 CUBOS_REFLECT_IMPL(DeltaTime)
 {
@@ -297,6 +298,11 @@ void Cubos::run()
 bool Cubos::isStarted() const
 {
     return mState != nullptr;
+}
+
+World& Cubos::world()
+{
+    return mWorld;
 }
 
 bool Cubos::isRegistered(const reflection::Type& type) const

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -294,6 +294,11 @@ void Cubos::run()
     }
 }
 
+bool Cubos::isStarted() const
+{
+    return mState != nullptr;
+}
+
 bool Cubos::isRegistered(const reflection::Type& type) const
 {
     return (mTypeToPlugin.contains(type) && this->isKnownPlugin(mTypeToPlugin.at(type), mPluginStack.back())) ||

--- a/engine/include/cubos/engine/prelude.hpp
+++ b/engine/include/cubos/engine/prelude.hpp
@@ -12,6 +12,9 @@
 
 namespace cubos::engine
 {
+    /// @copydoc cubos::core::ecs::World
+    using World = core::ecs::World;
+
     /// @copydoc cubos::core::ecs::Tag
     using Tag = core::ecs::Tag;
 

--- a/tools/tesseratos/CMakeLists.txt
+++ b/tools/tesseratos/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 set(TESSERATOS_SOURCE
 	"src/tesseratos/main.cpp"
+	"src/tesseratos/game/plugin.cpp"
+	"src/tesseratos/game/game.cpp"
 	"src/tesseratos/asset_explorer/plugin.cpp"
 	"src/tesseratos/asset_explorer/popup.cpp"
 	"src/tesseratos/settings_inspector/plugin.cpp"

--- a/tools/tesseratos/src/tesseratos/game/game.cpp
+++ b/tools/tesseratos/src/tesseratos/game/game.cpp
@@ -1,0 +1,110 @@
+#include "game.hpp"
+
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using tesseratos::Game;
+
+CUBOS_REFLECT_IMPL(tesseratos::Game)
+{
+    using namespace cubos::core::reflection;
+    return Type::create("tesseratos::Game").with(ConstructibleTrait::typed<Game>().build());
+}
+
+void Game::inject(cubos::core::ecs::Plugin target, cubos::core::ecs::Plugin plugin)
+{
+    CUBOS_ASSERT(!mInjections.contains(target), "Target plugin was injected into");
+    mInjections.emplace(target, plugin);
+}
+
+void Game::unload()
+{
+    mCubos.reset();
+    mPlugin = nullptr;
+}
+
+void Game::load(cubos::core::ecs::Plugin plugin)
+{
+    this->unload();
+    mPlugin = plugin;
+
+    for (auto [target, inject] : mInjections)
+    {
+        mCubos.inject(target, inject);
+    }
+
+    CUBOS_INFO("Loading game");
+    mCubos.plugin(mPlugin);
+}
+
+void Game::reset()
+{
+    this->load(mPlugin);
+}
+
+void Game::start()
+{
+    CUBOS_ASSERT(mPlugin != nullptr, "Game has not been loaded");
+    CUBOS_ASSERT(!mCubos.isStarted(), "Game has already been started");
+
+    CUBOS_INFO("Starting game");
+    mCubos.start();
+    mPaused = false;
+}
+
+void Game::update()
+{
+    CUBOS_ASSERT(mCubos.isStarted(), "Game has not been started");
+
+    if (!mPaused)
+    {
+        if (mCubos.update())
+        {
+            CUBOS_INFO("Game has ended, resetting");
+            this->reset();
+        }
+    }
+}
+
+void Game::pause()
+{
+    CUBOS_ASSERT(mCubos.isStarted(), "Game has not been started");
+
+    if (!mPaused)
+    {
+        CUBOS_INFO("Pausing game");
+        mPaused = true;
+    }
+}
+
+void Game::resume()
+{
+    CUBOS_ASSERT(mCubos.isStarted(), "Game has not been started");
+
+    if (mPaused)
+    {
+        CUBOS_INFO("Resuming game");
+        mPaused = false;
+    }
+}
+
+bool Game::isLoaded() const
+{
+    return mPlugin != nullptr;
+}
+
+bool Game::isStarted() const
+{
+    return this->isLoaded() && mCubos.isStarted();
+}
+
+bool Game::isRunning() const
+{
+    return this->isStarted() && !mPaused;
+}
+
+cubos::core::ecs::World& Game::world()
+{
+    CUBOS_ASSERT(this->isLoaded(), "Game has not been loaded");
+    return mCubos.world();
+}

--- a/tools/tesseratos/src/tesseratos/game/game.hpp
+++ b/tools/tesseratos/src/tesseratos/game/game.hpp
@@ -1,0 +1,100 @@
+/// @file
+/// @brief Resource @ref tesseratos::Game.
+/// @ingroup tesseratos-game-plugin
+
+#pragma once
+
+#include <cubos/core/ecs/cubos.hpp>
+
+namespace tesseratos
+{
+    /// @brief Resource which holds the game's Cubos instance.
+    ///
+    /// The game may be in four different states:
+    /// - @b Unloaded - Game plugin has not been loaded yet.
+    /// - @b Loaded - Game plugin has been loaded.
+    /// - @b Running - Game has been started, and is currently running.
+    /// - @b Paused - Game has been started, but is currently paused.
+    ///
+    /// @ingroup tesseratos-game-plugin
+    class Game
+    {
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief Marks the given target plugin so that when the game starts, it is replaced by the given plugin.
+        /// @param target Target plugin.
+        /// @param plugin Plugin to be injected.
+        void inject(cubos::core::ecs::Plugin target, cubos::core::ecs::Plugin plugin);
+
+        /// @brief Unloads the game.
+        ///
+        /// Does nothing if the game has not been loaded.
+        void unload();
+
+        /// @brief Loads the game from the given plugin.
+        ///
+        /// If the game has already been loaded, it is unloaded first.
+        ///
+        /// @param plugin Game plugin.
+        void load(cubos::core::ecs::Plugin plugin);
+
+        /// @brief If the game has been started, resets it to the loaded state.
+        ///
+        /// Equivalent to calling @ref load again with the currently loaded plugin.
+        void reset();
+
+        /// @brief Runs the game's startup systems.
+        ///
+        /// Aborts if the game if it has not been loaded, or if it has already been started.
+        void start();
+
+        /// @brief Runs the game's update systems.
+        ///
+        /// If the game is paused, does nothing.
+        /// Aborts if the game has not been started.
+        void update();
+
+        /// @brief Pauses the game.
+        ///
+        /// Aborts if the game has not been started.
+        /// Does nothing if the game is already paused.
+        void pause();
+
+        /// @brief Resumes the game.
+        ///
+        /// Aborts if the game has not been started.
+        /// Does nothing if the game is not paused.
+        void resume();
+
+        /// @brief Returns whether the game has been loaded.
+        /// @return Whether the game has been loaded.
+        bool isLoaded() const;
+
+        /// @brief Returns whether the game has been started.
+        /// @return Whether the game has been started.
+        bool isStarted() const;
+
+        /// @brief Returns whether the game is running.
+        /// @return Whether the game is running.
+        bool isRunning() const;
+
+        /// @brief Returns the game's world.
+        ///
+        /// Aborts if the game has not been loaded.
+        cubos::core::ecs::World& world();
+
+    private:
+        /// @brief Whether the game has been paused.
+        bool mPaused{false};
+
+        /// @brief Game's Cubos instance.
+        cubos::core::ecs::Cubos mCubos{};
+
+        /// @brief Loaded game plugin.
+        cubos::core::ecs::Plugin mPlugin{nullptr};
+
+        /// @brief Plugins to be injected.
+        std::unordered_map<cubos::core::ecs::Plugin, cubos::core::ecs::Plugin> mInjections{};
+    };
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/game/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/game/plugin.cpp
@@ -1,0 +1,19 @@
+#include "plugin.hpp"
+
+using namespace cubos::engine;
+
+CUBOS_DEFINE_TAG(tesseratos::gameUpdateTag);
+
+void tesseratos::gamePlugin(Cubos& cubos)
+{
+    cubos.resource<Game>();
+
+    cubos.tag(gameUpdateTag);
+
+    cubos.system("update Game").tagged(gameUpdateTag).call([](Game& game) {
+        if (game.isStarted())
+        {
+            game.update();
+        }
+    });
+}

--- a/tools/tesseratos/src/tesseratos/game/plugin.hpp
+++ b/tools/tesseratos/src/tesseratos/game/plugin.hpp
@@ -1,0 +1,27 @@
+/// @dir
+/// @brief @ref tesseratos-game-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup tesseratos-game-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+#include "game.hpp"
+
+namespace tesseratos
+{
+    /// @defgroup tesseratos-game-plugin Game
+    /// @ingroup tesseratos
+    /// @brief Adds the @ref Game resource to the editor.
+
+    /// @brief Game instance is updated, if running.
+    extern cubos::engine::Tag gameUpdateTag;
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b Cubos main class
+    /// @ingroup tesseratos-game-plugin
+    void gamePlugin(cubos::engine::Cubos& cubos);
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/main.cpp
+++ b/tools/tesseratos/src/tesseratos/main.cpp
@@ -12,6 +12,7 @@
 #include "ecs_statistics/plugin.hpp"
 #include "entity_inspector/plugin.hpp"
 #include "entity_selector/plugin.hpp"
+#include "game/plugin.hpp"
 #include "metrics_panel/plugin.hpp"
 #include "play_pause/plugin.hpp"
 #include "scene_editor/plugin.hpp"
@@ -38,22 +39,26 @@ int main(int argc, char** argv)
     // The third block contains plugins which depend on plugins from the first and second blocks.
     // And so on.
 
+    // TODO: Go through each of the commented plugins below, convert them to use the new Game resource, and uncomment
+    // them.
+
+    cubos.plugin(gamePlugin);
     cubos.plugin(toolboxPlugin);
-    cubos.plugin(entitySelectorPlugin);
+    //  cubos.plugin(entitySelectorPlugin);
 
     cubos.plugin(assetExplorerPlugin);
-    cubos.plugin(entityInspectorPlugin);
-    cubos.plugin(worldInspectorPlugin);
-    cubos.plugin(debugCameraPlugin);
-    cubos.plugin(settingsInspectorPlugin);
-    cubos.plugin(metricsPanelPlugin);
-    cubos.plugin(colliderGizmosPlugin);
-    cubos.plugin(transformGizmoPlugin);
-    cubos.plugin(playPausePlugin);
-    cubos.plugin(ecsStatisticsPlugin);
+    // cubos.plugin(entityInspectorPlugin);
+    // cubos.plugin(worldInspectorPlugin);
+    // cubos.plugin(debugCameraPlugin);
+    // cubos.plugin(settingsInspectorPlugin);
+    // cubos.plugin(metricsPanelPlugin);
+    // cubos.plugin(colliderGizmosPlugin);
+    // cubos.plugin(transformGizmoPlugin);
+    // cubos.plugin(playPausePlugin);
+    // cubos.plugin(ecsStatisticsPlugin);
 
-    cubos.plugin(sceneEditorPlugin);
-    cubos.plugin(voxelPaletteEditorPlugin);
+    // cubos.plugin(sceneEditorPlugin);
+    // cubos.plugin(voxelPaletteEditorPlugin);
 
     cubos.startupSystem("configure Assets plugin").tagged(cubos::engine::settingsTag).call([](Settings& settings) {
         settings.setString("assets.io.path", TESSERATOS_ASSETS_FOLDER);


### PR DESCRIPTION
# Description

Adds the game plugin to Tesseratos. This plugin adds a resource, which holds the state of the game being edited.
Check out the game resource docs for more info about its states.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~
- [x] ~~Write new samples.~~
- [x] ~~Add entry to the changelog's unreleased section.~~
