### PR TITLE
Physics Materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- PhysicsMaterial component (#1254, **@fallenatlas**).
+
 ## [v0.3.0] - 2024-08-02
 
 ### Added

--- a/engine/include/cubos/engine/physics/components/physics_material.hpp
+++ b/engine/include/cubos/engine/physics/components/physics_material.hpp
@@ -37,3 +37,5 @@ namespace cubos::engine
         MixProperty bouncinessMix = MixProperty::Average;
     };
 } // namespace cubos::engine
+
+CUBOS_REFLECT_EXTERNAL_DECL(CUBOS_EMPTY, cubos::engine::PhysicsMaterial::MixProperty);

--- a/engine/include/cubos/engine/physics/components/physics_material.hpp
+++ b/engine/include/cubos/engine/physics/components/physics_material.hpp
@@ -16,22 +16,24 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
+        /// @brief Type of mixing for the material property. When mixing between bodies with different types, the
+        /// priority is taken into account. The priority is as defined in the enum, lower priority takes precedence.
         enum class MixProperty
         {
-            Maximum,
-            Multiply,
-            Minimum,
-            Average
-        }; ///< Type of mixing for the material property. When mixing between bodies with different types, the priority
-           ///< is taken into account. The priority is as defined in the enum, lower values will take priority over
-           ///< higher values.
+            Maximum,  /**< Use highest property value | Priority 0. */
+            Multiply, /**< Multiply property values | Priority 1. */
+            Minimum,  /**< Use lowest property value | Priority 2. */
+            Average   /**< Use the average of property values | Priority 3. */
+        };
 
