### PR TITLE
Add components to support rigid body rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - PhysicsMaterial component (#1254, **@fallenatlas**).
+- Components to support rigid body rotation (#865, **@fallenatlas**).
 
 ## [v0.3.0] - 2024-08-02
 

--- a/engine/include/cubos/engine/collisions/shapes/box.hpp
+++ b/engine/include/cubos/engine/collisions/shapes/box.hpp
@@ -18,5 +18,7 @@ namespace cubos::engine
         CUBOS_REFLECT;
 
         cubos::core::geom::Box box; ///< Box shape.
+
+        bool changed = true;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/angular_impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/angular_impulse.hpp
@@ -1,0 +1,41 @@
+/// @file
+/// @brief Component @ref cubos::engine::AngularImpulse.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/vec3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which holds angular impulses applied on a body.
+    /// @note Should be used with @ref AngularVelocity.
+    /// @ingroup physics-plugin
+    struct CUBOS_ENGINE_API AngularImpulse
+    {
+        CUBOS_REFLECT;
+
+        glm::vec3 vec() const
+        {
+            return mAngularImpulse;
+        }
+
+        void add(glm::vec3 angularImpulse)
+        {
+            mAngularImpulse += angularImpulse;
+        }
+
+        void clear()
+        {
+            mAngularImpulse = {0.0F, 0.0F, 0.0F};
+        }
+
+    private:
+        glm::vec3 mAngularImpulse;
+    };
+
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/angular_velocity.hpp
+++ b/engine/include/cubos/engine/physics/components/angular_velocity.hpp
@@ -1,0 +1,24 @@
+/// @file
+/// @brief Component @ref cubos::engine::AngularVelocity.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/vec3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which holds angular velocity of a body.
+    /// @note Should be used with @ref Inertia and @ref Rotation.
+    /// @ingroup physics-plugin
+    struct CUBOS_ENGINE_API AngularVelocity
+    {
+        CUBOS_REFLECT;
+
+        glm::vec3 vec;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/center_of_mass.hpp
+++ b/engine/include/cubos/engine/physics/components/center_of_mass.hpp
@@ -1,0 +1,23 @@
+/// @file
+/// @brief Component @ref cubos::engine::CenterOfMass.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/vec3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which defines the center of mass of a body.
+    /// @ingroup physics-plugin
+    struct CUBOS_ENGINE_API CenterOfMass
+    {
+        CUBOS_REFLECT;
+
+        glm::vec3 vec = {0.0F, 0.0F, 0.0F};
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/center_of_mass.hpp
+++ b/engine/include/cubos/engine/physics/components/center_of_mass.hpp
@@ -18,6 +18,6 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 vec = {0.0F, 0.0F, 0.0F};
+        glm::vec3 vec = {0.0F, 0.0F, 0.0F}; ///< Position of the center in local space.
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/force.hpp
+++ b/engine/include/cubos/engine/physics/components/force.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <glm/geometric.hpp>
 #include <glm/vec3.hpp>
 
 #include <cubos/core/reflection/reflect.hpp>

--- a/engine/include/cubos/engine/physics/components/force.hpp
+++ b/engine/include/cubos/engine/physics/components/force.hpp
@@ -24,18 +24,32 @@ namespace cubos::engine
             return mForce;
         }
 
+        // Torque resulting from addForceOnPoint.
+        glm::vec3 torque() const
+        {
+            return mTorque;
+        }
+
         void add(glm::vec3 force)
         {
             mForce += force;
         }
 
+        void addForceOnPoint(glm::vec3 force, glm::vec3 localPoint, glm::vec3 centerOfMass)
+        {
+            mForce += force;
+            mTorque = glm::cross(localPoint - centerOfMass, force);
+        }
+
         void clear()
         {
             mForce = {0.0F, 0.0F, 0.0F};
+            mTorque = {0.0F, 0.0F, 0.0F};
         }
 
     private:
         glm::vec3 mForce = {0.0F, 0.0F, 0.0F};
+        glm::vec3 mTorque = {0.0F, 0.0F, 0.0F};
     };
 
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/impulse.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <glm/geometric.hpp>
 #include <glm/vec3.hpp>
 
 #include <cubos/core/reflection/reflect.hpp>

--- a/engine/include/cubos/engine/physics/components/impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/impulse.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @brief Component @ref cubos::engine::Force.
+/// @brief Component @ref cubos::engine::Impulse.
 /// @ingroup physics-plugin
 
 #pragma once
@@ -24,18 +24,32 @@ namespace cubos::engine
             return mImpulse;
         }
 
+        // Angular impulse resulting from addImpulseOnPoint.
+        glm::vec3 angularImpulse() const
+        {
+            return mAngularImpulse;
+        }
+
         void add(glm::vec3 impulse)
         {
             mImpulse += impulse;
         }
 
+        void addImpulseOnPoint(glm::vec3 impulse, glm::vec3 localPoint, glm::vec3 centerOfMass)
+        {
+            mImpulse += impulse;
+            mAngularImpulse += glm::cross(localPoint - centerOfMass, impulse);
+        }
+
         void clear()
         {
             mImpulse = {0.0F, 0.0F, 0.0F};
+            mAngularImpulse = {0.0F, 0.0F, 0.0F};
         }
 
     private:
         glm::vec3 mImpulse;
+        glm::vec3 mAngularImpulse;
     };
 
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/inertia.hpp
+++ b/engine/include/cubos/engine/physics/components/inertia.hpp
@@ -1,0 +1,25 @@
+/// @file
+/// @brief Component @ref cubos::engine::Inertia.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/mat3x3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which defines the inertia of a body.
+    /// @ingroup physics-plugin
+    struct CUBOS_ENGINE_API Inertia
+    {
+        CUBOS_REFLECT;
+
+        glm::mat3 inertia;
+        glm::mat3 inverseInertia;
+        bool selfUpdate = false;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/inertia.hpp
+++ b/engine/include/cubos/engine/physics/components/inertia.hpp
@@ -20,6 +20,6 @@ namespace cubos::engine
 
         glm::mat3 inertia;
         glm::mat3 inverseInertia;
-        bool selfUpdate = false;
+        bool autoUpdate = false;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/mass.hpp
+++ b/engine/include/cubos/engine/physics/components/mass.hpp
@@ -20,5 +20,7 @@ namespace cubos::engine
 
         float mass;
         float inverseMass;
+
+        bool changed = true;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/torque.hpp
+++ b/engine/include/cubos/engine/physics/components/torque.hpp
@@ -1,0 +1,41 @@
+/// @file
+/// @brief Component @ref cubos::engine::Torque.
+/// @ingroup physics-plugin
+
+#pragma once
+
+#include <glm/vec3.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component which holds torque applied on a body.
+    /// @note Should be used with @ref AngularVelocity.
+    /// @ingroup physics-plugin
+    struct CUBOS_ENGINE_API Torque
+    {
+        CUBOS_REFLECT;
+
+        glm::vec3 vec() const
+        {
+            return mTorque;
+        }
+
+        void add(glm::vec3 torque)
+        {
+            mTorque += torque;
+        }
+
+        void clear()
+        {
+            mTorque = {0.0F, 0.0F, 0.0F};
+        }
+
+    private:
+        glm::vec3 mTorque = {0.0F, 0.0F, 0.0F};
+    };
+
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/physics_bundle.hpp
+++ b/engine/include/cubos/engine/physics/physics_bundle.hpp
@@ -28,6 +28,7 @@ namespace cubos::engine
         glm::vec3 impulse = {0.0F, 0.0F, 0.0F};
         glm::vec3 angularImpulse = {0.0F, 0.0F, 0.0F};
         PhysicsMaterial material = PhysicsMaterial{};
-        glm::mat3 inertiaTensor = glm::mat3(0.0F);
+        glm::mat3 inertiaTensor = glm::mat3(0.0F); // Temporary value. We use this value to check if the inertia tensor
+                                                   // is to be calculated automatically.
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/physics_bundle.hpp
+++ b/engine/include/cubos/engine/physics/physics_bundle.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <glm/mat3x3.hpp>
 #include <glm/vec3.hpp>
 
 #include <cubos/core/reflection/reflect.hpp>
@@ -20,7 +21,6 @@ namespace cubos::engine
         CUBOS_REFLECT;
 
         float mass = 1.0F;
-        glm::vec3 colliderDimensions = {1.0F, 1.0F, 1.0F};
         glm::vec3 velocity = {0.0F, 0.0F, 0.0F};
         glm::vec3 angularVelocity = {0.0F, 0.0F, 0.0F};
         glm::vec3 force = {0.0F, 0.0F, 0.0F};
@@ -28,5 +28,6 @@ namespace cubos::engine
         glm::vec3 impulse = {0.0F, 0.0F, 0.0F};
         glm::vec3 angularImpulse = {0.0F, 0.0F, 0.0F};
         PhysicsMaterial material = PhysicsMaterial{};
+        glm::mat3 inertiaTensor = glm::mat3(0.0F);
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/physics_bundle.hpp
+++ b/engine/include/cubos/engine/physics/physics_bundle.hpp
@@ -20,9 +20,13 @@ namespace cubos::engine
         CUBOS_REFLECT;
 
         float mass = 1.0F;
+        glm::vec3 colliderDimensions = {1.0F, 1.0F, 1.0F};
         glm::vec3 velocity = {0.0F, 0.0F, 0.0F};
+        glm::vec3 angularVelocity = {0.0F, 0.0F, 0.0F};
         glm::vec3 force = {0.0F, 0.0F, 0.0F};
+        glm::vec3 torque = {0.0F, 0.0F, 0.0F};
         glm::vec3 impulse = {0.0F, 0.0F, 0.0F};
+        glm::vec3 angularImpulse = {0.0F, 0.0F, 0.0F};
         PhysicsMaterial material = PhysicsMaterial{};
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/plugin.hpp
+++ b/engine/include/cubos/engine/physics/plugin.hpp
@@ -57,6 +57,7 @@ namespace cubos::engine
 
     /// @brief Tag which should be used on all systems that modify velocity or apply forces or impulses.
     CUBOS_ENGINE_API extern Tag physicsApplyForcesTag;
+    extern Tag physicsPrepareTag;
 
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class

--- a/engine/include/cubos/engine/physics/plugin.hpp
+++ b/engine/include/cubos/engine/physics/plugin.hpp
@@ -12,10 +12,15 @@
 #include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/physics/components/accumulated_correction.hpp>
+#include <cubos/engine/physics/components/angular_impulse.hpp>
+#include <cubos/engine/physics/components/angular_velocity.hpp>
+#include <cubos/engine/physics/components/center_of_mass.hpp>
 #include <cubos/engine/physics/components/force.hpp>
 #include <cubos/engine/physics/components/impulse.hpp>
+#include <cubos/engine/physics/components/inertia.hpp>
 #include <cubos/engine/physics/components/mass.hpp>
 #include <cubos/engine/physics/components/physics_material.hpp>
+#include <cubos/engine/physics/components/torque.hpp>
 #include <cubos/engine/physics/components/velocity.hpp>
 #include <cubos/engine/physics/physics_bundle.hpp>
 #include <cubos/engine/physics/resources/damping.hpp>
@@ -36,9 +41,14 @@ namespace cubos::engine
     /// ## Components
     /// - @ref PhysicsBundle - bundle that holds the physics information to give to a new entity.
     /// - @ref Velocity - holds the information for moving an object straight.
+    /// - @ref AngularVelocity - holds the angular velocity of an object.
     /// - @ref Force - holds forces applied on a particle.
+    /// - @ref Torque - holds torque applied on an object.
     /// - @ref Impulse - holds impulses applied on a particle.
+    /// - @ref AngularImpulse - holds angular impulses applied on a particle.
     /// - @ref Mass - holds the mass of an object.
+    /// - @ref Inertia - holds the inertia tensor of an object.
+    /// - @ref CenterOfMass - holds the center of mass of an object.
     /// - @ref AccumulatedCorrection - holds the corrections accumulated from the constraints solving.
     /// - @ref PhysicsMaterial - holds the friction and bounciness properties of the particle.
     ///

--- a/engine/samples/complex_physics/assets/scenes/red_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/red_cube.cubos
@@ -7,9 +7,12 @@
           "z": 0.0
       },
       "cubos::engine::BoxCollisionShape": {
-        "x": 0.5,
-        "y": 0.5,
-        "z": 0.5
+        "box" : {
+          "x": 0.5,
+          "y": 0.5,
+          "z": 0.5 
+        },
+        "changed" : true
       },
       "cubos::engine::Collider": {
         "a": {
@@ -38,18 +41,25 @@
         }
       },
       "cubos::engine::Force": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
