### PR TITLE
Track key combos instead of keys with modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move Opt class to memory namespace (#1212, **@roby2014**).
 - Moved from XPBD to TGS Soft for physics solving (#1269, **@fallenatlas**).
+- Allow arbitrary input combinations for actions and axes (#417, #1279, **@luishfonseca**)
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/include/cubos/core/io/keyboard.hpp
+++ b/core/include/cubos/core/io/keyboard.hpp
@@ -129,16 +129,6 @@ namespace cubos::core::io
         System = 8,
     };
 
-    /// @brief Keyboard key code and modifier flags.
-    /// @ingroup core-io
-    struct CUBOS_CORE_API KeyWithModifiers
-    {
-        CUBOS_REFLECT;
-
-        Key key;
-        Modifiers modifiers;
-    };
-
     inline Modifiers operator~(Modifiers mods)
     {
         return static_cast<Modifiers>(~static_cast<int>(mods));

--- a/core/include/cubos/core/io/window.hpp
+++ b/core/include/cubos/core/io/window.hpp
@@ -246,6 +246,11 @@ namespace cubos::core::io
         /// @return Whether the key and modifiers (or a superset of) are currently pressed.
         virtual bool pressed(Key key, Modifiers modifiers = Modifiers::None) const = 0;
 
+        /// @brief Checks if a mouse button is currently pressed.
+        /// @param button Mouse button to check.
+        /// @return Whether the mouse button is currently pressed.
+        virtual bool pressed(MouseButton button) const = 0;
+
         /// @brief Gets the state of the specified gamepad.
         /// @param gamepad Gamepad to get the state of.
         /// @param state State to fill with the gamepad state.

--- a/core/src/data/ser/debug.cpp
+++ b/core/src/data/ser/debug.cpp
@@ -4,6 +4,7 @@
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/array.hpp>
 #include <cubos/core/reflection/traits/dictionary.hpp>
+#include <cubos/core/reflection/traits/enum.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/traits/string_conversion.hpp>
 #include <cubos/core/reflection/type.hpp>
@@ -11,6 +12,7 @@
 using cubos::core::data::DebugSerializer;
 using cubos::core::reflection::ArrayTrait;
 using cubos::core::reflection::DictionaryTrait;
+using cubos::core::reflection::EnumTrait;
 using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::StringConversionTrait;
 using cubos::core::reflection::Type;
@@ -135,6 +137,13 @@ bool DebugSerializer::decompose(const Type& type, const void* value)
         mLevel -= 1;
         this->separate(true);
         mStream.put(']');
+    }
+    else if (type.has<EnumTrait>())
+    {
+        const auto& trait = type.get<EnumTrait>();
+        mStream.put('"');
+        mStream.print(trait.variant(value).name());
+        mStream.put('"');
     }
     else if (type.has<FieldsTrait>())
     {

--- a/core/src/data/ser/debug.cpp
+++ b/core/src/data/ser/debug.cpp
@@ -141,9 +141,7 @@ bool DebugSerializer::decompose(const Type& type, const void* value)
     else if (type.has<EnumTrait>())
     {
         const auto& trait = type.get<EnumTrait>();
-        mStream.put('"');
         mStream.print(trait.variant(value).name());
-        mStream.put('"');
     }
     else if (type.has<FieldsTrait>())
     {

--- a/core/src/io/glfw_window.cpp
+++ b/core/src/io/glfw_window.cpp
@@ -22,6 +22,7 @@ static void charCallback(GLFWwindow* window, unsigned int codepoint);
 static void joystickCallback(int id, int event);
 static void updateMods(GLFWWindow* handler, int glfwMods);
 static MouseButton glfwToCubosMouseButton(int button);
+static int cubosToGlfwMouseButton(MouseButton key);
 static Key glfwToCubosKey(int key);
 static int cubosToGlfwKey(Key key);
 
@@ -344,6 +345,15 @@ bool GLFWWindow::pressed(Key key, Modifiers modifiers) const
 #endif
 }
 
+bool GLFWWindow::pressed(MouseButton button) const
+{
+#ifdef WITH_GLFW
+    return glfwGetMouseButton(mHandle, cubosToGlfwMouseButton(button)) == GLFW_PRESS;
+#else
+    UNSUPPORTED();
+#endif
+}
+
 Modifiers GLFWWindow::modifiers() const
 {
 #ifdef WITH_GLFW
@@ -495,6 +505,24 @@ static MouseButton glfwToCubosMouseButton(int button)
         MAP_BUTTON(5, Extra2)
     default:
         return MouseButton::Invalid;
+    }
+#undef MAP_BUTTON
+}
+
+static int cubosToGlfwMouseButton(MouseButton button)
+{
+#define MAP_BUTTON(cubos, glfw)                                                                                        \
+    case MouseButton::cubos:                                                                                           \
+        return GLFW_MOUSE_BUTTON_##glfw;
+    switch (button)
+    {
+        MAP_BUTTON(Left, LEFT)
+        MAP_BUTTON(Right, RIGHT)
+        MAP_BUTTON(Middle, MIDDLE)
+        MAP_BUTTON(Extra1, 4)
+        MAP_BUTTON(Extra2, 5)
+    default:
+        return GLFW_MOUSE_BUTTON_LAST;
     }
 #undef MAP_BUTTON
 }

--- a/core/src/io/glfw_window.cpp
+++ b/core/src/io/glfw_window.cpp
@@ -22,7 +22,7 @@ static void charCallback(GLFWwindow* window, unsigned int codepoint);
 static void joystickCallback(int id, int event);
 static void updateMods(GLFWWindow* handler, int glfwMods);
 static MouseButton glfwToCubosMouseButton(int button);
-static int cubosToGlfwMouseButton(MouseButton key);
+static int cubosToGlfwMouseButton(MouseButton button);
 static Key glfwToCubosKey(int key);
 static int cubosToGlfwKey(Key key);
 

--- a/core/src/io/glfw_window.hpp
+++ b/core/src/io/glfw_window.hpp
@@ -42,6 +42,7 @@ namespace cubos::core::io
         const char* clipboard() const override;
         Modifiers modifiers() const override;
         bool pressed(Key key, Modifiers modifiers = Modifiers::None) const override;
+        bool pressed(MouseButton button) const override;
         bool gamepadState(int gamepad, GamepadState& state) const override;
 
         void modifiers(Modifiers modifiers);

--- a/core/src/io/keyboard.cpp
+++ b/core/src/io/keyboard.cpp
@@ -2,18 +2,13 @@
 #include <cubos/core/log.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/traits/enum.hpp>
-#include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/traits/mask.hpp>
-#include <cubos/core/reflection/traits/string_conversion.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 using cubos::core::io::Key;
-using cubos::core::io::KeyWithModifiers;
 using cubos::core::io::Modifiers;
 using cubos::core::reflection::EnumTrait;
-using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::MaskTrait;
-using cubos::core::reflection::StringConversionTrait;
 using cubos::core::reflection::Type;
 
 CUBOS_REFLECT_EXTERNAL_IMPL(Key)
@@ -132,58 +127,4 @@ CUBOS_REFLECT_EXTERNAL_IMPL(Modifiers)
                   .withBit<Modifiers::Shift>("Shift")
                   .withBit<Modifiers::Alt>("Alt")
                   .withBit<Modifiers::System>("System"));
-}
-
-CUBOS_REFLECT_IMPL(KeyWithModifiers)
-{
-    return Type::create("cubos::core::io::KeyWithModifiers")
-        .with(StringConversionTrait{[](const void* instance) {
-                                        const auto* keyWithMods = static_cast<const KeyWithModifiers*>(instance);
-                                        const auto& modsMask = reflection::reflect<Modifiers>().get<MaskTrait>();
-
-                                        std::string string;
-                                        for (const auto& bit : modsMask.view(&keyWithMods->modifiers))
-                                        {
-                                            string += bit.name() + '-';
-                                        }
-                                        string += EnumTrait::toString(keyWithMods->key);
-                                        return string;
-                                    },
-                                    [](void* instance, const std::string& string) {
-                                        auto* keyWithMods = static_cast<KeyWithModifiers*>(instance);
-                                        const auto& modsMask = reflection::reflect<Modifiers>().get<MaskTrait>();
-
-                                        keyWithMods->modifiers = Modifiers::None;
-                                        std::size_t cursor = 0;
-                                        for (;;)
-                                        {
-                                            auto nextCursor = string.find_first_of('-', cursor + 1);
-                                            if (nextCursor == std::string::npos)
-                                            {
-                                                break;
-                                            }
-                                            nextCursor += 1;
-
-                                            auto modifier = string.substr(cursor, nextCursor - cursor - 1);
-                                            if (!modsMask.contains(modifier))
-                                            {
-                                                CUBOS_WARN("No such keyboard modifier {}", modifier);
-                                                return false;
-                                            }
-
-                                            modsMask.at(modifier).set(&keyWithMods->modifiers);
-                                            cursor = nextCursor;
-                                        }
-
-                                        if (!EnumTrait::fromString(keyWithMods->key, string.substr(cursor)))
-                                        {
-                                            CUBOS_WARN("No such keyboard key code {}", string.substr(cursor));
-                                            return false;
-                                        }
-
-                                        return true;
-                                    }})
-        .with(FieldsTrait{}
-                  .withField("key", &KeyWithModifiers::key)
-                  .withField("modifiers", &KeyWithModifiers::modifiers));
 }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -85,6 +85,7 @@ set(CUBOS_ENGINE_SOURCE
 
 	"src/input/plugin.cpp"
 	"src/input/input.cpp"
+	"src/input/combination.cpp"
 	"src/input/bindings.cpp"
 	"src/input/action.cpp"
 	"src/input/axis.cpp"

--- a/engine/include/cubos/engine/input/action.hpp
+++ b/engine/include/cubos/engine/input/action.hpp
@@ -6,18 +6,16 @@
 
 #include <vector>
 
-#include <cubos/core/io/gamepad.hpp>
-#include <cubos/core/io/keyboard.hpp>
-#include <cubos/core/io/window.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
+#include <cubos/engine/input/combination.hpp>
 
 namespace cubos::engine
 {
     /// @brief Stores the state of a single input action, such as "jump" or "attack".
     ///
-    /// Can be bound to multiple keys, and will be considered "pressed" if any of them are pressed.
+    /// Can be bound to multiple key combinations, and will be considered "pressed" if any of them are pressed.
     ///
     /// @ingroup input-plugin
     class CUBOS_ENGINE_API InputAction final
@@ -31,40 +29,19 @@ namespace cubos::engine
         InputAction() = default;
 
         /// @brief Constructs with existing bindings.
-        /// @param keys Key bindings.
-        /// @param gamepadButtons Gamepad button bindings.
-        /// @param mouseButtons Mouse button bindings.
-        InputAction(std::vector<core::io::Key> keys, std::vector<core::io::GamepadButton> gamepadButtons,
-                    std::vector<core::io::MouseButton> mouseButtons)
-            : mKeys(std::move(keys))
-            , mGamepadButtons(std::move(gamepadButtons))
-            , mMouseButtons(std::move(mouseButtons))
+        /// @param combinations Combinations to bind.
+        InputAction(std::vector<InputCombination> combinations)
+            : mCombinations(std::move(combinations))
         {
         }
 
-        /// @brief Gets the key bindings.
-        /// @return Vector of keys.
-        const std::vector<core::io::Key>& keys() const;
+        /// @brief Gets the bound combinations.
+        /// @return Vector of combinations.
+        const std::vector<InputCombination>& combinations() const;
 
-        /// @brief Gets the key bindings.
-        /// @return Vector of keys.
-        std::vector<core::io::Key>& keys();
-
-        /// @brief Gets the gamepad button bindings.
-        /// @return Vector of buttons.
-        const std::vector<core::io::GamepadButton>& gamepadButtons() const;
-
-        /// @brief Gets the gamepad button bindings.
-        /// @return Vector of buttons.
-        std::vector<core::io::GamepadButton>& gamepadButtons();
-
-        /// @brief Gets the mouse button bindings.
-        /// @return Vector of buttons.
-        const std::vector<core::io::MouseButton>& mouseButtons() const;
-
-        /// @brief Gets the mouse button bindings.
-        /// @return Vector of buttons.
-        std::vector<core::io::MouseButton>& mouseButtons();
+        /// @brief Gets the bound combinations.
+        /// @return Vector of combinations.
+        std::vector<InputCombination>& combinations();
 
         /// @brief Checks if this action is pressed.
         /// @return Whether this action is pressed.
@@ -91,9 +68,7 @@ namespace cubos::engine
         void justReleased(bool justReleased);
 
     private:
-        std::vector<core::io::Key> mKeys;
-        std::vector<core::io::GamepadButton> mGamepadButtons;
-        std::vector<core::io::MouseButton> mMouseButtons;
+        std::vector<InputCombination> mCombinations;
 
         bool mPressed;      ///< Not serialized.
         bool mJustPressed;  ///< Not serialized.

--- a/engine/include/cubos/engine/input/action.hpp
+++ b/engine/include/cubos/engine/input/action.hpp
@@ -44,15 +44,15 @@ namespace cubos::engine
         std::vector<InputCombination>& combinations();
 
         /// @brief Checks if this action is pressed.
-        /// @return Whether this action is pressed.
+        /// @return Sets whether this action is pressed.
         bool pressed() const;
 
         /// @brief Checks if this action was just pressed.
-        /// @return Whether this action was just pressed.
+        /// @return Sets whether this action was just pressed.
         bool justPressed() const;
 
         /// @brief Checks if this action was just released.
-        /// @return Whether this action was just released.
+        /// @return Sets whether this action was just released.
         bool justReleased() const;
 
         /// @brief Sets whether this action is pressed.

--- a/engine/include/cubos/engine/input/action.hpp
+++ b/engine/include/cubos/engine/input/action.hpp
@@ -34,7 +34,7 @@ namespace cubos::engine
         /// @param keys Key bindings.
         /// @param gamepadButtons Gamepad button bindings.
         /// @param mouseButtons Mouse button bindings.
-        InputAction(std::vector<core::io::KeyWithModifiers> keys, std::vector<core::io::GamepadButton> gamepadButtons,
+        InputAction(std::vector<core::io::Key> keys, std::vector<core::io::GamepadButton> gamepadButtons,
                     std::vector<core::io::MouseButton> mouseButtons)
             : mKeys(std::move(keys))
             , mGamepadButtons(std::move(gamepadButtons))
@@ -44,11 +44,11 @@ namespace cubos::engine
 
         /// @brief Gets the key bindings.
         /// @return Vector of keys.
-        const std::vector<core::io::KeyWithModifiers>& keys() const;
+        const std::vector<core::io::Key>& keys() const;
 
         /// @brief Gets the key bindings.
         /// @return Vector of keys.
-        std::vector<core::io::KeyWithModifiers>& keys();
+        std::vector<core::io::Key>& keys();
 
         /// @brief Gets the gamepad button bindings.
         /// @return Vector of buttons.
@@ -86,12 +86,12 @@ namespace cubos::engine
         /// @param justPressed Whether this action was just pressed.
         void justPressed(bool justPressed);
 
-        /// @brief Checks if this accion was just released.
+        /// @brief Checks if this action was just released.
         /// @param justReleased Whether this action was just released.
         void justReleased(bool justReleased);
 
     private:
-        std::vector<core::io::KeyWithModifiers> mKeys;
+        std::vector<core::io::Key> mKeys;
         std::vector<core::io::GamepadButton> mGamepadButtons;
         std::vector<core::io::MouseButton> mMouseButtons;
 

--- a/engine/include/cubos/engine/input/axis.hpp
+++ b/engine/include/cubos/engine/input/axis.hpp
@@ -31,8 +31,8 @@ namespace cubos::engine
         InputAxis() = default;
 
         /// @brief Constructs with existing bindings.
-        /// @param positive Positive key bindings.
-        /// @param negative Negative key bindings.
+        /// @param positive Positive input combinations.
+        /// @param negative Negative input combinations.
         /// @param gamepadAxes Gamepad axis bindings.
         InputAxis(std::vector<InputCombination> positive, std::vector<InputCombination> negative,
                   std::vector<core::io::GamepadAxis> gamepadAxes)
@@ -42,24 +42,24 @@ namespace cubos::engine
         {
         }
 
-        /// @brief Gets the positive key bindings.
-        /// @return Vector of positive keys.
+        /// @brief Gets the positive input combinations.
+        /// @return Vector of positive input combinations.
         const std::vector<InputCombination>& positive() const;
 
-        /// @brief Gets the negative key bindings.
-        /// @return Vector of negative keys.
+        /// @brief Gets the negative input combinations.
+        /// @return Vector of negative input combinations.
         const std::vector<InputCombination>& negative() const;
 
         /// @brief Gets the gamepad axis bindings.
         /// @return Vector of gamepad axes.
         const std::vector<core::io::GamepadAxis>& gamepadAxes() const;
 
-        /// @brief Gets the positive key bindings.
-        /// @return Vector of positive keys.
+        /// @brief Gets the positive input combinations.
+        /// @return Vector of positive input combinations.
         std::vector<InputCombination>& positive();
 
-        /// @brief Gets the negative key bindings.
-        /// @return Vector of negative keys.
+        /// @brief Gets the negative input combinations.
+        /// @return Vector of negative input combinations.
         std::vector<InputCombination>& negative();
 
         /// @brief Gets the gamepad axis bindings.

--- a/engine/include/cubos/engine/input/axis.hpp
+++ b/engine/include/cubos/engine/input/axis.hpp
@@ -7,10 +7,10 @@
 #include <vector>
 
 #include <cubos/core/io/gamepad.hpp>
-#include <cubos/core/io/keyboard.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
+#include <cubos/engine/input/combination.hpp>
 
 namespace cubos::engine
 {
@@ -34,7 +34,7 @@ namespace cubos::engine
         /// @param positive Positive key bindings.
         /// @param negative Negative key bindings.
         /// @param gamepadAxes Gamepad axis bindings.
-        InputAxis(std::vector<core::io::Key> positive, std::vector<core::io::Key> negative,
+        InputAxis(std::vector<InputCombination> positive, std::vector<InputCombination> negative,
                   std::vector<core::io::GamepadAxis> gamepadAxes)
             : mPositive(std::move(positive))
             , mNegative(std::move(negative))
@@ -44,11 +44,11 @@ namespace cubos::engine
 
         /// @brief Gets the positive key bindings.
         /// @return Vector of positive keys.
-        const std::vector<core::io::Key>& positive() const;
+        const std::vector<InputCombination>& positive() const;
 
         /// @brief Gets the negative key bindings.
         /// @return Vector of negative keys.
-        const std::vector<core::io::Key>& negative() const;
+        const std::vector<InputCombination>& negative() const;
 
         /// @brief Gets the gamepad axis bindings.
         /// @return Vector of gamepad axes.
@@ -56,11 +56,11 @@ namespace cubos::engine
 
         /// @brief Gets the positive key bindings.
         /// @return Vector of positive keys.
-        std::vector<core::io::Key>& positive();
+        std::vector<InputCombination>& positive();
 
         /// @brief Gets the negative key bindings.
         /// @return Vector of negative keys.
-        std::vector<core::io::Key>& negative();
+        std::vector<InputCombination>& negative();
 
         /// @brief Gets the gamepad axis bindings.
         /// @return Vector of gamepad axes.
@@ -75,8 +75,8 @@ namespace cubos::engine
         void value(float value);
 
     private:
-        std::vector<core::io::Key> mPositive;
-        std::vector<core::io::Key> mNegative;
+        std::vector<InputCombination> mPositive;
+        std::vector<InputCombination> mNegative;
         std::vector<core::io::GamepadAxis> mGamepadAxes;
 
         float mValue{0.0F}; ///< Not serialized.

--- a/engine/include/cubos/engine/input/axis.hpp
+++ b/engine/include/cubos/engine/input/axis.hpp
@@ -34,7 +34,7 @@ namespace cubos::engine
         /// @param positive Positive key bindings.
         /// @param negative Negative key bindings.
         /// @param gamepadAxes Gamepad axis bindings.
-        InputAxis(std::vector<core::io::KeyWithModifiers> positive, std::vector<core::io::KeyWithModifiers> negative,
+        InputAxis(std::vector<core::io::Key> positive, std::vector<core::io::Key> negative,
                   std::vector<core::io::GamepadAxis> gamepadAxes)
             : mPositive(std::move(positive))
             , mNegative(std::move(negative))
@@ -44,11 +44,11 @@ namespace cubos::engine
 
         /// @brief Gets the positive key bindings.
         /// @return Vector of positive keys.
-        const std::vector<core::io::KeyWithModifiers>& positive() const;
+        const std::vector<core::io::Key>& positive() const;
 
         /// @brief Gets the negative key bindings.
         /// @return Vector of negative keys.
-        const std::vector<core::io::KeyWithModifiers>& negative() const;
+        const std::vector<core::io::Key>& negative() const;
 
         /// @brief Gets the gamepad axis bindings.
         /// @return Vector of gamepad axes.
@@ -56,11 +56,11 @@ namespace cubos::engine
 
         /// @brief Gets the positive key bindings.
         /// @return Vector of positive keys.
-        std::vector<core::io::KeyWithModifiers>& positive();
+        std::vector<core::io::Key>& positive();
 
         /// @brief Gets the negative key bindings.
         /// @return Vector of negative keys.
-        std::vector<core::io::KeyWithModifiers>& negative();
+        std::vector<core::io::Key>& negative();
 
         /// @brief Gets the gamepad axis bindings.
         /// @return Vector of gamepad axes.
@@ -75,8 +75,8 @@ namespace cubos::engine
         void value(float value);
 
     private:
-        std::vector<core::io::KeyWithModifiers> mPositive;
-        std::vector<core::io::KeyWithModifiers> mNegative;
+        std::vector<core::io::Key> mPositive;
+        std::vector<core::io::Key> mNegative;
         std::vector<core::io::GamepadAxis> mGamepadAxes;
 
         float mValue{0.0F}; ///< Not serialized.

--- a/engine/include/cubos/engine/input/combination.hpp
+++ b/engine/include/cubos/engine/input/combination.hpp
@@ -67,8 +67,8 @@ namespace cubos::engine
         std::vector<core::io::MouseButton>& mouseButtons();
 
         /// @brief Checks if the key combination is pressed.
-        /// @param window The window to check for key and mouse button presses.
-        /// @param gamepad The gamepad to check for button presses.
+        /// @param window Window to check for key and mouse button presses.
+        /// @param gamepad Gamepad to check for button presses.
         /// @return Whether the key combination is pressed
         bool pressed(const core::io::Window& window, const core::io::GamepadState* gamepad) const;
 

--- a/engine/include/cubos/engine/input/combination.hpp
+++ b/engine/include/cubos/engine/input/combination.hpp
@@ -1,0 +1,81 @@
+/// @file
+/// @brief Class @ref cubos::engine::InputCombination.
+/// @ingroup input-plugin
+
+#pragma once
+
+#include <vector>
+
+#include <cubos/core/io/gamepad.hpp>
+#include <cubos/core/io/keyboard.hpp>
+#include <cubos/core/io/window.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Stores the keys, gamepad buttons, and mouse buttons of a single input combination.
+    ///
+    /// Composed of multiple keys and buttons, and will be considered "pressed" if all of them are pressed.
+    ///
+    /// @ingroup input-plugin
+    class CUBOS_ENGINE_API InputCombination final
+    {
+    public:
+        CUBOS_REFLECT;
+
+        ~InputCombination() = default;
+
+        /// @brief Constructs without any keys or buttons.
+        InputCombination() = default;
+
+        /// @brief Constructs from sets of keys, gamepad buttons, and mouse buttons.
+        /// @param keys Keys to be pressed.
+        /// @param gamepadButtons Gamepad buttons to be pressed.
+        /// @param mouseButtons Mouse buttons to be pressed.
+        InputCombination(std::vector<core::io::Key> keys, std::vector<core::io::GamepadButton> gamepadButtons,
+                         std::vector<core::io::MouseButton> mouseButtons)
+            : mKeys(std::move(keys))
+            , mGamepadButtons(std::move(gamepadButtons))
+            , mMouseButtons(std::move(mouseButtons))
+        {
+        }
+
+        /// @brief Gets the keys to be pressed.
+        /// @return Vector of keys.
+        const std::vector<core::io::Key>& keys() const;
+
+        /// @brief Gets the keys to be pressed.
+        /// @return Vector of keys.
+        std::vector<core::io::Key>& keys();
+
+        /// @brief Gets the gamepad buttons to be pressed.
+        /// @return Vector of buttons.
+        const std::vector<core::io::GamepadButton>& gamepadButtons() const;
+
+        /// @brief Gets the gamepad buttons to be pressed.
+        /// @return Vector of buttons.
+        std::vector<core::io::GamepadButton>& gamepadButtons();
+
+        /// @brief Gets the mouse buttons to be pressed.
+        /// @return Vector of buttons.
+        const std::vector<core::io::MouseButton>& mouseButtons() const;
+
+        /// @brief Gets the mouse buttons to be pressed.
+        /// @return Vector of buttons.
+        std::vector<core::io::MouseButton>& mouseButtons();
+
+        /// @brief Checks if the key combination is pressed.
+        /// @param window The window to check for key and mouse button presses.
+        /// @param gamepad The gamepad to check for button presses.
+        /// @return Whether the key combination is pressed
+        bool pressed(const core::io::Window& window, const core::io::GamepadState* gamepad) const;
+
+    private:
+        std::vector<core::io::Key> mKeys;                     ///< Keys to be pressed.
+        std::vector<core::io::GamepadButton> mGamepadButtons; ///< Gamepad buttons to be pressed.
+        std::vector<core::io::MouseButton> mMouseButtons;     ///< Mouse buttons to be pressed.
+    };
+
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/input/combination.hpp
+++ b/engine/include/cubos/engine/input/combination.hpp
@@ -34,8 +34,8 @@ namespace cubos::engine
         /// @param keys Keys to be pressed.
         /// @param gamepadButtons Gamepad buttons to be pressed.
         /// @param mouseButtons Mouse buttons to be pressed.
-        InputCombination(std::vector<core::io::Key> keys, std::vector<core::io::GamepadButton> gamepadButtons,
-                         std::vector<core::io::MouseButton> mouseButtons)
+        InputCombination(std::vector<core::io::Key> keys, std::vector<core::io::GamepadButton> gamepadButtons = {},
+                         std::vector<core::io::MouseButton> mouseButtons = {})
             : mKeys(std::move(keys))
             , mGamepadButtons(std::move(gamepadButtons))
             , mMouseButtons(std::move(mouseButtons))

--- a/engine/include/cubos/engine/input/input.hpp
+++ b/engine/include/cubos/engine/input/input.hpp
@@ -154,14 +154,13 @@ namespace cubos::engine
 
         static bool anyPressed(const core::io::Window& window, const std::vector<core::io::Key>& keys);
         bool anyPressed(int player, const std::vector<GamepadButton>& buttons) const;
-        bool anyPressed(const std::vector<MouseButton>& buttons);
+        bool anyPressed(const core::io::Window& window, const std::vector<MouseButton>& buttons);
         void handleActions(const core::io::Window& window, const std::vector<BindingIndex>& boundActions);
         void handleAxes(const core::io::Window& window, const std::vector<BindingIndex>& boundAxes);
 
         std::unordered_map<int, InputBindings> mPlayerBindings;
         std::unordered_map<int, int> mPlayerGamepads;
         std::unordered_map<int, core::io::GamepadState> mGamepadStates;
-        std::unordered_map<MouseButton, bool> mPressedMouseButtons;
 
         std::unordered_map<Key, std::vector<BindingIndex>> mBoundActions;
         std::unordered_map<Key, std::vector<BindingIndex>> mBoundAxes;

--- a/engine/include/cubos/engine/input/input.hpp
+++ b/engine/include/cubos/engine/input/input.hpp
@@ -23,9 +23,6 @@ namespace cubos::engine
         /// @brief Alias for @ref core::io::Key.
         using Key = core::io::Key;
 
-        /// @brief Alias for @ref core::io::Modifiers.
-        using Modifiers = core::io::Modifiers;
-
         /// @brief Alias for @ref core::io::GamepadButton.
         using GamepadButton = core::io::GamepadButton;
 
@@ -155,7 +152,7 @@ namespace cubos::engine
             bool negative = false; ///< Whether the pressed key is a negative axis key.
         };
 
-        static bool anyPressed(const core::io::Window& window, const std::vector<core::io::KeyWithModifiers>& keys);
+        static bool anyPressed(const core::io::Window& window, const std::vector<core::io::Key>& keys);
         bool anyPressed(int player, const std::vector<GamepadButton>& buttons) const;
         bool anyPressed(const std::vector<MouseButton>& buttons);
         void handleActions(const core::io::Window& window, const std::vector<BindingIndex>& boundActions);

--- a/engine/include/cubos/engine/input/input.hpp
+++ b/engine/include/cubos/engine/input/input.hpp
@@ -152,9 +152,8 @@ namespace cubos::engine
             bool negative = false; ///< Whether the pressed key is a negative axis key.
         };
 
-        static bool anyPressed(const core::io::Window& window, const std::vector<core::io::Key>& keys);
-        bool anyPressed(int player, const std::vector<GamepadButton>& buttons) const;
-        bool anyPressed(const core::io::Window& window, const std::vector<MouseButton>& buttons);
+        bool anyPressed(int player, const core::io::Window& window,
+                        const std::vector<InputCombination>& combinations) const;
         void handleActions(const core::io::Window& window, const std::vector<BindingIndex>& boundActions);
         void handleAxes(const core::io::Window& window, const std::vector<BindingIndex>& boundAxes);
 
@@ -162,11 +161,13 @@ namespace cubos::engine
         std::unordered_map<int, int> mPlayerGamepads;
         std::unordered_map<int, core::io::GamepadState> mGamepadStates;
 
-        std::unordered_map<Key, std::vector<BindingIndex>> mBoundActions;
-        std::unordered_map<Key, std::vector<BindingIndex>> mBoundAxes;
-        std::unordered_map<GamepadButton, std::vector<BindingIndex>> mBoundGamepadActions;
+        std::unordered_map<Key, std::vector<BindingIndex>> mBoundKeyActions;
+        std::unordered_map<GamepadButton, std::vector<BindingIndex>> mBoundGamepadButtonActions;
+        std::unordered_map<MouseButton, std::vector<BindingIndex>> mBoundMouseButtonActions;
+        std::unordered_map<Key, std::vector<BindingIndex>> mBoundKeyAxes;
+        std::unordered_map<GamepadButton, std::vector<BindingIndex>> mBoundGamepadButtonAxes;
+        std::unordered_map<MouseButton, std::vector<BindingIndex>> mBoundMouseButtonAxes;
         std::unordered_map<GamepadAxis, std::vector<BindingIndex>> mBoundGamepadAxes;
-        std::unordered_map<MouseButton, std::vector<BindingIndex>> mBoundMouseActions;
 
         glm::ivec2 mMousePosition = {0, 0};
         glm::ivec2 mPreviousMousePosition = {0, 0};

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -70,7 +70,7 @@ int main()
     cubos.startupSystem("setup input").call([](Input& input) {
         // Add procedural asset for detecting a reset action on a space key press.
         auto bindings = InputBindings{};
-        bindings.actions()["reset"].keys().push_back({Key::Space, Modifiers::None});
+        bindings.actions()["reset"].combinations().emplace_back(std::vector<Key>{Key::Space});
         input.bind(bindings);
     });
 

--- a/engine/samples/games/cubosurfers/assets/input.bind
+++ b/engine/samples/games/cubosurfers/assets/input.bind
@@ -1,21 +1,15 @@
 {
     "actions": {
-        "left": {
-            "keys": [
-                "A",
-                "Left"
-            ]
-        },
-        "right": {
-            "keys": [
-                "D",
-                "Right"
-            ]
-        },
-        "restart": {
-            "keys": [
-                "R"
-            ]
-        }
+        "left": [
+            {"keys": ["A"]},
+            {"keys": ["Left"]}
+        ],
+        "right": [
+            {"keys": ["D"]},
+            {"keys": ["Right"]}
+        ],
+        "restart": [
+            {"keys": ["R"]}
+        ]
     }
 }

--- a/engine/samples/input/assets/sample.bind
+++ b/engine/samples/input/assets/sample.bind
@@ -1,50 +1,46 @@
 {
     "actions": {
-        "next-showcase": {
-            "keys": [
-                "Return"
-            ],
-            "gamepadButtons": [
-                "RBumper"
-            ]
-        },
-        "x-or-z": {
-            "keys": [
-                "X",
-                "Z"
-            ]
-        },
-        "left-mb": {
-            "mouseButtons": [
-                "Left"
-            ]
-        },
-        "right-mb": {
-            "mouseButtons": [
-                "Right"
-            ]
-        },
-        "middle-mb": {
-            "mouseButtons": [
-                "Middle"
-            ]
-        },
-        "extra-mb": {
-            "mouseButtons": [
-                "Extra1",
-                "Extra2"
-            ]
-        }
+        "next-showcase": [
+            {"keys": ["Return"]},
+            {"gamepadButtons": ["RBumper"]}
+        ],
+        "x-or-z": [
+            {"keys": ["X"]},
+            {"keys": ["Z"]}
+        ],
+        "shift-space": [
+            {"keys": ["LShift", "Space"]},
+            {"keys": ["RShift", "Space"]}
+        ],
+        "ctrl-shift-space": [
+            {"keys": ["LControl", "LShift", "Space"]},
+            {"keys": ["LControl", "RShift", "Space"]},
+            {"keys": ["RControl", "LShift", "Space"]},
+            {"keys": ["RControl", "RShift", "Space"]}
+        ],
+        "left-mb": [
+            {"mouseButtons": ["Left"]}
+        ],
+        "right-mb": [
+            {"mouseButtons": ["Right"]}
+        ],
+        "middle-mb": [
+            {"mouseButtons": ["Middle"]}
+        ],
+        "extra-mb": [
+            {"mouseButtons": ["Extra1"]},
+            {"mouseButtons": ["Extra2"]}
+        ]
     },
     "axes": {
         "vertical": {
             "positive": [
-                "W",
-                "Up"
+                {"keys": ["W"]},
+                {"keys": ["Up"]}
             ],
             "negative": [
-                "S",
-                "Down"
+                {"keys": ["S"]},
+                {"keys": ["Down"]}
             ],
             "gamepadAxes": [
                 "LY"
@@ -52,15 +48,43 @@
         },
         "horizontal": {
             "positive": [
-                "D",
-                "Right"
+                {"keys": ["D"]},
+                {"keys": ["Right"]}
             ],
             "negative": [
-                "A",
-                "Left"
+                {"keys": ["A"]},
+                {"keys": ["Left"]}
             ],
             "gamepadAxes": [
                 "LX"
+            ]
+        },
+        "shift-vertical": {
+            "positive": [
+                {"keys": ["LShift", "W"]},
+                {"keys": ["LShift", "Up"]},
+                {"keys": ["RShift", "W"]},
+                {"keys": ["RShift", "Up"]}
+            ],
+            "negative": [
+                {"keys": ["LShift", "S"]},
+                {"keys": ["LShift", "Down"]},
+                {"keys": ["RShift", "S"]},
+                {"keys": ["RShift", "Down"]}
+            ]
+        },
+        "shift-horizontal": {
+            "positive": [
+                {"keys": ["LShift", "D"]},
+                {"keys": ["LShift", "Right"]},
+                {"keys": ["RShift", "D"]},
+                {"keys": ["RShift", "Right"]}
+            ],
+            "negative": [
+                {"keys": ["LShift", "A"]},
+                {"keys": ["LShift", "Left"]},
+                {"keys": ["RShift", "A"]},
+                {"keys": ["RShift", "Left"]}
             ]
         }
     }

--- a/engine/samples/input/assets/sample.bind
+++ b/engine/samples/input/assets/sample.bind
@@ -14,16 +14,6 @@
                 "Z"
             ]
         },
-        "shift-space": {
-            "keys": [
-                "Shift-Space"
-            ]
-        },
-        "ctrl-shift-space": {
-            "keys": [
-                "Control-Shift-Space"
-            ]
-        },
         "left-mb": {
             "mouseButtons": [
                 "Left"
@@ -72,17 +62,6 @@
             "gamepadAxes": [
                 "LX"
             ]
-        },
-        "shift-vertical": {
-            "positive": [
-                "Shift-W",
-                "Shift-Up"
-            ],
-            "negative": [
-                "Shift-S",
-                "Shift-Down"
-            ],
-            "gamepadAxes": []
         }
     }
 }

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -69,6 +69,39 @@ static void showcaseJustXZ(const Input& input, bool& explained)
 }
 
 /// [Showcase Action Press]
+/// [Showcase Modifier]
+static void showcaseModifiers(const Input& input, bool& explained)
+{
+    if (!explained)
+    {
+        CUBOS_WARN("Modifiers are supported. This showcase will print `Shift` when Shift+Space is pressed. "
+                   "Press Enter to advance to the next showcase.");
+        explained = true;
+    }
+
+    if (input.pressed("shift-space"))
+    {
+        CUBOS_INFO("Shift");
+    }
+}
+/// [Showcase Modifier]
+
+/// [Showcase Multi Modifier]
+static void showcaseMultipleModifiers(const Input& input, bool& explained)
+{
+    if (!explained)
+    {
+        CUBOS_WARN("Multiple modifiers are supported. This showcase will print `Ctrl Shift` when Ctrl+Shift+Space is "
+                   "pressed. Press Enter to advance to the next showcase.");
+        explained = true;
+    }
+
+    if (input.pressed("ctrl-shift-space"))
+    {
+        CUBOS_INFO("Ctrl Shift");
+    }
+}
+/// [Showcase Multi Modifier]
 
 /// [Showcase Axis]
 static void showcaseAxis(const Input& input, bool& explained)
@@ -87,6 +120,25 @@ static void showcaseAxis(const Input& input, bool& explained)
     }
 }
 /// [Showcase Axis]