-        float friction = 0.0F;   ///< Static and Dynamic friction coefficient for the body. Range between 0, for no
-                                 ///< friction, and 1, for maximum friction.
-        float bounciness = 0.0F; ///< Bounciness of the body. Range between 0, for no bounce, and 1, for maximum bounce.
-        MixProperty frictionMix =
-            MixProperty::Average; ///< Type of value mixing for friction, according to @ref MixProperty.
-        MixProperty bouncinessMix =
-            MixProperty::Average; ///< Type of value mixing for bounciness, according to @ref MixProperty.
+        /// @brief Static and Dynamic friction coefficient for the body. Range between 0, for no friction, and 1, for
+        /// maximum friction.
+        float friction = 0.0F;
+        /// @brief Bounciness of the body. Range between 0, for no bounce, and 1, for maximum bounce.
+        float bounciness = 0.0F;
+        /// @brief Type of value mixing for friction, according to @ref MixProperty.
+        MixProperty frictionMix = MixProperty::Average;
+        /// @brief Type of value mixing for bounciness, according to @ref MixProperty.
+        MixProperty bouncinessMix = MixProperty::Average;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/physics_material.hpp
+++ b/engine/include/cubos/engine/physics/components/physics_material.hpp
@@ -1,0 +1,37 @@
+/// @file
+/// @brief Component @ref cubos::engine::PhysicsMaterial.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which defines the friction and bounciness of a body.
+    /// @ingroup physics-plugin
+    struct CUBOS_ENGINE_API PhysicsMaterial
+    {
+        CUBOS_REFLECT;
+
+        enum class MixProperty
+        {
+            Maximum,
+            Multiply,
+            Minimum,
+            Average
+        }; ///< Type of mixing for the material property. When mixing between bodies with different types, the priority
+           ///< is taken into account. The priority is as defined in the enum, lower values will take priority over
+           ///< higher values.
+
+        float friction = 0.0F;   ///< Static and Dynamic friction coefficient for the body. Range between 0, for no
+                                 ///< friction, and 1, for maximum friction.
+        float bounciness = 0.0F; ///< Bounciness of the body. Range between 0, for no bounce, and 1, for maximum bounce.
+        MixProperty frictionMix =
+            MixProperty::Average; ///< Type of value mixing for friction, according to @ref MixProperty.
+        MixProperty bouncinessMix =
+            MixProperty::Average; ///< Type of value mixing for bounciness, according to @ref MixProperty.
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/physics_bundle.hpp
+++ b/engine/include/cubos/engine/physics/physics_bundle.hpp
@@ -9,6 +9,7 @@
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
+#include <cubos/engine/physics/components/physics_material.hpp>
 
 namespace cubos::engine
 {
@@ -22,5 +23,6 @@ namespace cubos::engine
         glm::vec3 velocity = {0.0F, 0.0F, 0.0F};
         glm::vec3 force = {0.0F, 0.0F, 0.0F};
         glm::vec3 impulse = {0.0F, 0.0F, 0.0F};
+        PhysicsMaterial material = PhysicsMaterial{};
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/plugin.hpp
+++ b/engine/include/cubos/engine/physics/plugin.hpp
@@ -15,6 +15,7 @@
 #include <cubos/engine/physics/components/force.hpp>
 #include <cubos/engine/physics/components/impulse.hpp>
 #include <cubos/engine/physics/components/mass.hpp>
+#include <cubos/engine/physics/components/physics_material.hpp>
 #include <cubos/engine/physics/components/velocity.hpp>
 #include <cubos/engine/physics/physics_bundle.hpp>
 #include <cubos/engine/physics/resources/damping.hpp>
@@ -39,6 +40,7 @@ namespace cubos::engine
     /// - @ref Impulse - holds impulses applied on a particle.
     /// - @ref Mass - holds the mass of an object.
     /// - @ref AccumulatedCorrection - holds the corrections accumulated from the constraints solving.
+    /// - @ref PhysicsMaterial - holds the friction and bounciness properties of the particle.
     ///
     /// ## Dependencies
     /// - @ref physics-gravity-plugin

--- a/engine/samples/complex_physics/assets/scenes/red_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/red_cube.cubos
@@ -51,6 +51,12 @@
         "inverseMass": 0.02,
         "mass": 50.0
       },
+      "cubos::engine::PhysicsMaterial": {
+        "friction": 0.02,
+        "bounciness": 1.0,
+        "frictionMix": "Average",
+        "bouncinessMix": "Average"
+      },
       "cubos::engine::Position": {
         "x": 0.0,
         "y": 0.0,

--- a/engine/samples/complex_physics/assets/scenes/white_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/white_cube.cubos
@@ -51,6 +51,12 @@
         "inverseMass": 0.1,
         "mass": 10.0
       },
+      "cubos::engine::PhysicsMaterial": {
+        "friction": 0.02,
+        "bounciness": 1.0,
+        "frictionMix": "Average",
+        "bouncinessMix": "Average"
+      },
       "cubos::engine::Position": {
         "x": 0.0,
         "y": 0.0,

--- a/engine/samples/complex_physics/main.cpp
+++ b/engine/samples/complex_physics/main.cpp
@@ -118,7 +118,8 @@ int main(int argc, char** argv)
             .add(Force{})
             .add(Impulse{})
             .add(Mass{.mass = 1.0F, .inverseMass = 0.0F})
-            .add(AccumulatedCorrection{{0.0F, 0.0F, 0.0F}});
+            .add(AccumulatedCorrection{{0.0F, 0.0F, 0.0F}})
+            .add(PhysicsMaterial{});
 
         auto redCube = assets.read(RedCubeSceneAsset);
         auto whiteCube = assets.read(WhiteCubeSceneAsset);

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -46,10 +46,9 @@ CUBOS_REFLECT_IMPL(Impulse)
         .build();
 }
 
-CUBOS_REFLECT_EXTERNAL_DECL(CUBOS_EMPTY, PhysicsMaterial::MixProperty);
 CUBOS_REFLECT_EXTERNAL_IMPL(PhysicsMaterial::MixProperty)
 {
-    return cubos::core::reflection::Type::create("PhysicsMaterial::MixProperty")
+    return cubos::core::reflection::Type::create("cubos::engine::PhysicsMaterial::MixProperty")
         .with(cubos::core::reflection::EnumTrait{}
                   .withVariant<PhysicsMaterial::MixProperty::Maximum>("Maximum")
                   .withVariant<PhysicsMaterial::MixProperty::Multiply>("Multiply")

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -2,6 +2,9 @@
 
 #include <glm/glm.hpp>
 
+#include <cubos/core/reflection/traits/enum.hpp>
+#include <cubos/core/reflection/type.hpp>
+
 #include <cubos/engine/physics/plugin.hpp>
 #include <cubos/engine/physics/solver/plugin.hpp>
 
@@ -43,6 +46,27 @@ CUBOS_REFLECT_IMPL(Impulse)
         .build();
 }
 
+CUBOS_REFLECT_EXTERNAL_DECL(CUBOS_EMPTY, PhysicsMaterial::MixProperty);
+CUBOS_REFLECT_EXTERNAL_IMPL(PhysicsMaterial::MixProperty)
+{
+    return cubos::core::reflection::Type::create("PhysicsMaterial::MixProperty")
+        .with(cubos::core::reflection::EnumTrait{}
+                  .withVariant<PhysicsMaterial::MixProperty::Maximum>("Maximum")
+                  .withVariant<PhysicsMaterial::MixProperty::Multiply>("Multiply")
+                  .withVariant<PhysicsMaterial::MixProperty::Minimum>("Minimum")
+                  .withVariant<PhysicsMaterial::MixProperty::Average>("Average"));
+}
+
+CUBOS_REFLECT_IMPL(PhysicsMaterial)
+{
+    return cubos::core::ecs::TypeBuilder<PhysicsMaterial>("cubos::engine::PhysicsMaterial")
+        .withField("friction", &PhysicsMaterial::friction)
+        .withField("bounciness", &PhysicsMaterial::bounciness)
+        .withField("frictionMix", &PhysicsMaterial::frictionMix)
+        .withField("bouncinessMix", &PhysicsMaterial::bouncinessMix)
+        .build();
+}
+
 CUBOS_REFLECT_IMPL(PhysicsBundle)
 {
     return cubos::core::ecs::TypeBuilder<PhysicsBundle>("cubos::engine::PhysicsBundle")
@@ -69,6 +93,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
     cubos.component<Impulse>();
     cubos.component<Mass>();
     cubos.component<AccumulatedCorrection>();
+    cubos.component<PhysicsMaterial>();
     cubos.component<PhysicsBundle>();
 
     cubos.observer("unpack PhysicsBundle's")
@@ -89,6 +114,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
                 cmds.add(ent, force);
                 cmds.add(ent, impulse);
                 cmds.add(ent, AccumulatedCorrection{});
+                cmds.add(ent, PhysicsMaterial{});
             }
         });
 

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -73,6 +73,7 @@ CUBOS_REFLECT_IMPL(PhysicsBundle)
         .withField("velocity", &PhysicsBundle::velocity)
         .withField("force", &PhysicsBundle::force)
         .withField("impulse", &PhysicsBundle::impulse)