+      },
+      "cubos::engine::Torque": {
       },
       "cubos::engine::Impulse": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
+      },
+      "cubos::engine::AngularImpulse": {
       },
       "cubos::engine::Mass": {
         "inverseMass": 0.02,
-        "mass": 50.0
+        "mass": 50.0,
+        "changed": true
+      },
+      "cubos::engine::Inertia": {
+        "autoUpdate": true
+      },
+      "cubos::engine::CenterOfMass": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
       },
       "cubos::engine::PhysicsMaterial": {
         "friction": 0.02,
@@ -78,6 +88,11 @@
       },
       "cubos::engine::Scale": 1.0,
       "cubos::engine::Velocity": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "cubos::engine::AngularVelocity": {
         "x": 0.0,
         "y": 0.0,
         "z": 0.0

--- a/engine/samples/complex_physics/assets/scenes/white_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/white_cube.cubos
@@ -7,9 +7,12 @@
           "z": 0.0
       },
       "cubos::engine::BoxCollisionShape": {
-        "x": 0.5,
-        "y": 0.5,
-        "z": 0.5
+        "box" : {
+          "x": 0.5,
+          "y": 0.5,
+          "z": 0.5 
+        },
+        "changed" : true
       },
       "cubos::engine::Collider": {
         "a": {
@@ -38,18 +41,25 @@
         }
       },
       "cubos::engine::Force": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