+
+/// [Showcase Modifier Axis]
+static void showcaseModifierAxis(const Input& input, bool& explained)
+{
+    if (!explained)
+    {
+        CUBOS_WARN("Modifiers are supported with axis. This showcase will print the value of the `shift-vertical` axis "
+                   "when its value is different to 0. Use Shift+arrows and Shift+WASD to move the axis. Press Enter to "
+                   "advance to the next showcase.");
+        explained = true;
+    }
+
+    if (input.axis("shift-horizontal") != 0.0F || input.axis("shift-vertical") != 0.0F)
+    {
+        CUBOS_INFO("shift-horizontal: {}, shift-vertical: {}", input.axis("shift-horizontal"),
+                   input.axis("shift-vertical"));
+    }
+}
+/// [Showcase Modifier Axis]
 
 /// [Showcase Unbound]
 static void showcaseUnbound(const Window& window, bool& explained)
@@ -166,14 +218,8 @@ int main()
     cubos.system("detect input")
         .after(inputUpdateTag)
         .call([](const Input& input, const Window& window, State& state, ShouldQuit& shouldQuit) {
-            // FIXME: This is an hack to have one-shot actions while we don't have input events.
-            if (input.pressed("next-showcase"))
+            if (input.justPressed("next-showcase"))
             {
-                state.nextPressed = true;
-            }
-            else if (state.nextPressed)
-            {
-                state.nextPressed = false;
                 state.explained = false;
                 state.showcase++;
             }
@@ -188,10 +234,16 @@ int main()
             case 2:
                 return showcaseJustXZ(input, state.explained);
             case 3:
-                return showcaseAxis(input, state.explained);
+                return showcaseModifiers(input, state.explained);
             case 4:
-                return showcaseUnbound(window, state.explained);
+                return showcaseMultipleModifiers(input, state.explained);
             case 5:
+                return showcaseAxis(input, state.explained);
+            case 6:
+                return showcaseModifierAxis(input, state.explained);
+            case 7:
+                return showcaseUnbound(window, state.explained);
+            case 8:
                 return showcaseMouseButtons(input, state.explained);
             default:
                 shouldQuit.value = true;

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -70,40 +70,6 @@ static void showcaseJustXZ(const Input& input, bool& explained)
 
 /// [Showcase Action Press]
 
-/// [Showcase Modifier]
-static void showcaseModifiers(const Input& input, bool& explained)
-{
-    if (!explained)
-    {
-        CUBOS_WARN("Modifiers are supported. This showcase will print `Shift` when Shift+Space is pressed. "
-                   "Press Enter to advance to the next showcase.");
-        explained = true;
-    }
-
-    if (input.pressed("shift-space"))
-    {
-        CUBOS_INFO("Shift");
-    }
-}
-/// [Showcase Modifier]
-
-/// [Showcase Multi Modifier]
-static void showcaseMultipleModifiers(const Input& input, bool& explained)
-{
-    if (!explained)
-    {
-        CUBOS_WARN("Multiple modifiers are supported. This showcase will print `Ctrl Shift` when Ctrl+Shift+Space is "
-                   "pressed. Press Enter to advance to the next showcase.");
-        explained = true;
-    }
-
-    if (input.pressed("ctrl-shift-space"))
-    {
-        CUBOS_INFO("Ctrl Shift");
-    }
-}
-/// [Showcase Multi Modifier]
-
 /// [Showcase Axis]
 static void showcaseAxis(const Input& input, bool& explained)
 {
@@ -122,36 +88,18 @@ static void showcaseAxis(const Input& input, bool& explained)
 }
 /// [Showcase Axis]
 
-/// [Showcase Modifier Axis]
-static void showcaseModifierAxis(const Input& input, bool& explained)
-{
-    if (!explained)
-    {
-        CUBOS_WARN("Modifiers are supported with axis. This showcase will print the value of the `shift-vertical` axis "
-                   "when its value is different to 0. Use Shift+arrows and Shift+WASD to move the axis. Press Enter to "
-                   "advance to the next showcase.");
-        explained = true;
-    }
-
-    if (input.axis("shift-vertical") != 0.0F)
-    {
-        CUBOS_INFO("shift-vertical: {}", input.axis("shift-vertical"));
-    }
-}
-/// [Showcase Modifier Axis]
-
 /// [Showcase Unbound]
 static void showcaseUnbound(const Window& window, bool& explained)
 {
     if (!explained)
     {
-        CUBOS_WARN("Direct access is supported. This showcase will print `Unbound` when Ctrl+Shift+Y is pressed. Note "
-                   "that Ctrl+Shift+Y is not bound in sample.bind. Press Enter to advance to the next showcase.");
+        CUBOS_WARN("Direct access is supported. This showcase will print `Unbound` when Y is pressed. Note "
+                   "that Y is not bound in sample.bind. Press Enter to advance to the next showcase.");
         explained = true;
     }
 
     /// When no action is bound to a key, its state can still be accessed directly through the Window.
-    if (window->pressed(Input::Key::Y, Input::Modifiers::Shift | Input::Modifiers::Control))
+    if (window->pressed(Input::Key::Y))
     {
         CUBOS_INFO("Unbound");
     }
@@ -240,16 +188,10 @@ int main()
             case 2:
                 return showcaseJustXZ(input, state.explained);
             case 3:
-                return showcaseModifiers(input, state.explained);
-            case 4:
-                return showcaseMultipleModifiers(input, state.explained);
-            case 5:
                 return showcaseAxis(input, state.explained);
-            case 6:
-                return showcaseModifierAxis(input, state.explained);
-            case 7:
+            case 4:
                 return showcaseUnbound(window, state.explained);
-            case 8:
+            case 5:
                 return showcaseMouseButtons(input, state.explained);
             default:
                 shouldQuit.value = true;

--- a/engine/src/input/action.cpp
+++ b/engine/src/input/action.cpp
@@ -5,7 +5,7 @@
 #include <cubos/engine/input/action.hpp>
 
 using cubos::core::io::GamepadButton;
-using cubos::core::io::KeyWithModifiers;
+using cubos::core::io::Key;
 using cubos::core::io::MouseButton;
 using namespace cubos::engine;
 
@@ -19,7 +19,7 @@ CUBOS_REFLECT_IMPL(cubos::engine::InputAction)
                   .withField("mouseButtons", &InputAction::mMouseButtons));
 }
 
-const std::vector<KeyWithModifiers>& InputAction::keys() const
+const std::vector<Key>& InputAction::keys() const
 {
     return mKeys;
 }
@@ -34,7 +34,7 @@ const std::vector<MouseButton>& InputAction::mouseButtons() const
     return mMouseButtons;
 }
 
