### PR TITLE
Add core::gl::Timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin injection to the Cubos class (#1214, **@RiscadoA**).
 - Utility class used to load plugins from shared libraries (#1035, **@RiscadoA**).
 - Implemented metrics and profiling tools (#1150, **@roby2014**).
+- GL timer for profiling sections of rendering code (#1228, **@tomas7770**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/include/cubos/core/gl/render_device.hpp
+++ b/core/include/cubos/core/gl/render_device.hpp
@@ -77,6 +77,8 @@ namespace cubos::core::gl
         class ShaderStage;
         class ShaderPipeline;
         class ShaderBindingPoint;
+
+        class Timer;
     } // namespace impl
 
     /// @brief Handle to a framebuffer.
@@ -173,6 +175,11 @@ namespace cubos::core::gl
     /// @see @ref impl::ShaderBindingPoint - shader binding point interface.
     /// @ingroup core-gl
     using ShaderBindingPoint = impl::ShaderBindingPoint*;
+
+    /// @brief Handle to a timer.
+    /// @see @ref impl::Timer - timer interface.
+    /// @ingroup core-gl
+    using Timer = std::shared_ptr<impl::Timer>;
 
     /// @brief Render device properties that can be queried at runtime.
     /// @see @ref RenderDevice::getProperty().
@@ -876,6 +883,10 @@ namespace cubos::core::gl
         /// @param pipeline Shader pipeline handle.
         virtual void setShaderPipeline(ShaderPipeline pipeline) = 0;
 
+        /// @brief Creates a new timer.
+        /// @return Timer handle, or nullptr on failure.
+        virtual Timer createTimer() = 0;
+
         /// @brief Clears the color buffer bit on the current framebuffer to a specific color.
         /// @param r Red component.
         /// @param g Green component.
@@ -1453,6 +1464,34 @@ namespace cubos::core::gl
 
         protected:
             ShaderBindingPoint() = default;
+        };
+
+        /// @brief Abstract timer.
+        class CUBOS_CORE_API Timer
+        {
+        public:
+            virtual ~Timer() = default;
+
+            /// @brief Starts a region to be timed.
+            virtual void begin() = 0;
+
+            /// @brief Ends a region.
+            virtual void end() = 0;
+
+            /// @brief Checks if result is available.
+            /// @return Whether the result is available.
+            virtual bool done() = 0;
+
+            /// @brief Gets the result, in nanoseconds.
+            ///
+            /// Blocks until a result is available.
+            ///
+            /// @return Time spent in region, in nanoseconds, or -1 if an error
+            /// occurred while querying the time.
+            virtual int result() = 0;
+
+        protected:
+            Timer() = default;
         };
     } // namespace impl
 

--- a/core/src/gl/ogl_render_device.hpp
+++ b/core/src/gl/ogl_render_device.hpp
@@ -42,6 +42,7 @@ namespace cubos::core::gl
         ShaderPipeline createShaderPipeline(ShaderStage vs, ShaderStage ps) override;
         ShaderPipeline createShaderPipeline(ShaderStage vs, ShaderStage gs, ShaderStage ps) override;
         ShaderPipeline createShaderPipeline(ShaderStage cs) override;
+        Timer createTimer() override;
         void setShaderPipeline(ShaderPipeline pipeline) override;
         void clearColor(float r, float g, float b, float a) override;
         void clearTargetColor(std::size_t target, float r, float g, float b, float a) override;


### PR DESCRIPTION
# Description

Adds a Timer to RenderDevice, which exposes OpenGL queries to allow profiling sections of rendering code. Also adds an higher-level PipelinedTimer for profiling every frame asynchronously.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