+      },
+      "cubos::engine::Torque": {
       },
       "cubos::engine::Impulse": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
+      },
+      "cubos::engine::AngularImpulse": {
       },
       "cubos::engine::Mass": {
         "inverseMass": 0.1,
-        "mass": 10.0
+        "mass": 10.0,
+        "changed": true
+      },
+      "cubos::engine::Inertia": {
+        "autoUpdate": true
+      },
+      "cubos::engine::CenterOfMass": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
       },
       "cubos::engine::PhysicsMaterial": {
         "friction": 0.02,
@@ -78,6 +88,11 @@
       },
       "cubos::engine::Scale": 1.0,
       "cubos::engine::Velocity": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "cubos::engine::AngularVelocity": {
         "x": 0.0,
         "y": 0.0,
         "z": 0.0

--- a/engine/src/collisions/interface/shapes/box.cpp
+++ b/engine/src/collisions/interface/shapes/box.cpp
@@ -6,5 +6,6 @@ CUBOS_REFLECT_IMPL(cubos::engine::BoxCollisionShape)
 {
     return core::ecs::TypeBuilder<BoxCollisionShape>("cubos::engine::BoxCollisionShape")
         .withField("box", &BoxCollisionShape::box)
+        .withField("changed", &BoxCollisionShape::changed)
         .build();
 }

--- a/engine/src/collisions/interface/shapes/box.cpp
+++ b/engine/src/collisions/interface/shapes/box.cpp
@@ -1,4 +1,5 @@
 #include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
 
 #include <cubos/engine/collisions/shapes/box.hpp>
 

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -27,6 +27,21 @@ CUBOS_REFLECT_IMPL(Mass)
         .build();
 }
 
