### PR TITLE
refactor(reflection): no longer fallback to anonymous types automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move Opt class to memory namespace (#1212, **@roby2014**).
 - Moved from XPBD to TGS Soft for physics solving (#1269, **@fallenatlas**).
-- Allow arbitrary input combinations for actions and axes (#417, #1279, **@luishfonseca**)
+- Allow arbitrary input combinations for actions and axes (#417, #1279, **@luishfonseca**).
+- Replaced fallback anonymous reflection types by a new anonymous reflection macro (#1163, **@RiscadoA**).
 
 ## [v0.2.0] - 2024-05-07
 

--- a/core/include/cubos/core/reflection/traits/inherits.hpp
+++ b/core/include/cubos/core/reflection/traits/inherits.hpp
@@ -9,9 +9,11 @@ namespace cubos::core::reflection
     /// @brief Provides inheritance relationship between types.
     /// @see See @ref examples-core-reflection-traits-inherits for an example of using this trait.
     /// @ingroup core-reflection
-    class InheritsTrait
+    class CUBOS_CORE_API InheritsTrait
     {
     public:
+        CUBOS_REFLECT;
+
         ~InheritsTrait() = default;
 
         /// @brief Constructs.

--- a/core/include/cubos/core/reflection/type.hpp
+++ b/core/include/cubos/core/reflection/type.hpp
@@ -33,14 +33,6 @@ namespace cubos::core::reflection
         /// @return Reference to the type.
         static Type& create(std::string name);
 
-        /// @brief Constructs an unnamed type with the given identifier.
-        ///
-        /// The type is also marked as not being implemented.
-        ///
-        /// @param id Type identifier.
-        /// @return Reference to the type.
-        static Type& unnamed(unsigned long long id);
-
         /// @brief Destroys the given type.
         /// @param type Type to destroy.
         static void destroy(Type& type);
@@ -122,9 +114,6 @@ namespace cubos::core::reflection
         /// @return Whether the objects have the same address, which indicates equality.
         bool operator==(const Type& other) const;
 
-        /// @brief Checks whether the type had reflection implemented for it.
-        bool implemented() const;
-
     private:
         ~Type();
 
@@ -142,7 +131,6 @@ namespace cubos::core::reflection
 
         std::string mName;
         std::string mShortName;
-        bool mImplemented{true};
         std::vector<Trait> mTraits;
     };
 } // namespace cubos::core::reflection

--- a/core/samples/logging/main.cpp
+++ b/core/samples/logging/main.cpp
@@ -11,10 +11,6 @@
 #include <cubos/core/reflection/external/unordered_map.hpp>
 /// [External reflection includes]
 
-struct TypeWithoutReflection
-{
-};
-
 int main()
 {
     /// [Set logging level]
@@ -42,6 +38,5 @@ int main()
     CUBOS_INFO("An integer: {}", 1);
     CUBOS_INFO("A glm::vec3: {}", glm::vec3(0.0F, 1.0F, 2.0F));
     CUBOS_INFO("An std::unordered_map: {}", std::unordered_map<int, const char*>{{1, "one"}, {2, "two"}});
-    CUBOS_INFO("A type without reflection: {}", TypeWithoutReflection{});
 }
 /// [Logging macros with arguments]

--- a/core/samples/reflection/basic/main.cpp
+++ b/core/samples/reflection/basic/main.cpp
@@ -33,11 +33,17 @@ struct Position
 /// [Your own trait]
 struct ColorTrait
 {
+    CUBOS_REFLECT;
     float r, g, b;
 };
 /// [Your own trait]
 
 /// [Adding your own trait]
+CUBOS_REFLECT_IMPL(ColorTrait)
+{
+    return Type::create("ColorTrait");
+}
+
 CUBOS_REFLECT_IMPL(Position)
 {
     return Type::create("Position").with(ColorTrait{.r = 0.0F, .g = 1.0F, .b = 0.0F});

--- a/core/src/ecs/dynamic.cpp
+++ b/core/src/ecs/dynamic.cpp
@@ -1,5 +1,6 @@
 #include <cubos/core/ecs/dynamic.hpp>
 #include <cubos/core/log.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 

--- a/core/src/log.cpp
+++ b/core/src/log.cpp
@@ -243,17 +243,7 @@ const char* Logger::streamFormat(memory::Stream& stream, const char* format, con
             }
 
             foundArgument = true;
-            if (!type.implemented())
-            {
-                CUBOS_WARN("You tried to print a type ({}) which doesn't implement reflection. Did you forget to "
-                           "include its reflection definition?",
-                           type.name());
-                stream.print("(no reflection)");
-            }
-            else
-            {
-                data::DebugSerializer{stream}.write(type, value);
-            }
+            data::DebugSerializer{stream}.write(type, value);
             ++format;
         }
         else

--- a/core/src/reflection/reflect.cpp
+++ b/core/src/reflection/reflect.cpp
@@ -4,8 +4,49 @@
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-auto cubos::core::reflection::makeUnnamedType(unsigned long long id, std::size_t size, std::size_t alignment,
-                                              void (*destructor)(void*)) -> const Type&
+auto cubos::core::reflection::makeAnonymousType(const char* name, const char* file, std::size_t size,
+                                                std::size_t alignment, void (*destructor)(void*)) -> const Type&
 {
-    return Type::unnamed(id).with(ConstructibleTrait{size, alignment, destructor});
+    // Replace non-ASCII-alphanumeric characters in the file path with underscores.
+    std::string fileName;
+    for (const char* c = file; *c != '\0'; ++c)
+    {
+        if ((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z') || (*c >= '0' && *c <= '9'))
+        {
+            fileName.push_back(*c);
+        }
+        else
+        {
+            fileName.push_back('_');
+        }
+    }
+
+    // Remove the "_src_" prefix from the file name.
+    if (auto cursor = fileName.find("_src_"); cursor != std::string::npos)
+    {
+        fileName.erase(0, cursor + 5);
+    }
+
+    // The "_include_" too.
+    if (auto cursor = fileName.find("_include_"); cursor != std::string::npos)
+    {
+        fileName.erase(0, cursor + 9);
+    }
+
+    // Remove the "_cpp" suffix from the file name.
+    if (fileName.ends_with("_cpp"))
+    {
+        fileName.erase(fileName.size() - 4, 4);
+    }
+
+    // And the "_hpp" suffix too.
+    if (fileName.ends_with("_hpp"))
+    {
+        fileName.erase(fileName.size() - 4, 4);
+    }
+
+    std::string fullName = name;
+    fullName.append("#");
+    fullName.append(fileName);
+    return Type::create(fullName).with(ConstructibleTrait{size, alignment, destructor});
 }

--- a/core/src/reflection/traits/inherits.cpp
+++ b/core/src/reflection/traits/inherits.cpp
@@ -3,6 +3,11 @@
 
 using namespace cubos::core::reflection;
 
+CUBOS_REFLECT_IMPL(InheritsTrait)
+{
+    return Type::create("cubos::core::ecs::InheritsTrait");
+}
+
 const Type& InheritsTrait::base()
 {
     return *mType;

--- a/core/src/reflection/type.cpp
+++ b/core/src/reflection/type.cpp
@@ -9,13 +9,6 @@ Type& Type::create(std::string name)
     return *(new Type(std::move(name)));
 }
 
-Type& Type::unnamed(unsigned long long id)
-{
-    auto& type = Type::create("unnamed" + std::to_string(id));
-    type.mImplemented = false;
-    return type;
-}
-
 void Type::destroy(Type& type)
 {
     delete &type;
@@ -79,11 +72,6 @@ bool Type::operator==(const Type& other) const
 
     CUBOS_ASSERT(this->mName != other.mName, "Two types should never have the same name");
     return false;
-}
-
-bool Type::implemented() const
-{
-    return mImplemented;
 }
 
 Type::~Type()

--- a/core/tests/reflection/reflect.cpp
+++ b/core/tests/reflection/reflect.cpp
@@ -40,30 +40,27 @@ CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename T), (Templated<T>))
     return Type::create("Templated<" + reflect<T>().name() + ">");
 }
 
-/// @brief Type without reflection.
-struct Unreflected
+/// @brief Type with anonymous reflection.
+struct Anonymous
 {
+    CUBOS_ANONYMOUS_REFLECT(Anonymous);
 };
 
 TEST_CASE("reflection::reflect")
 {
-    CHECK(reflect<Internal>().implemented());
     CHECK(reflect<Internal>().name() == "Internal");
     CHECK(reflect<Internal>().is<Internal>());
 
-    CHECK(reflect<External>().implemented());
     CHECK(reflect<External>().name() == "External");
     CHECK(reflect<External>().is<External>());
     CHECK_FALSE(reflect<External>().is<Internal>());
 
-    CHECK(reflect<Templated<Internal>>().implemented());
     CHECK(reflect<Templated<Internal>>().name() == "Templated<Internal>");
     CHECK(reflect<Templated<External>>().name() == "Templated<External>");
     CHECK(reflect<Templated<Templated<Internal>>>().name() == "Templated<Templated<Internal>>");
 
-    CHECK_FALSE(reflect<Unreflected>().implemented());
-    CHECK(reflect<Unreflected>().is<Unreflected>());
-    CHECK(reflect<Unreflected>().has<ConstructibleTrait>());
-    CHECK(reflect<Unreflected>().get<ConstructibleTrait>().size() == sizeof(Unreflected));
-    CHECK(reflect<Unreflected>().get<ConstructibleTrait>().alignment() == alignof(Unreflected));
+    CHECK(reflect<Anonymous>().is<Anonymous>());
+    CHECK(reflect<Anonymous>().has<ConstructibleTrait>());
+    CHECK(reflect<Anonymous>().get<ConstructibleTrait>().size() == sizeof(Anonymous));
+    CHECK(reflect<Anonymous>().get<ConstructibleTrait>().alignment() == alignof(Anonymous));
 }

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -35,6 +35,8 @@ static CUBOS_DEFINE_TAG(collisionsSampleUpdated);
 
 struct State
 {
+    CUBOS_ANONYMOUS_REFLECT(State);
+
     bool collided = false;
 
     Entity a;

--- a/engine/samples/complex_physics/main.cpp
+++ b/engine/samples/complex_physics/main.cpp
@@ -41,6 +41,8 @@ static const glm::vec3 AimPoint = glm::vec3(0.0F, 3.0F, 0.0F);
 
 struct TimeBetweenShoots
 {
+    CUBOS_ANONYMOUS_REFLECT(TimeBetweenShoots);
+
     float max = 3.0F;
     float current = 0.0F;
 };

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -18,12 +18,16 @@ CUBOS_DEFINE_TAG(cubos::engine::eventC);
 /// [Event struct]
 struct MyEvent
 {
+    CUBOS_ANONYMOUS_REFLECT(MyEvent);
+
     int value;
 };
 /// [Event struct]
 
 struct State
 {
+    CUBOS_ANONYMOUS_REFLECT(State);
+
     int step;
 };
 

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -17,6 +17,8 @@ static const Asset<InputBindings> BindingsAsset = AnyAsset("bf49ba61-5103-41bc-9
 
 struct State
 {
+    CUBOS_ANONYMOUS_REFLECT(State);
+
     int showcase = 0;
     bool nextPressed = false;
     bool explained = false;

--- a/engine/samples/physics/main.cpp
+++ b/engine/samples/physics/main.cpp
@@ -25,6 +25,8 @@ static const Asset<VoxelPalette> PaletteAsset = AnyAsset("1aa5e234-28cb-4386-99b
 
 struct MaxTime
 {
+    CUBOS_ANONYMOUS_REFLECT(MaxTime);
+
     float max = 1.0F;
     float current = 0.0F;
 };

--- a/engine/src/fixed_step/plugin.cpp
+++ b/engine/src/fixed_step/plugin.cpp
@@ -6,6 +6,8 @@ namespace
 {
     struct AccumulatedTime
     {
+        CUBOS_ANONYMOUS_REFLECT(AccumulatedTime);
+
         float value = 0.0F;
     };
 } // namespace

--- a/engine/src/physics/fixed_substep/plugin.cpp
+++ b/engine/src/physics/fixed_substep/plugin.cpp
@@ -9,6 +9,8 @@ namespace
 {
     struct SubstepsCount
     {
+        CUBOS_ANONYMOUS_REFLECT(SubstepsCount);
+
         int value = 0;
     };
 } // namespace

--- a/engine/src/render/bloom/plugin.cpp
+++ b/engine/src/render/bloom/plugin.cpp
@@ -23,6 +23,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         ShaderPipeline extractPipeline;
         ShaderBindingPoint extractInputBP;
         ShaderBindingPoint extractThresholdFilterBP;

--- a/engine/src/render/deferred_shading/plugin.cpp
+++ b/engine/src/render/deferred_shading/plugin.cpp
@@ -93,6 +93,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         ShaderPipeline pipeline;
         ShaderBindingPoint positionBP;
         ShaderBindingPoint normalBP;

--- a/engine/src/render/g_buffer_rasterizer/plugin.cpp
+++ b/engine/src/render/g_buffer_rasterizer/plugin.cpp
@@ -48,6 +48,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         ShaderPipeline pipeline;
         ShaderBindingPoint perSceneBP;
         ShaderBindingPoint perMeshBP;

--- a/engine/src/render/mesh/plugin.cpp
+++ b/engine/src/render/mesh/plugin.cpp
@@ -31,6 +31,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         struct Entry
         {
             RenderMeshPool::BucketId firstBucketId{};

--- a/engine/src/render/shadow_atlas_rasterizer/plugin.cpp
+++ b/engine/src/render/shadow_atlas_rasterizer/plugin.cpp
@@ -41,6 +41,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         ShaderPipeline pipeline;
         ShaderBindingPoint perSceneBP;
         ShaderBindingPoint perMeshBP;

--- a/engine/src/render/shadows/directional_caster.cpp
+++ b/engine/src/render/shadows/directional_caster.cpp
@@ -1,6 +1,7 @@
 #include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/reflection/external/glm.hpp>
 #include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/vector.hpp>
 
 #include <cubos/engine/render/shadows/directional_caster.hpp>
 

--- a/engine/src/render/ssao/plugin.cpp
+++ b/engine/src/render/ssao/plugin.cpp
@@ -44,6 +44,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         ShaderPipeline basePipeline;
         ShaderBindingPoint basePositionBP;
         ShaderBindingPoint baseNormalBP;

--- a/engine/src/render/tone_mapping/plugin.cpp
+++ b/engine/src/render/tone_mapping/plugin.cpp
@@ -23,6 +23,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         ShaderPipeline pipeline;
         ShaderBindingPoint gammaBP;
         ShaderBindingPoint exposureBP;

--- a/engine/src/ui/canvas/plugin.cpp
+++ b/engine/src/ui/canvas/plugin.cpp
@@ -34,6 +34,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         cubos::core::gl::DepthStencilState dss;
         cubos::core::gl::ConstantBuffer mvpBuffer;
         State(cubos::core::gl::DepthStencilState depthStencilState, cubos::core::gl::ConstantBuffer mvpConstantBuffer)

--- a/engine/src/ui/color_rect/plugin.cpp
+++ b/engine/src/ui/color_rect/plugin.cpp
@@ -23,6 +23,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         VertexArray va;
         UIDrawList::Type drawType;
 

--- a/engine/src/ui/image/plugin.cpp
+++ b/engine/src/ui/image/plugin.cpp
@@ -27,6 +27,8 @@ namespace
 
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         VertexArray va;
         UIDrawList::Type drawType;
 

--- a/tools/tesseratos/src/tesseratos/asset_explorer/plugin.hpp
+++ b/tools/tesseratos/src/tesseratos/asset_explorer/plugin.hpp
@@ -26,6 +26,8 @@ namespace tesseratos
     /// @brief Event sent when an asset is selected.
     struct AssetSelectedEvent
     {
+        CUBOS_REFLECT;
+
         cubos::engine::AnyAsset asset; ///< Handle to the selected asset.
     };
 

--- a/tools/tesseratos/src/tesseratos/console/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/console/plugin.cpp
@@ -17,6 +17,8 @@ namespace
     // Resource used to store the state of the console
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         std::vector<cubos::core::Logger::Entry> uiEntries;
         std::size_t cursor = 0;
         char searchString[256];

--- a/tools/tesseratos/src/tesseratos/debug_camera/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/debug_camera/plugin.cpp
@@ -35,6 +35,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         // Cameras which were deactivated by the plugin.
         std::unordered_set<Entity, EntityHash> deactivated;
 

--- a/tools/tesseratos/src/tesseratos/ecs_statistics/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/ecs_statistics/plugin.cpp
@@ -25,6 +25,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         char columnFilter[256]{0};
         ArchetypeId selectedArchetype{ArchetypeId::Invalid};
         DataTypeId selectedSparseRelationTypeId{DataTypeId::Invalid};

--- a/tools/tesseratos/src/tesseratos/entity_inspector/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/entity_inspector/plugin.cpp
@@ -28,6 +28,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         const Type* relationType;
     };
 } // namespace

--- a/tools/tesseratos/src/tesseratos/metrics_panel/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/metrics_panel/plugin.cpp
@@ -16,6 +16,8 @@ namespace
 {
     struct Metrics
     {
+        CUBOS_ANONYMOUS_REFLECT(Metrics);
+
         float timeElapsed = 0.0F;
         float fps = 0.0F;
         float maxFps = 0.0F;

--- a/tools/tesseratos/src/tesseratos/play_pause/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/play_pause/plugin.cpp
@@ -15,6 +15,8 @@ namespace
 {
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         bool paused{false};
         float scale{1.0F};
     };

--- a/tools/tesseratos/src/tesseratos/scene_editor/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/scene_editor/plugin.cpp
@@ -52,6 +52,8 @@ namespace
     // Resource which stores the editor state.
     struct State
     {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
         Asset<Scene> asset{nullptr};
         SceneInfo root;
         std::unordered_map<std::string, Asset<Scene>> imports;

--- a/tools/tesseratos/src/tesseratos/voxel_palette_editor/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/voxel_palette_editor/plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <imgui.h>
 
+#include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/log.hpp>
 #include <cubos/core/reflection/type.hpp>
 
@@ -28,12 +29,21 @@ namespace
 {
     struct SelectedPaletteInfo
     {
+        CUBOS_ANONYMOUS_REFLECT(SelectedPaletteInfo);
+
         Asset<VoxelPalette> asset;
         VoxelPalette paletteCopy;
         bool modified;
         Asset<VoxelPalette> next;
     };
 } // namespace
+
+CUBOS_REFLECT_IMPL(AssetSelectedEvent)
+{
+    return cubos::core::ecs::TypeBuilder<AssetSelectedEvent>("tesseratos::AssetSelectedEvent")
+        .withField("asset", &AssetSelectedEvent::asset)
+        .build();
+}
 
 static void savePaletteUiGuard(Assets& assets, SelectedPaletteInfo& selectedPalette)
 {


### PR DESCRIPTION
# Description

This change was necessary due to the previous system being highly error prone. Before, if reflect<T> was called for a type T without defined reflection included, a placeholder definition would be used which returned an anonymous type. Sadly, due to the C++ One Definition Rule, this meant that other source files using reflect<T>, could return an anonymous type, even if the type's reflection definition was included!

Basically, previously a simple mistake such as forgetting to include an external reflection header could lead to a random reflection failure in the core of the library, such as a missing trait error. Now, the users must define reflection for all types, as there is no longer a fallback. To simplify this for the previous 'anonymous types', a new CUBOS_ANONYMOUS_REFLECT macro was added.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] ~~Write new samples.~~
- [x] Add entry to the changelog's unreleased section.