-std::vector<KeyWithModifiers>& InputAction::keys()
+std::vector<Key>& InputAction::keys()
 {
     return mKeys;
 }

--- a/engine/src/input/action.cpp
+++ b/engine/src/input/action.cpp
@@ -4,49 +4,23 @@
 
 #include <cubos/engine/input/action.hpp>
 
-using cubos::core::io::GamepadButton;
-using cubos::core::io::Key;
-using cubos::core::io::MouseButton;
 using namespace cubos::engine;
 
 CUBOS_REFLECT_IMPL(cubos::engine::InputAction)
 {
     using namespace cubos::core::reflection;
     return Type::create("cubos::engine::InputAction")
-        .with(FieldsTrait{}
-                  .withField("keys", &InputAction::mKeys)
-                  .withField("gamepadButtons", &InputAction::mGamepadButtons)
-                  .withField("mouseButtons", &InputAction::mMouseButtons));
+        .with(FieldsTrait{}.withField("combinations", &InputAction::mCombinations));
 }
 
-const std::vector<Key>& InputAction::keys() const
+const std::vector<InputCombination>& InputAction::combinations() const
 {
-    return mKeys;
+    return mCombinations;
 }
 
-const std::vector<GamepadButton>& InputAction::gamepadButtons() const
+std::vector<InputCombination>& InputAction::combinations()
 {
-    return mGamepadButtons;
-}
-
-const std::vector<MouseButton>& InputAction::mouseButtons() const
-{
-    return mMouseButtons;
-}
-
-std::vector<Key>& InputAction::keys()
-{
-    return mKeys;
-}
-
-std::vector<GamepadButton>& InputAction::gamepadButtons()
-{
-    return mGamepadButtons;
-}
-
-std::vector<MouseButton>& InputAction::mouseButtons()
-{
-    return mMouseButtons;
+    return mCombinations;
 }
 
 void InputAction::pressed(bool pressed)