+CUBOS_REFLECT_IMPL(CenterOfMass)
+{
+    return cubos::core::ecs::TypeBuilder<CenterOfMass>("cubos::engine::CenterOfMass")
+        .withField("vec", &CenterOfMass::vec)
+        .build();
+}
+
+CUBOS_REFLECT_IMPL(Inertia)
+{
+    return cubos::core::ecs::TypeBuilder<Inertia>("cubos::engine::Inertia")
+        .withField("Inertia", &Inertia::inertia)
+        .withField("inverseInertia", &Inertia::inverseInertia)
+        .build();
+}
+
 CUBOS_REFLECT_IMPL(Velocity)
 {
     return cubos::core::ecs::TypeBuilder<Velocity>("cubos::engine::Velocity")
@@ -34,15 +49,40 @@ CUBOS_REFLECT_IMPL(Velocity)
         .build();
 }
 
+CUBOS_REFLECT_IMPL(AngularVelocity)
+{
+    return cubos::core::ecs::TypeBuilder<AngularVelocity>("cubos::engine::AngularVelocity")
+        .withField("vec", &AngularVelocity::vec)
+        .build();
+}
+
 CUBOS_REFLECT_IMPL(Force)
 {
-    return cubos::core::ecs::TypeBuilder<Force>("cubos::engine::Force").withField("mForce", &Force::mForce).build();
+    return cubos::core::ecs::TypeBuilder<Force>("cubos::engine::Force")
+        .withField("mForce", &Force::mForce)
+        .withField("mTorque", &Force::mTorque)
+        .build();
+}
+
+CUBOS_REFLECT_IMPL(Torque)
+{
+    return cubos::core::ecs::TypeBuilder<Torque>("cubos::engine::Torque")
+        .withField("mTorque", &Torque::mTorque)
+        .build();
 }
 
 CUBOS_REFLECT_IMPL(Impulse)
 {
     return cubos::core::ecs::TypeBuilder<Impulse>("cubos::engine::Impulse")
         .withField("mImpulse", &Impulse::mImpulse)
+        .withField("mAngularImpulse", &Impulse::mAngularImpulse)
+        .build();
+}
+
+CUBOS_REFLECT_IMPL(AngularImpulse)
+{
+    return cubos::core::ecs::TypeBuilder<AngularImpulse>("cubos::engine::AngularImpulse")
+        .withField("mAngularImpulse", &AngularImpulse::mAngularImpulse)
         .build();
 }
 