+        .withField("material", &PhysicsBundle::material)
         .build();
 }
 
@@ -113,7 +114,7 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
                 cmds.add(ent, force);
                 cmds.add(ent, impulse);
                 cmds.add(ent, AccumulatedCorrection{});
-                cmds.add(ent, PhysicsMaterial{});
+                cmds.add(ent, bundle.material);
             }
         });
 

--- a/engine/src/physics/solver/penetration_constraint/plugin.cpp
+++ b/engine/src/physics/solver/penetration_constraint/plugin.cpp
@@ -33,13 +33,13 @@ void getPlaneSpace(const glm::vec3& n, glm::vec3& tangent1, glm::vec3& tangent2)
     }
 }
 
-PhysicsMaterial::MixProperty getMixProperty(PhysicsMaterial::MixProperty mixProperty1,
-                                            PhysicsMaterial::MixProperty mixProperty2)
+static PhysicsMaterial::MixProperty getMixProperty(PhysicsMaterial::MixProperty mixProperty1,
+                                                   PhysicsMaterial::MixProperty mixProperty2)
 {
     return mixProperty1 > mixProperty2 ? mixProperty2 : mixProperty1;
 }
 
-float mixValues(float value1, float value2, PhysicsMaterial::MixProperty mixProperty)
+static float mixValues(float value1, float value2, PhysicsMaterial::MixProperty mixProperty)
 {
     switch (mixProperty)
     {

--- a/engine/src/physics/solver/penetration_constraint/plugin.cpp
+++ b/engine/src/physics/solver/penetration_constraint/plugin.cpp
@@ -289,11 +289,11 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
                 float kFriction = mass1.inverseMass + mass2.inverseMass;
                 float frictionMass = kFriction > 0.0F ? 1.0F / kFriction : 0.0F;
 
-                // determine friction (set to predefined value for now)
+                // determine friction
                 float friction = mixValues(material1.friction, material2.friction,
                                            getMixProperty(material1.frictionMix, material2.frictionMix));
 
-                // determine restitution (set to predefined value for now)
+                // determine restitution
                 float restitution = mixValues(material1.bounciness, material2.bounciness,
                                               getMixProperty(material1.bouncinessMix, material2.bouncinessMix));
                 glm::vec3 vr = velocity2.vec - velocity1.vec;


### PR DESCRIPTION
# Description

Add PhysicsMaterial component which allows to customize the behaviour of physics objects by changing their friction coefficient and bounciness. How the values of each are mixed to determine the value to use in the collision resolution can also be customized by choosing between 4 methods, which are some of the most common methods found online. This is inspired by Unity and Unreal which also do this. What the best is will depend on the use case, so I believe that this is better than only letting 1 method.

What some use (restitution only): https://stackoverflow.com/questions/1678908/applying-coefficient-of-restitution-in-a-collision-resolution-method
Unity: https://docs.unity3d.com/Manual/collider-surfaces-combine.html
Unreal: https://dev.epicgames.com/documentation/en-us/unreal-engine/physical-materials-reference-for-unreal-engine

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