--- a/engine/src/input/axis.cpp
+++ b/engine/src/input/axis.cpp
@@ -23,12 +23,12 @@ CUBOS_REFLECT_IMPL(cubos::engine::InputAxis)
                   .withField("gamepadAxes", &InputAxis::mGamepadAxes));
 }
 
-const std::vector<Key>& InputAxis::positive() const
+const std::vector<InputCombination>& InputAxis::positive() const
 {
     return mPositive;
 }
 
-const std::vector<Key>& InputAxis::negative() const
+const std::vector<InputCombination>& InputAxis::negative() const
 {
     return mNegative;
 }
@@ -38,12 +38,12 @@ const std::vector<GamepadAxis>& InputAxis::gamepadAxes() const
     return mGamepadAxes;
 }
 
-std::vector<Key>& InputAxis::positive()
+std::vector<InputCombination>& InputAxis::positive()
 {
     return mPositive;
 }
 
-std::vector<Key>& InputAxis::negative()
+std::vector<InputCombination>& InputAxis::negative()
 {
     return mNegative;
 }

--- a/engine/src/input/axis.cpp
+++ b/engine/src/input/axis.cpp
@@ -10,7 +10,7 @@
 #include <cubos/engine/input/axis.hpp>
 
 using cubos::core::io::GamepadAxis;