@@ -70,9 +110,13 @@ CUBOS_REFLECT_IMPL(PhysicsBundle)
 {
     return cubos::core::ecs::TypeBuilder<PhysicsBundle>("cubos::engine::PhysicsBundle")
         .withField("mass", &PhysicsBundle::mass)
+        .withField("colliderDimensions", &PhysicsBundle::colliderDimensions)
         .withField("velocity", &PhysicsBundle::velocity)
+        .withField("angularVelocity", &PhysicsBundle::angularVelocity)
         .withField("force", &PhysicsBundle::force)
+        .withField("torque", &PhysicsBundle::torque)
         .withField("impulse", &PhysicsBundle::impulse)
+        .withField("angularImpulse", &PhysicsBundle::angularImpulse)
         .withField("material", &PhysicsBundle::material)
         .build();
 }
@@ -82,6 +126,18 @@ CUBOS_REFLECT_IMPL(Damping)
     return core::ecs::TypeBuilder<Damping>("cubos::engine::Damping").build();
 }
 
+// Compute Inertia Tensor for box shape
+glm::mat3 boxInertiaTensor(float mass, glm::vec3 dimensions)
+{
+    float constant = mass / 12.0F;
+    float x2 = (float)glm::pow(dimensions.x, 2);
+    float y2 = (float)glm::pow(dimensions.y, 2);
+    float z2 = (float)glm::pow(dimensions.z, 2);
+
+    return glm::mat3{constant * (z2 + y2), 0.0F, 0.0F, 0.0F, constant * (x2 + z2), 0.0F, 0.0F, 0.0F,
+                     constant * (x2 + y2)};
+}
+
 void cubos::engine::physicsPlugin(Cubos& cubos)
 {
     cubos.plugin(physicsFixedSubstepPlugin);
@@ -89,9 +145,13 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
     cubos.resource<Damping>();
 
     cubos.component<Velocity>();
+    cubos.component<AngularVelocity>();
     cubos.component<Force>();
+    cubos.component<Torque>();
     cubos.component<Impulse>();
+    cubos.component<AngularImpulse>();
     cubos.component<Mass>();
+    cubos.component<Inertia>();
     cubos.component<AccumulatedCorrection>();
     cubos.component<PhysicsMaterial>();
     cubos.component<PhysicsBundle>();
@@ -106,13 +166,25 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
                 auto force = Force{};
                 force.add(bundle.force);
 
+                auto torque = Torque{};
+                torque.add(bundle.torque);
+
                 auto impulse = Impulse{};
                 impulse.add(bundle.impulse);
 
+                auto angularImpulse = AngularImpulse{};
+                angularImpulse.add(bundle.angularImpulse);
+
                 cmds.add(ent, Mass{.mass = bundle.mass, .inverseMass = 1.0F / bundle.mass});
+
+                glm::mat3 inertiaTensor = boxInertiaTensor(bundle.mass, bundle.colliderDimensions);
+                cmds.add(ent, Inertia{.inertia = inertiaTensor, .inverseInertia = glm::inverse(inertiaTensor)});
                 cmds.add(ent, Velocity{.vec = bundle.velocity});
+                cmds.add(ent, AngularVelocity{.vec = bundle.angularVelocity});
                 cmds.add(ent, force);
+                cmds.add(ent, torque);
                 cmds.add(ent, impulse);
+                cmds.add(ent, angularImpulse);
                 cmds.add(ent, AccumulatedCorrection{});
                 cmds.add(ent, bundle.material);
             }

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -130,9 +130,9 @@ CUBOS_REFLECT_IMPL(Damping)
 glm::mat3 boxInertiaTensor(float mass, glm::vec3 dimensions)
 {
     float constant = mass / 12.0F;
-    float x2 = (float)glm::pow(dimensions.x, 2);
-    float y2 = (float)glm::pow(dimensions.y, 2);
-    float z2 = (float)glm::pow(dimensions.z, 2);
+    auto x2 = (float)glm::pow(dimensions.x, 2);
+    auto y2 = (float)glm::pow(dimensions.y, 2);
+    auto z2 = (float)glm::pow(dimensions.z, 2);
 
     return glm::mat3{constant * (z2 + y2), 0.0F, 0.0F, 0.0F, constant * (x2 + z2), 0.0F, 0.0F, 0.0F,
                      constant * (x2 + y2)};

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -39,7 +39,7 @@ CUBOS_REFLECT_IMPL(CenterOfMass)
 CUBOS_REFLECT_IMPL(Inertia)
 {
     return cubos::core::ecs::TypeBuilder<Inertia>("cubos::engine::Inertia")
-        .withField("Inertia", &Inertia::inertia)
+        .withField("inertia", &Inertia::inertia)
         .withField("inverseInertia", &Inertia::inverseInertia)
         .build();
 }
@@ -60,32 +60,22 @@ CUBOS_REFLECT_IMPL(AngularVelocity)
 
 CUBOS_REFLECT_IMPL(Force)
 {
-    return cubos::core::ecs::TypeBuilder<Force>("cubos::engine::Force")
-        .withField("mForce", &Force::mForce)
-        .withField("mTorque", &Force::mTorque)
-        .build();
+    return cubos::core::ecs::TypeBuilder<Force>("cubos::engine::Force").build();
 }
 
 CUBOS_REFLECT_IMPL(Torque)
 {
-    return cubos::core::ecs::TypeBuilder<Torque>("cubos::engine::Torque")
-        .withField("mTorque", &Torque::mTorque)
-        .build();
+    return cubos::core::ecs::TypeBuilder<Torque>("cubos::engine::Torque").build();
 }
 
 CUBOS_REFLECT_IMPL(Impulse)
 {
-    return cubos::core::ecs::TypeBuilder<Impulse>("cubos::engine::Impulse")
-        .withField("mImpulse", &Impulse::mImpulse)
-        .withField("mAngularImpulse", &Impulse::mAngularImpulse)
-        .build();
+    return cubos::core::ecs::TypeBuilder<Impulse>("cubos::engine::Impulse").build();
 }
 
 CUBOS_REFLECT_IMPL(AngularImpulse)
 {
-    return cubos::core::ecs::TypeBuilder<AngularImpulse>("cubos::engine::AngularImpulse")
-        .withField("mAngularImpulse", &AngularImpulse::mAngularImpulse)
-        .build();
+    return cubos::core::ecs::TypeBuilder<AngularImpulse>("cubos::engine::AngularImpulse").build();
 }
 
 CUBOS_REFLECT_EXTERNAL_IMPL(PhysicsMaterial::MixProperty)
@@ -129,7 +119,7 @@ CUBOS_REFLECT_IMPL(Damping)
 }
 
 // Compute Inertia Tensor for box shape
