### PR TITLE
Add network Address class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented metrics and profiling tools (#1150, **@roby2014**).
 - GL timer for profiling sections of rendering code (#1228, **@tomas7770**).
 - Shadows plugin (#1185, **@tomas7770**).
+- Network Address class (#1211, **@roby2014**).
 
 ### Changed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -137,6 +137,8 @@ set(CUBOS_CORE_SOURCE
     "src/geom/box.cpp"
     "src/geom/capsule.cpp"
     "src/geom/intersections.cpp"
+
+    "src/net/address.cpp"
 )
 
 # Create core library

--- a/core/include/cubos/core/net/address.hpp
+++ b/core/include/cubos/core/net/address.hpp
@@ -1,0 +1,85 @@
+/// @file
+/// @brief Class @ref cubos::core::net::Address.
+/// @ingroup core-net
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include <cubos/core/api.hpp>
+#include <cubos/core/memory/opt.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::core::net
+{
+    /// @brief Represents an address, either IPv4 or IPv6.
+    /// @ingroup core-net
+    class CUBOS_CORE_API Address
+    {
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief 0.0.0.0
+        static const Address Any;
+
+        /// @brief 127.0.0.1
+        static const Address LocalHost;
+
+        /// @brief Constructs a empty address (IPv4 by default).
+        Address();
+
+        /// @brief Deconstructs by cleaning necessary resources.
+        ~Address();
+
+        /// @brief Constructs a new IPv4 address from four octets (`a.b.c.d`).
+        /// @param a First octet.
+        /// @param b Second octet.
+        /// @param c Third octet.
+        /// @param d Fourth octet.
+        static Address fromIPv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d);
+
+        /// @brief Constructs a new IPv6 address from four 32-bit integers (`a.b.c.d`).
+        /// @param a First octet.
+        /// @param b Second octet.
+        /// @param c Third octet.
+        /// @param d Fourth octet.
+        static Address fromIPv6(uint32_t a, uint32_t b, uint32_t c, uint32_t d);
+
+        /// @brief Converts the provided string value to an Address.
+        /// @param address The address, either in IPv4/IPv6 format, or as a domain hostname.
+        /// @return Address object, or nothing if could not resolve the provided `address`.
+        static memory::Opt<Address> from(const std::string& address);
+
+        /// @brief Converts the address value to a string.
+        /// @return Address represented as a string.
+        std::string toString() const;
+
+    private:
+        /// @copydoc cubos::core::net::fromIPv4
+        Address(uint8_t a, uint8_t b, uint8_t c, uint8_t d);
+
+        /// @copydoc cubos::core::net::fromIPv6
+        Address(uint32_t a, uint32_t b, uint32_t c, uint32_t d);
+
+        /// @brief Constructs a new IPv4 address from the given value.
+        /// @param address Address in 32-bit format (octets together basically).
+        Address(uint32_t address);
+
+        enum class IPType
+        {
+            IPv4,
+            IPv6
+        };
+
+        union A {
+            uint32_t v4Addr;
+            std::array<uint32_t, 4> v6Addr;
+        };
+
+        A mAddr{};
+        IPType mType{};
+    };
+
+} // namespace cubos::core::net

--- a/core/src/net/address.cpp
+++ b/core/src/net/address.cpp
@@ -1,0 +1,184 @@
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "Ws2_32.lib")
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#endif
+
+#include <algorithm>
+#include <cstring>
+
+#include <cubos/core/net/address.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using namespace cubos::core::net;
+using cubos::core::memory::Opt;
+
+const Address Address::Any((uint8_t)0, 0, 0, 0);
+const Address Address::LocalHost((uint8_t)127, 0, 0, 1);
+
+CUBOS_REFLECT_IMPL(cubos::core::net::Address)
+{
+    using cubos::core::reflection::StringConversionTrait;
+    using cubos::core::reflection::Type;
+
+    return Type::create("cubos::core::net::Address")
+        .with(StringConversionTrait{
+            [](const void* instance) { return static_cast<const Address*>(instance)->toString(); },
+            [](void* instance, const std::string& string) {
+                auto addr = Address::from(string);
+                if (addr.contains())
+                {
+                    *static_cast<Address*>(instance) = addr.value();
+                    return true;
+                }
+                return false;
+            }});
+}
+
+/// @brief Inits needed resources.
+static void init()
+{
+#ifdef _WIN32
+    WSADATA wsa;
+    CUBOS_ASSERT(WSAStartup(MAKEWORD(2, 2), &wsa) == 0, " WSAStartup failed: {}", WSAGetLastError());
+#endif
+}
+
+/// @brief Cleans up resources.
+static void cleanup()
+{
+#ifdef _WIN32
+    WSACleanup();
+#endif
+}
+
+Address::Address()
+    : mType(IPType::IPv4)
+{
+}
+
+Address::Address(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
+    : mAddr{.v4Addr = static_cast<uint32_t>(a) << 24 | static_cast<uint32_t>(b) << 16 | static_cast<uint32_t>(c) << 8 |
+                      static_cast<uint32_t>(d)}
+    , mType(IPType::IPv4)
+{
+}
+
+Address::Address(uint32_t address)
+    : mAddr{.v4Addr = address}
+    , mType(IPType::IPv4){};
+
+Address::Address(uint32_t a, uint32_t b, uint32_t c, uint32_t d)
+    : mAddr{.v6Addr = {a, b, c, d}}
+    , mType(IPType::IPv6)
+{
+}
+
+Address::~Address()
+{
+    cleanup();
+}
+
+std::string Address::toString() const
+{
+    if (mType == IPType::IPv4)
+    {
+        char str[INET_ADDRSTRLEN];
+        auto ip = htonl(mAddr.v4Addr);
+
+        inet_ntop(AF_INET, &ip, str, INET_ADDRSTRLEN);
+        return std::string{str};
+    }
+
+    char str[INET6_ADDRSTRLEN];
+    std::array<uint32_t, 4> ip;
+
+    std::transform(mAddr.v6Addr.begin(), mAddr.v6Addr.end(), ip.begin(), [](uint32_t v) { return htonl(v); });
+    inet_ntop(AF_INET6, &ip, str, INET6_ADDRSTRLEN);
+    return std::string{str};
+}
+
+Address Address::fromIPv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
+{
+    return {a, b, c, d};
+}
+
+Address Address::fromIPv6(uint32_t a, uint32_t b, uint32_t c, uint32_t d)
+{
+    return {a, b, c, d};
+}
+
+Opt<Address> Address::from(const std::string& address)
+{
+    init();
+
+    struct addrinfo hints;
+    std::memset(&hints, 0, sizeof(struct addrinfo));
+    hints.ai_family = PF_UNSPEC;
+    hints.ai_flags |= AI_CANONNAME;
+
+    struct addrinfo* res = nullptr;
+    auto err = getaddrinfo(address.c_str(), nullptr, &hints, &res);
+    if (err != 0)
+    {
+        CUBOS_ERROR("Failure to parse host '{}': {} ({})", address.c_str(), gai_strerror(err), err);
+        return {};
+    }
+
+    if (res == nullptr)
+    {
+        CUBOS_ERROR("No host found for '{}'", address.c_str());
+        return {};
+    }
+
+    struct sockaddr_storage result;
+    memcpy(&result, res->ai_addr, res->ai_addrlen);
+    freeaddrinfo(res);
+
+    cleanup();
+
+    if (result.ss_family == AF_INET)
+    {
+        auto* sa4 = reinterpret_cast<struct sockaddr_in*>(&result);
+        struct in_addr* in4 = &sa4->sin_addr;
+        return Address(ntohl(in4->s_addr));
+    }
+
+    if (result.ss_family == AF_INET6)
+    {
+        auto* sa6 = reinterpret_cast<struct sockaddr_in6*>(&result);
+        struct in6_addr* in6 = &sa6->sin6_addr;
+#ifdef _WIN32
+        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dpdx/2b400962-05ef-4e69-9185-927755b322a5
+        // The IN6_ADDR structure specifies an IPv6 transport address whose bytes are in network byte order
+        // (big-endian).
+        uint32_t a = in6->u.Word[1] << 16 | in6->u.Word[0];
+        uint32_t b = in6->u.Word[3] << 16 | in6->u.Word[2];
+        uint32_t c = in6->u.Word[5] << 16 | in6->u.Word[4];
+        uint32_t d = in6->u.Word[7] << 16 | in6->u.Word[6];
+        return Address((uint32_t)ntohl(a), ntohl(b), ntohl(c), ntohl(d));
+#else
+        uint32_t a = static_cast<uint32_t>(in6->s6_addr[3]) << 24 | static_cast<uint32_t>(in6->s6_addr[2]) << 16 |
+                     static_cast<uint32_t>(in6->s6_addr[1]) << 8 | static_cast<uint32_t>(in6->s6_addr[0]);
+
+        uint32_t b = static_cast<uint32_t>(in6->s6_addr[7]) << 24 | static_cast<uint32_t>(in6->s6_addr[6]) << 16 |
+                     static_cast<uint32_t>(in6->s6_addr[5]) << 8 | static_cast<uint32_t>(in6->s6_addr[4]);
+
+        uint32_t c = static_cast<uint32_t>(in6->s6_addr[11]) << 24 | static_cast<uint32_t>(in6->s6_addr[10]) << 16 |
+                     static_cast<uint32_t>(in6->s6_addr[9]) << 8 | static_cast<uint32_t>(in6->s6_addr[8]);
+
+        uint32_t d = static_cast<uint32_t>(in6->s6_addr[15]) << 24 | static_cast<uint32_t>(in6->s6_addr[14]) << 16 |
+                     static_cast<uint32_t>(in6->s6_addr[13]) << 8 | static_cast<uint32_t>(in6->s6_addr[12]);
+
+        return Address((uint32_t)ntohl(a), ntohl(b), ntohl(c), ntohl(d));
+#endif
+    }
+
+    return {};
+}

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -69,6 +69,8 @@ add_executable(
 	thread/task.cpp
 
 	metrics/metrics.cpp
+
+	net/address.cpp
 )
 
 target_link_libraries(cubos-core-tests cubos-core doctest::doctest)

--- a/core/tests/net/address.cpp
+++ b/core/tests/net/address.cpp
@@ -1,0 +1,84 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/net/address.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/traits/string_conversion.hpp>
+
+TEST_CASE("address")
+{
+    using cubos::core::net::Address;
+    using cubos::core::reflection::reflect;
+    using cubos::core::reflection::StringConversionTrait;
+
+    SUBCASE("from and to string ipv4")
+    {
+        auto addr = Address::from("127.0.0.1");
+        REQUIRE(addr.contains());
+        REQUIRE(addr.value().toString() == "127.0.0.1");
+
+        REQUIRE(!Address::from("abc123").contains());
+    }
+
+    SUBCASE("from and to string ipv6")
+    {
+        auto addr = Address::from("::1");
+        REQUIRE(addr.contains());
+        REQUIRE(addr.value().toString() == "::1");
+
+        REQUIRE(!Address::from("abc123").contains());
+    }
+
+    SUBCASE("from and to string hostname")
+    {
+        auto addr = Address::from("localhost");
+        REQUIRE(addr.contains());
+        auto expected = addr.value().toString() == "127.0.0.1" || addr.value().toString() == "::1";
+        REQUIRE(expected);
+    }
+
+    SUBCASE("empty address")
+    {
+        Address addr;
+        REQUIRE(addr.toString() == "0.0.0.0");
+    }
+
+    SUBCASE("octets separate")
+    {
+        auto addr = Address::fromIPv4(127, 0, 0, 1);
+        REQUIRE(addr.toString() == "127.0.0.1");
+
+        const auto& addr2 = addr;
+        REQUIRE(addr2.toString() == "127.0.0.1");
+
+        auto addr3 = Address::fromIPv6(0, 0, 0, 1);
+        REQUIRE(addr3.toString() == "::1");
+    }
+
+    SUBCASE("localhost and any")
+    {
+        REQUIRE(Address::Any.toString() == Address::fromIPv4(0, 0, 0, 0).toString());
+        REQUIRE(Address::LocalHost.toString() == Address::fromIPv4(127, 0, 0, 1).toString());
+    }
+
+    SUBCASE("from domain name")
+    {
+        auto addr = Address::from("www.google.com");
+        REQUIRE(addr.contains());
+    }
+
+    SUBCASE("reflection string trait")
+    {
+        auto addr = Address::fromIPv4(127, 0, 0, 1);
+
+        const auto& r = reflect<Address>();
+        REQUIRE(r.name() == "cubos::core::net::Address");
+        REQUIRE(r.has<StringConversionTrait>());
+
+        const auto& strTrait = r.get<StringConversionTrait>();
+        REQUIRE(strTrait.into(&addr) == "127.0.0.1");
+        REQUIRE(strTrait.from(&addr, "0.0.0.0"));
+        REQUIRE(addr.toString() == "0.0.0.0");
+
+        REQUIRE(!strTrait.from(&addr, "aaa"));
+    }
+}


### PR DESCRIPTION
blocked by #1259 

# Description

Add a network `Address` class, as proposed in the issue.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
- [x] Add entry to the changelog's unreleased section.
