### PR TITLE
Add rotation to integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PhysicsMaterial component (#1254, **@fallenatlas**).
 - Components to support rigid body rotation (#865, **@fallenatlas**).
 - Compute contact points and contact manifold for collision between boxes (#1243, **@fallenatlas**).
+- Handle body rotation on physics integration (#1242, **&fallenatlas**).
 
 ### Fixed
 

--- a/engine/include/cubos/engine/physics/components/inertia.hpp
+++ b/engine/include/cubos/engine/physics/components/inertia.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <glm/gtx/quaternion.hpp>
 #include <glm/mat3x3.hpp>
 
 #include <cubos/core/reflection/reflect.hpp>
@@ -21,5 +22,19 @@ namespace cubos::engine
         glm::mat3 inertia;
         glm::mat3 inverseInertia;
         bool autoUpdate = false;
+
+        glm::mat3 rotatedInertia(const glm::quat& rotationQuat) const
+        {
+            auto rotationMat = glm::mat3(rotationQuat);
+            return rotationMat * inertia * glm::transpose(rotationMat);
+        }
+
+        // TODO: check if we use this many times. If we do, it might be worth it to calculate and store them
+        // somewhere instead.
+        glm::mat3 rotatedInverseInertia(const glm::quat& rotationQuat) const
+        {
+            auto rotationMat = glm::mat3(rotationQuat);
+            return rotationMat * inverseInertia * glm::transpose(rotationMat);
+        }
     };
 } // namespace cubos::engine

--- a/engine/src/physics/plugin.cpp
+++ b/engine/src/physics/plugin.cpp
@@ -185,6 +185,12 @@ void cubos::engine::physicsPlugin(Cubos& cubos)
                                           .inverseInertia = glm::inverse(bundle.inertiaTensor),
                                           .autoUpdate = false});
                 }
+                else
+                {
+                    cmds.add(
+                        ent,
+                        Inertia{.inertia = glm::mat3(0.0F), .inverseInertia = glm::mat3(0.0F), .autoUpdate = true});
+                }
                 cmds.add(ent, Velocity{.vec = bundle.velocity});
                 cmds.add(ent, AngularVelocity{.vec = bundle.angularVelocity});
                 cmds.add(ent, force);


### PR DESCRIPTION
# Description

Apply torque and angular impulses on integration to rotate the bodies.

Resources: https://research.ncl.ac.uk/game/mastersdegree/gametechnologies/physicstutorials/3angularmotion/Physics%20-%20Angular%20Motion.pdf

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
