### PR TITLE
Fix spot light range cutoff when using shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Spot light angle mismatch between light and shadows (#1310, **@tomas7770**).
+- Spot shadows cause light range cutoff (#1312, **@tomas7770**).
 
 ## [v0.3.0] - 2024-08-02
 

--- a/engine/src/render/deferred_shading/plugin.cpp
+++ b/engine/src/render/deferred_shading/plugin.cpp
@@ -257,8 +257,9 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
                             auto slot = shadowAtlas.slotsMap.at(caster.value().baseSettings.id);
 
                             // The light is actually facing the direction opposite to what's visible, so rotate it.
-                            auto lightView = glm::inverse(
-                                glm::rotate(lightLocalToWorld.mat, glm::radians(180.0F), glm::vec3(0.0F, 1.0F, 0.0F)));
+                            auto lightView = glm::inverse(glm::scale(
+                                glm::rotate(lightLocalToWorld.mat, glm::radians(180.0F), glm::vec3(0.0F, 1.0F, 0.0F)),
+                                glm::vec3(1.0F / lightLocalToWorld.worldScale())));
                             auto lightProj = glm::perspective(glm::radians(light.spotAngle),
                                                               (float(shadowAtlas.getSize().x) * slot->size.x) /
                                                                   (float(shadowAtlas.getSize().y) * slot->size.y),

--- a/engine/src/render/shadow_atlas_rasterizer/plugin.cpp
+++ b/engine/src/render/shadow_atlas_rasterizer/plugin.cpp
@@ -166,8 +166,9 @@ void cubos::engine::shadowAtlasRasterizerPlugin(Cubos& cubos)
 
                 // Send the PerScene data to the GPU.
                 // The light is actually facing the direction opposite to what's visible, so rotate it.
-                auto view =
-                    glm::inverse(glm::rotate(localToWorld.mat, glm::radians(180.0F), glm::vec3(0.0F, 1.0F, 0.0F)));
+                auto view = glm::inverse(
+                    glm::scale(glm::rotate(localToWorld.mat, glm::radians(180.0F), glm::vec3(0.0F, 1.0F, 0.0F)),
+                               glm::vec3(1.0F / localToWorld.worldScale())));
                 auto proj = glm::perspective(glm::radians(light.spotAngle),
                                              (float(atlas.getSize().x) * slot->size.x) /
                                                  (float(atlas.getSize().y) * slot->size.y),


### PR DESCRIPTION
# Description

Fixes spot lights being "cut" before the maximum range is reached, when shadows are used on a spot light with global scale lower than 1.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