-glm::mat3 boxInertiaTensor(float mass, glm::vec3 dimensions)
+static glm::mat3 boxInertiaTensor(float mass, glm::vec3 dimensions)
 {
     float constant = mass / 12.0F;
     auto x2 = (float)glm::pow(dimensions.x, 2);

--- a/engine/src/physics/solver/plugin.cpp
+++ b/engine/src/physics/solver/plugin.cpp
@@ -1,6 +1,5 @@
 #include "penetration_constraint/plugin.hpp"
 
-#include <cubos/engine/collisions/plugin.hpp>
 #include <cubos/engine/fixed_step/plugin.hpp>
 #include <cubos/engine/physics/plugin.hpp>
 #include <cubos/engine/physics/solver/plugin.hpp>
@@ -25,11 +24,10 @@ void cubos::engine::physicsSolverPlugin(Cubos& cubos)
 {
     cubos.depends(physicsPlugin);
     cubos.depends(fixedStepPlugin);
-    cubos.depends(collisionsPlugin);
 
     // doesn't need to be after collisions but for now it should stay in case we do velocity based prediction for
     // collisions in the future
-    cubos.tag(physicsPrepareSolveTag).after(collisionsTag).tagged(fixedStepTag);
+    cubos.tag(physicsPrepareSolveTag).tagged(physicsPrepareTag);
 
     cubos.tag(physicsIntegrateVelocityTag)
         .after(physicsPrepareSolveTag)


### PR DESCRIPTION
# Description

Add components for torque, angular impulse, inertia, angular velocity and center of mass.
Add ability to add force or impulse on a point of the object, for this we changed the Force and Impulse components, which now also hold a torque and angular impulse, respectively.

Reference: https://research.ncl.ac.uk/game/mastersdegree/gametechnologies/physicstutorials/3angularmotion/Physics%20-%20Angular%20Motion.pdf

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
