### PR TITLE
Move Opt class to memory namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented metrics and profiling tools (#1150, **@roby2014**).
 - GL timer for profiling sections of rendering code (#1228, **@tomas7770**).
 
+### Changed
+
+- Move Opt class to memory namespace (#1212, **@roby2014**).
+
 ## [v0.2.0] - 2024-05-07
 
 ### Added

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,6 +38,7 @@ set(CUBOS_CORE_SOURCE
 	"src/memory/buffer_stream.cpp"
 	"src/memory/any_value.cpp"
 	"src/memory/any_vector.cpp"
+	"src/memory/opt.cpp"
 
 	"src/reflection/reflect.cpp"
 	"src/reflection/type.cpp"
@@ -119,7 +120,6 @@ set(CUBOS_CORE_SOURCE
 	"src/ecs/query/data.cpp"
 	"src/ecs/query/filter.cpp"
 	"src/ecs/query/fetcher.cpp"
-	"src/ecs/query/opt.cpp"
 	"src/ecs/query/node/node.cpp"
 	"src/ecs/query/node/archetype.cpp"
 	"src/ecs/query/node/related.cpp"

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -15,6 +15,7 @@
 #include <cubos/core/ecs/system/system.hpp>
 #include <cubos/core/ecs/system/tag.hpp>
 #include <cubos/core/ecs/world.hpp>
+#include <cubos/core/memory/opt.hpp>
 
 namespace cubos::core::ecs
 {
@@ -536,7 +537,7 @@ namespace cubos::core::ecs
         Cubos& mCubos;
         bool mIsStartup;
         std::string mName;
-        Opt<System<bool>> mCondition;
+        memory::Opt<System<bool>> mCondition;
         std::unordered_set<std::string> mTagged;
         std::unordered_set<std::string> mBefore;
         std::unordered_set<std::string> mAfter;

--- a/core/include/cubos/core/ecs/query/data.hpp
+++ b/core/include/cubos/core/ecs/query/data.hpp
@@ -162,7 +162,7 @@ namespace cubos::core::ecs
         /// @brief Accesses the match for the given entity, if there is one.
         /// @param entity Entity.
         /// @return Requested data, or nothing if the entity does not match the query.
-        Opt<std::tuple<Ts...>> at(Entity entity)
+        memory::Opt<std::tuple<Ts...>> at(Entity entity)
         {
             CUBOS_ASSERT(mFilter->targetCount() == 1);
 
@@ -180,7 +180,7 @@ namespace cubos::core::ecs
         /// @param firstEntity Entity for the first target.
         /// @param secondEntity Entity for the second target.
         /// @return Requested data, or nothing if the entities do not match the query.
-        Opt<std::tuple<Ts...>> at(Entity firstEntity, Entity secondEntity)
+        memory::Opt<std::tuple<Ts...>> at(Entity firstEntity, Entity secondEntity)
         {
             CUBOS_ASSERT(mFilter->targetCount() == 2);
 

--- a/core/include/cubos/core/ecs/query/fetcher.hpp
+++ b/core/include/cubos/core/ecs/query/fetcher.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <cubos/core/ecs/query/opt.hpp>
 #include <cubos/core/ecs/query/term.hpp>
 #include <cubos/core/ecs/world.hpp>
+#include <cubos/core/memory/opt.hpp>
 
 namespace cubos::core::ecs
 {
@@ -268,7 +268,7 @@ namespace cubos::core::ecs
     };
 
     template <typename T>
-    class QueryFetcher<Opt<T&>>
+    class QueryFetcher<memory::Opt<T&>>
     {
     public:
         QueryFetcher(World& world, const QueryTerm& term)
@@ -299,7 +299,7 @@ namespace cubos::core::ecs
             }
         }
 
-        Opt<T&> fetch(std::size_t row)
+        memory::Opt<T&> fetch(std::size_t row)
         {
             if (mColumn == nullptr)
             {
@@ -317,7 +317,7 @@ namespace cubos::core::ecs
     };
 
     template <typename T>
-    class QueryFetcher<Opt<const T&>>
+    class QueryFetcher<memory::Opt<const T&>>
     {
     public:
         QueryFetcher(World& world, const QueryTerm& term)
@@ -349,7 +349,7 @@ namespace cubos::core::ecs
             }
         }
 
-        Opt<const T&> fetch(std::size_t row)
+        memory::Opt<const T&> fetch(std::size_t row)
         {
             if (mColumn == nullptr)
             {

--- a/core/include/cubos/core/ecs/system/arguments/query.hpp
+++ b/core/include/cubos/core/ecs/system/arguments/query.hpp
@@ -68,7 +68,7 @@ namespace cubos::core::ecs
         /// @brief Accesses the match for the given entity, if there is one.
         /// @param entity Entity.
         /// @return Requested components, or nothing if the entity does not match the query.
-        Opt<std::tuple<Ts...>> at(Entity entity)
+        memory::Opt<std::tuple<Ts...>> at(Entity entity)
         {
             return mView.data().at(entity);
         }
@@ -77,14 +77,14 @@ namespace cubos::core::ecs
         /// @param firstEntity Entity for the first target.
         /// @param secondEntity Entity for the second target.
         /// @return Requested data, or nothing if the entities do not match the query.
-        Opt<std::tuple<Ts...>> at(Entity firstEntity, Entity secondEntity)
+        memory::Opt<std::tuple<Ts...>> at(Entity firstEntity, Entity secondEntity)
         {
             return mView.data().at(firstEntity, secondEntity);
         }
 
         /// @brief Returns the first match of the query, if there's any.
         /// @return Requested data, or nothing if there are no matches.
-        Opt<std::tuple<Ts...>> first()
+        memory::Opt<std::tuple<Ts...>> first()
         {
             auto it = this->begin();
             if (it == this->end())

--- a/core/include/cubos/core/ecs/system/planner.hpp
+++ b/core/include/cubos/core/ecs/system/planner.hpp
@@ -94,7 +94,7 @@ namespace cubos::core::ecs
 
         /// @brief Constructs a new schedule from the constraints specified until now.
         /// @return Schedule, or nothing if the constraints couldn't be fulfilled.
-        Opt<Schedule> build() const;
+        memory::Opt<Schedule> build() const;
 
     private:
         /// @brief Holds the constraints and data of a tag.
@@ -106,16 +106,16 @@ namespace cubos::core::ecs
             /// @brief System identifier associated to the tag.
             ///
             /// Only used by leaf tags.
-            Opt<SystemId> systemId{};
+            memory::Opt<SystemId> systemId{};
 
             /// @brief Condition identifiers associated to the tag.
             std::vector<ConditionId> conditionIds{};
 
             /// @brief If the tag is a repeat tag, holds its repeat condition.
-            Opt<ConditionId> repeatConditionId{};
+            memory::Opt<ConditionId> repeatConditionId{};
 
             /// @brief Parent repeating tag, if there's one. Set internally during @ref build.
-            Opt<TagId> repeatingParent{};
+            memory::Opt<TagId> repeatingParent{};
 
             /// @brief Parent tags of this tag.
             std::unordered_set<TagId, TagId::Hash> parents{};
@@ -159,7 +159,7 @@ namespace cubos::core::ecs
         /// @param tags Tags array.
         /// @param nodes Node identifiers for each tag.
         static void makeSystemOrRepeatNode(TagId tagId, Schedule& schedule, const std::vector<TagData>& tags,
-                                           std::vector<Opt<Schedule::NodeId>>& nodes);
+                                           std::vector<memory::Opt<Schedule::NodeId>>& nodes);
 
         std::vector<TagData> mTags{};
     };

--- a/core/include/cubos/core/ecs/system/schedule.hpp
+++ b/core/include/cubos/core/ecs/system/schedule.hpp
@@ -7,8 +7,8 @@
 #include <queue>
 #include <vector>
 
-#include <cubos/core/ecs/query/opt.hpp>
 #include <cubos/core/ecs/system/registry.hpp>
+#include <cubos/core/memory/opt.hpp>
 
 namespace cubos::core::ecs
 {
@@ -94,19 +94,19 @@ namespace cubos::core::ecs
         /// @param conditionId Condition identifier.
         /// @param repeatId Repeat node to become part of, if any.
         /// @return Repeat node identifier, or nothing if the given repeat node is not a repeat node.
-        Opt<NodeId> repeat(ConditionId conditionId, Opt<NodeId> repeatId = {});
+        memory::Opt<NodeId> repeat(ConditionId conditionId, const memory::Opt<NodeId>& repeatId = {});
 
         /// @brief Adds a system node to the schedule.
         /// @param systemId System identifier.
         /// @param repeatId Repeat node to become part of, if any.
         /// @return System node identifier, or nothing if the given repeat node is not a repeat node.
-        Opt<NodeId> system(SystemId systemId, Opt<NodeId> repeatId = {});
+        memory::Opt<NodeId> system(SystemId systemId, const memory::Opt<NodeId>& repeatId = {});
 
         /// @brief Adds a condition node to the schedule.
         /// @param conditionId Condition identifier.
         /// @param repeatId Repeat node to become part of, if any.
         /// @return Condition node identifier, or nothing if the given repeat node is not a repeat node.
-        Opt<NodeId> condition(ConditionId conditionId, Opt<NodeId> repeatId = {});
+        memory::Opt<NodeId> condition(ConditionId conditionId, const memory::Opt<NodeId>& repeatId = {});
 
         /// @brief Specifies that a node should only run if a given condition node returns true after finishing.
         ///
@@ -166,13 +166,13 @@ namespace cubos::core::ecs
             bool alreadyEvaluatedToTrue{false};
 
             /// @brief If the node is part of a repeat node, holds the repeat node's identifier.
-            Opt<NodeId> repeatId{};
+            memory::Opt<NodeId> repeatId{};
 
             /// @brief If the node is a system node, holds the system identifier.
-            Opt<SystemId> systemId{};
+            memory::Opt<SystemId> systemId{};
 
             /// @brief If the node is a repeat or condition node, holds the respective condition identifier.
-            Opt<ConditionId> conditionId{};
+            memory::Opt<ConditionId> conditionId{};
 
             /// @brief Used to distinguish between repeat and condition nodes.
             bool isRepeat{false};
@@ -200,7 +200,7 @@ namespace cubos::core::ecs
         /// @brief Adds a new default constructed node to the schedule.
         /// @param repeatId Repeat node to become part of, if any.
         /// @return Node identifier, or nothing if the given repeat node is not a repeat node.
-        Opt<NodeId> node(Opt<NodeId> repeatId);
+        memory::Opt<NodeId> node(memory::Opt<NodeId> repeatId);
 
         /// @brief Runs a specific node.
         /// @param registry Registry containing the systems.
@@ -227,11 +227,11 @@ namespace cubos::core::ecs
         /// @brief Increments the satisfaction of nodes which depend on the given node, as it won't run.
         /// @param repeatId Identifier of the repeat group the condition which failed is in.
         /// @param nodeId Node identifier.
-        void skip(Opt<NodeId> repeatId, NodeId nodeId);
+        void skip(const memory::Opt<NodeId>& repeatId, NodeId nodeId);
 
         /// @brief Increments the satisfaction of the given node, if there's one.
         /// @param node Node identifier.
-        void incrementSatisfaction(Opt<NodeId> node);
+        void incrementSatisfaction(memory::Opt<NodeId> node);
 
         /// @brief Increments the satisfaction of all of the given nodes.
         /// @param nodes Node identifiers.

--- a/core/include/cubos/core/memory/opt.hpp
+++ b/core/include/cubos/core/memory/opt.hpp
@@ -1,6 +1,6 @@
 /// @file
-/// @brief Class @ref cubos::core::ecs::Opt.
-/// @ingroup core-ecs-query
+/// @brief Class @ref cubos::core::memory::Opt.
+/// @ingroup core-memory
 
 #pragma once
 
@@ -10,11 +10,11 @@
 #include <cubos/core/reflection/traits/nullable.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-namespace cubos::core::ecs
+namespace cubos::core::memory
 {
-    /// @brief Wrapper for reference types to indicate that the given argument type is optional in a query.
+    /// @brief Wrapper for reference types to indicate that the given argument type is optional.
     /// @tparam T Argument type.
-    /// @ingroup core-ecs-query
+    /// @ingroup core-memory
     template <typename T>
     class Opt
     {
@@ -190,14 +190,14 @@ namespace cubos::core::ecs
     private:
         T* mValue;
     };
-} // namespace cubos::core::ecs
+} // namespace cubos::core::memory
 
-CUBOS_REFLECT_TEMPLATE_IMPL((typename T), (cubos::core::ecs::Opt<T>))
+CUBOS_REFLECT_TEMPLATE_IMPL((typename T), (cubos::core::memory::Opt<T>))
 {
     using namespace cubos::core::reflection;
-    using cubos::core::ecs::Opt;
+    using cubos::core::memory::Opt;
 
-    return reflection::Type::create("cubos::core::ecs::Opt<" + reflect<T>().name() + ">")
+    return reflection::Type::create("cubos::core::memory::Opt<" + reflect<T>().name() + ">")
         .with(ConstructibleTrait::typed<Opt<T>>().withDefaultConstructor().withCopyConstructor().build())
         .with(NullableTrait{[](const void* obj) -> bool { return static_cast<const Opt<T>*>(obj)->contains(); },
                             [](void* obj) { static_cast<Opt<T>*>(obj)->reset(); }});

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -6,6 +6,7 @@
 #include <cubos/core/ecs/observer/observers.hpp>
 #include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/memory/opt.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/external/vector.hpp>
@@ -15,6 +16,7 @@ using cubos::core::ecs::Cubos;
 using cubos::core::ecs::DeltaTime;
 using cubos::core::ecs::Name;
 using cubos::core::ecs::ShouldQuit;
+using cubos::core::memory::Opt;
 
 CUBOS_REFLECT_IMPL(DeltaTime)
 {

--- a/core/src/ecs/query/opt.cpp
+++ b/core/src/ecs/query/opt.cpp
@@ -1,1 +1,0 @@
-#include <cubos/core/ecs/query/opt.hpp>

--- a/core/src/ecs/system/planner.cpp
+++ b/core/src/ecs/system/planner.cpp
@@ -4,6 +4,7 @@
 #include <cubos/core/reflection/external/primitives.hpp>
 
 using cubos::core::ecs::Planner;
+using cubos::core::memory::Opt;
 
 std::size_t Planner::TagId::Hash::operator()(const TagId& tagId) const
 {

--- a/core/src/ecs/system/schedule.cpp
+++ b/core/src/ecs/system/schedule.cpp
@@ -3,13 +3,14 @@
 #include <cubos/core/reflection/external/primitives.hpp>
 
 using cubos::core::ecs::Schedule;
+using cubos::core::memory::Opt;
 
 void Schedule::clear()
 {
     mNodes.clear();
 }
 
-auto Schedule::repeat(ConditionId conditionId, Opt<NodeId> repeatId) -> Opt<NodeId>
+auto Schedule::repeat(ConditionId conditionId, const Opt<NodeId>& repeatId) -> Opt<NodeId>
 {
     if (auto id = this->node(repeatId))
     {
@@ -21,7 +22,7 @@ auto Schedule::repeat(ConditionId conditionId, Opt<NodeId> repeatId) -> Opt<Node
     return {};
 }
 
-auto Schedule::system(SystemId systemId, Opt<NodeId> repeatId) -> Opt<NodeId>
+auto Schedule::system(SystemId systemId, const Opt<NodeId>& repeatId) -> Opt<NodeId>
 {
     if (auto id = this->node(repeatId))
     {
@@ -32,7 +33,7 @@ auto Schedule::system(SystemId systemId, Opt<NodeId> repeatId) -> Opt<NodeId>
     return {};
 }
 
-auto Schedule::condition(ConditionId conditionId, Opt<NodeId> repeatId) -> Opt<NodeId>
+auto Schedule::condition(ConditionId conditionId, const Opt<NodeId>& repeatId) -> Opt<NodeId>
 {
     if (auto id = this->node(repeatId))
     {
@@ -380,7 +381,7 @@ void Schedule::matchNodeDepths(NodeId& left, NodeId& right) const
     }
 }
 
-void Schedule::skip(Opt<NodeId> repeatId, NodeId nodeId)
+void Schedule::skip(const Opt<NodeId>& repeatId, NodeId nodeId)
 {
     auto& node = mNodes[nodeId.inner];
 

--- a/core/src/memory/opt.cpp
+++ b/core/src/memory/opt.cpp
@@ -1,0 +1,1 @@
+#include <cubos/core/memory/opt.hpp>

--- a/core/tests/ecs/query.cpp
+++ b/core/tests/ecs/query.cpp
@@ -5,6 +5,7 @@
 #include "utils.hpp"
 
 using namespace cubos::core::ecs;
+using namespace cubos::core::memory;
 
 template <typename... Ts>
 static std::size_t queryCount(World& world)

--- a/core/tests/ecs/system/schedule.cpp
+++ b/core/tests/ecs/system/schedule.cpp
@@ -2,11 +2,14 @@
 
 #include <cubos/core/ecs/command_buffer.hpp>
 #include <cubos/core/ecs/system/schedule.hpp>
+#include <cubos/core/memory/opt.hpp>
 #include <cubos/core/reflection/external/map.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/external/vector.hpp>
 
 #include "utils.hpp"
+
+using cubos::core::memory::Opt;
 
 static Schedule::NodeId validate(Opt<Schedule::NodeId> nodeId)
 {

--- a/engine/include/cubos/engine/prelude.hpp
+++ b/engine/include/cubos/engine/prelude.hpp
@@ -40,9 +40,9 @@ namespace cubos::engine
     /// @copydoc cubos::core::ecs::Commands
     using Commands = core::ecs::Commands;
 
-    /// @copydoc cubos::core::ecs::Opt
+    /// @copydoc cubos::core::memory::Opt
     template <typename T>
-    using Opt = core::ecs::Opt<T>;
+    using Opt = core::memory::Opt<T>;
 
     /// @copydoc cubos::core::ecs::EventReader
     template <typename T, unsigned int M = DEFAULT_FILTER_MASK>

--- a/engine/include/cubos/engine/render/defaults/target.hpp
+++ b/engine/include/cubos/engine/render/defaults/target.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <cubos/core/ecs/query/opt.hpp>
 #include <cubos/core/gl/render_device.hpp>
+#include <cubos/core/memory/opt.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
@@ -21,11 +21,11 @@
 #include <cubos/engine/render/target/target.hpp>
 #include <cubos/engine/render/tone_mapping/tone_mapping.hpp>
 
-namespace cubos::core::ecs
+namespace cubos::core::memory
 {
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::SplitScreen>;
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::Bloom>;
-} // namespace cubos::core::ecs
+} // namespace cubos::core::memory
 
 namespace cubos::engine
 {
@@ -63,9 +63,9 @@ namespace cubos::engine
         DeferredShading deferredShading{};
 
         /// @brief SplitScreen component.
-        core::ecs::Opt<SplitScreen> splitScreen{SplitScreen{}};
+        core::memory::Opt<SplitScreen> splitScreen{SplitScreen{}};
 
         /// @brief Bloom component.
-        core::ecs::Opt<Bloom> bloom{Bloom{}};
+        core::memory::Opt<Bloom> bloom{Bloom{}};
     };
 } // namespace cubos::engine

--- a/engine/src/render/defaults/target.cpp
+++ b/engine/src/render/defaults/target.cpp
@@ -3,8 +3,8 @@
 
 #include <cubos/engine/render/defaults/target.hpp>
 
-template class cubos::core::ecs::Opt<cubos::engine::SplitScreen>;
-template class cubos::core::ecs::Opt<cubos::engine::Bloom>;
+template class cubos::core::memory::Opt<cubos::engine::SplitScreen>;
+template class cubos::core::memory::Opt<cubos::engine::Bloom>;
 
 CUBOS_REFLECT_IMPL(cubos::engine::RenderTargetDefaults)
 {

--- a/tools/tesseratos/src/tesseratos/transform_gizmo/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/transform_gizmo/plugin.cpp
@@ -19,10 +19,10 @@
 
 using cubos::core::ecs::Entity;
 using cubos::core::ecs::EventReader;
-using cubos::core::ecs::Opt;
 using cubos::core::ecs::Query;
 using cubos::core::ecs::World;
 using cubos::core::io::Window;
+using cubos::core::memory::Opt;
 
 using cubos::engine::Cubos;
 using cubos::engine::Gizmos;

--- a/tools/tesseratos/src/tesseratos/world_inspector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/world_inspector/plugin.cpp
@@ -7,7 +7,7 @@
 #include <imgui.h>
 
 #include <cubos/core/ecs/name.hpp>
-#include <cubos/core/ecs/query/opt.hpp>
+#include <cubos/core/memory/opt.hpp>
 
 #include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/transform/child_of.hpp>


### PR DESCRIPTION
# Description

Move `Opt` class from `ecs` to `memory` namespace. 

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
- [ ] Write new samples.
- [X] Add entry to the changelog's unreleased section.
