### PR TITLE
Change spot light angles to match the angle between edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Components to support rigid body rotation (#865, **@fallenatlas**).
 - Compute contact points and contact manifold for collision between boxes (#1243, **@fallenatlas**).
 
+### Fixed
+
+- Spot light angle mismatch between light and shadows (#1310, **@tomas7770**).
+
 ## [v0.3.0] - 2024-08-02
 
 ### Added

--- a/engine/src/render/deferred_shading/plugin.cpp
+++ b/engine/src/render/deferred_shading/plugin.cpp
@@ -248,8 +248,8 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
                         perLight.color = glm::vec4(light.color, 1.0F);
                         perLight.intensity = light.intensity;
                         perLight.range = light.range;
-                        perLight.spotCutoff = glm::cos(glm::radians(light.spotAngle));
-                        perLight.innerSpotCutoff = glm::cos(glm::radians(light.innerSpotAngle));
+                        perLight.spotCutoff = glm::cos(glm::radians(light.spotAngle / 2.0F));
+                        perLight.innerSpotCutoff = glm::cos(glm::radians(light.innerSpotAngle / 2.0F));
 
                         if (caster.contains())
                         {


### PR DESCRIPTION
# Description

Changes `spotAngle` and `innerSpotAngle` to match the total angle between lateral edges of the spot light, instead of the angle between each edge and the center. This is more intuitive and matches the way shadow rendering already used these values.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