-using cubos::core::io::KeyWithModifiers;
+using cubos::core::io::Key;
 using namespace cubos::engine;
 
 CUBOS_REFLECT_IMPL(cubos::engine::InputAxis)
@@ -23,12 +23,12 @@ CUBOS_REFLECT_IMPL(cubos::engine::InputAxis)
                   .withField("gamepadAxes", &InputAxis::mGamepadAxes));
 }
 
-const std::vector<KeyWithModifiers>& InputAxis::positive() const
+const std::vector<Key>& InputAxis::positive() const
 {
     return mPositive;
 }
 
-const std::vector<KeyWithModifiers>& InputAxis::negative() const
+const std::vector<Key>& InputAxis::negative() const
 {
     return mNegative;
 }
@@ -38,12 +38,12 @@ const std::vector<GamepadAxis>& InputAxis::gamepadAxes() const
     return mGamepadAxes;
 }
 
-std::vector<KeyWithModifiers>& InputAxis::positive()
+std::vector<Key>& InputAxis::positive()
 {
     return mPositive;
 }
 
-std::vector<KeyWithModifiers>& InputAxis::negative()
+std::vector<Key>& InputAxis::negative()
 {
     return mNegative;
 }

--- a/engine/src/input/combination.cpp
+++ b/engine/src/input/combination.cpp
@@ -1,0 +1,87 @@
+#include <cubos/core/reflection/external/vector.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+#include <cubos/engine/input/combination.hpp>
+
+using cubos::core::io::GamepadButton;
+using cubos::core::io::GamepadState;
+using cubos::core::io::Key;
+using cubos::core::io::MouseButton;
+using cubos::core::io::Window;
+using namespace cubos::engine;
+
+CUBOS_REFLECT_IMPL(cubos::engine::InputCombination)
+{
+    using namespace cubos::core::reflection;
+    return Type::create("cubos::engine::InputCombination")
+        .with(FieldsTrait{}
+                  .withField("keys", &InputCombination::mKeys)
+                  .withField("gamepadButtons", &InputCombination::mGamepadButtons)
+                  .withField("mouseButtons", &InputCombination::mMouseButtons));
+}
+
+const std::vector<Key>& InputCombination::keys() const
+{
+    return mKeys;
+}
+
+const std::vector<GamepadButton>& InputCombination::gamepadButtons() const
+{
+    return mGamepadButtons;
+}
+
+const std::vector<MouseButton>& InputCombination::mouseButtons() const
+{
+    return mMouseButtons;
+}
+
+std::vector<Key>& InputCombination::keys()
+{
+    return mKeys;
+}
+
+std::vector<GamepadButton>& InputCombination::gamepadButtons()
+{
+    return mGamepadButtons;
+}
+
+std::vector<MouseButton>& InputCombination::mouseButtons()
+{
+    return mMouseButtons;
+}
+
+bool InputCombination::pressed(const Window& window, const GamepadState* const gamepad) const
+{
+    for (const auto& key : mKeys)
+    {
+        if (!window->pressed(key))
+        {
+            return false;
+        }
+    }
+
+    for (const auto& button : mMouseButtons)
+    {
+        if (!window->pressed(button))
+        {
+            return false;
+        }
+    }
+
+    if (gamepad == nullptr)
+    {
+        // If there are gamepad buttons to be pressed, but no gamepad is connected, combination is not pressed.
+        return mGamepadButtons.empty();
+    }
+
+    for (const auto& button : mGamepadButtons)
+    {
+        if (!gamepad->pressed(button))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/engine/src/input/input.cpp
+++ b/engine/src/input/input.cpp
@@ -253,11 +253,11 @@ bool Input::anyPressed(int player, const std::vector<GamepadButton>& buttons) co
     return false;
 }
 
-bool Input::anyPressed(const std::vector<MouseButton>& buttons)
+bool Input::anyPressed(const Window& window, const std::vector<MouseButton>& buttons)
 {
     for (const auto& button : buttons)
     {
-        if (mPressedMouseButtons[button])
+        if (window->pressed(button))
         {
             return true;
         }
@@ -271,7 +271,7 @@ void Input::handleActions(const Window& window, const std::vector<BindingIndex>&
     {
         auto& action = mPlayerBindings[boundAction.player].actions()[boundAction.name];
         auto pressed = anyPressed(window, action.keys()) || anyPressed(boundAction.player, action.gamepadButtons()) ||
-                       anyPressed(action.mouseButtons());
+                       anyPressed(window, action.mouseButtons());
 
         if (action.pressed() != pressed)
         {
@@ -361,7 +361,6 @@ void Input::handle(const Window& /*unused*/, const GamepadConnectionEvent& event
 
 void Input::handle(const Window& window, const MouseButtonEvent& event)
 {
-    mPressedMouseButtons[event.button] = event.pressed;
     this->handleActions(window, mBoundMouseActions[event.button]);
 }
 

--- a/engine/src/input/input.cpp
+++ b/engine/src/input/input.cpp
@@ -35,9 +35,9 @@ void Input::clear(int player)
 {
     for (const auto& action : mPlayerBindings[player].actions())
     {
-        for (const auto& keyWithMods : action.second.keys())
+        for (const auto& key : action.second.keys())
         {
-            std::erase_if(mBoundActions[keyWithMods.key], [player](const auto& idx) { return idx.player == player; });
+            std::erase_if(mBoundActions[key], [player](const auto& idx) { return idx.player == player; });
         }
 
         for (const auto& button : action.second.gamepadButtons())
@@ -55,12 +55,12 @@ void Input::clear(int player)
     {
         for (const auto& pos : axis.second.positive())
         {
-            std::erase_if(mBoundAxes[pos.key], [player](const auto& idx) { return idx.player == player; });
+            std::erase_if(mBoundAxes[pos], [player](const auto& idx) { return idx.player == player; });
         }
 
         for (const auto& neg : axis.second.negative())
         {
-            std::erase_if(mBoundAxes[neg.key], [player](const auto& idx) { return idx.player == player; });
+            std::erase_if(mBoundAxes[neg], [player](const auto& idx) { return idx.player == player; });
         }
 
         for (const auto& gamepadAxis : axis.second.gamepadAxes())
@@ -79,9 +79,9 @@ void Input::bind(const InputBindings& bindings, int player)
 
     for (const auto& action : bindings.actions())
     {
-        for (const auto& keyWithMods : action.second.keys())
+        for (const auto& key : action.second.keys())
         {
-            mBoundActions[keyWithMods.key].push_back(BindingIndex{action.first, player});
+            mBoundActions[key].push_back(BindingIndex{action.first, player});
         }
 
         for (const auto& button : action.second.gamepadButtons())
@@ -99,12 +99,12 @@ void Input::bind(const InputBindings& bindings, int player)
     {
         for (const auto& pos : axis.second.positive())
         {
-            mBoundAxes[pos.key].push_back(BindingIndex{axis.first, player, false});
+            mBoundAxes[pos].push_back(BindingIndex{axis.first, player, false});
         }
 
         for (const auto& neg : axis.second.negative())
         {
-            mBoundAxes[neg.key].push_back(BindingIndex{axis.first, player, true});
+            mBoundAxes[neg].push_back(BindingIndex{axis.first, player, true});
         }
 
         for (const auto& gamepadAxis : axis.second.gamepadAxes())
@@ -222,14 +222,11 @@ float Input::axis(const char* axisName, int player) const
     return aIt->second.value();
 }
 
-bool Input::anyPressed(const Window& window, const std::vector<core::io::KeyWithModifiers>& keys)
+bool Input::anyPressed(const Window& window, const std::vector<core::io::Key>& keys)
 {
-    for (const auto& keyWithMods : keys)
+    for (const auto& key : keys)
     {
-        // window->pressed() returns true when more modifiers than the specified are active, so we need to check that
-        // the modifiers are exactly the same as the ones specified in the binding.
-
-        if (window->pressed(keyWithMods.key, keyWithMods.modifiers) && window->modifiers() == keyWithMods.modifiers)
+        if (window->pressed(key))
         {
             return true;
         }

--- a/engine/src/input/input.cpp
+++ b/engine/src/input/input.cpp
@@ -325,12 +325,10 @@ void Input::handleActions(const Window& window, const std::vector<BindingIndex>&
             if (pressed)
             {
                 action.justPressed(true);
-                action.justReleased(false);
             }
             else
             {
                 action.justReleased(true);
-                action.justPressed(false);
             }
         }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,9 @@
             glfw
             glm
             doctest
+
+            # = debug =
+            gdb
           ]
           ++ sysLibs;
 

--- a/tools/tesseratos/assets/tesseratos.bind
+++ b/tools/tesseratos/assets/tesseratos.bind
@@ -1,34 +1,32 @@
 {
     "actions": {
-        "debug-camera-toggle": {
-            "keys": [
-                "LControl"
-            ]
-        }
+        "debug-camera-toggle": [
+            {"keys": ["LControl"]}
+        ],
     },
     "axes": {
         "debug-move-lateral": {
             "positive": [
-                "D"
+                {"keys": ["D"]}
             ],
             "negative": [
-                "A"
+                {"keys": ["A"]}
             ]
         },
         "debug-move-vertical": {
             "positive": [
-                "E"
+                {"keys": ["E"]}
             ],
             "negative": [
-                "Q"
+                {"keys": ["Q"]}
             ]
         },
         "debug-move-longitudinal": {
             "positive": [
-                "W"
+                {"keys": ["W"]}
             ],
             "negative": [
-                "S"
+                {"keys": ["S"]}
             ]
         }
     }


### PR DESCRIPTION
# Description

Depends on #1278 

Introduces InputCombinations to replace KeyWithModifiers
Also closes #1279 

Did not test if gamepad was broken with the changes

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
