### PR TITLE
fix(ci): do not request changes on clang-tidy-lint.yml

### DIFF
--- a/.github/workflows/clang-tidy-lint.yml
+++ b/.github/workflows/clang-tidy-lint.yml
@@ -72,5 +72,5 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         clang_tidy_fixes: clang-tidy-fixes.yaml
-        request_changes: true
+        request_changes: false
         suggestions_per_comment: 10


### PR DESCRIPTION
# Description

The action fails while trying to dismiss the reviews, might as well disable the request changes feature.
Note that this doesn't mean disabling the comments, the comments are still there.

## Checklist

- [x] Self-review changes.
- [x] ~~Evaluate impact on the documentation.~~
- [x] ~~Ensure test coverage.~~
- [x] ~~Write new samples.~~
- [x] ~~Add entry to the changelog's unreleased section.~~
