### PR TITLE
Add initial communication between game and editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type Client and Type Server (#1302, **@RiscadoA**).
 - Deadzone for input axis (#844, **@kuukitenshi**)
 - Generic Camera component to hold projection matrix (#1331, **@mkuritsu**)
+- Initial application debugging through Tesseratos (#1303, **@RiscadoA**).
 
 ### Fixed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -138,6 +138,7 @@ set(CUBOS_CORE_SOURCE
 	"src/ecs/types.cpp"
 	"src/ecs/cubos.cpp"
 	"src/ecs/dynamic.cpp"
+	"src/ecs/debugger.cpp"
 
     "src/geom/box.cpp"
     "src/geom/capsule.cpp"

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -16,6 +16,7 @@
 #include <cubos/core/ecs/system/tag.hpp>
 #include <cubos/core/ecs/world.hpp>
 #include <cubos/core/memory/opt.hpp>
+#include <cubos/core/reflection/type_server.hpp>
 
 namespace cubos::core::ecs
 {
@@ -213,6 +214,13 @@ namespace cubos::core::ecs
         /// @return Builder used to configure the observer.
         ObserverBuilder observer(std::string name);
 
+        /// @brief Returns the type server to be used by the engine, in case debugging is enabled.
+        ///
+        /// Can be used to register new types or traits manually.
+        ///
+        /// @return Type server.
+        memory::Opt<reflection::TypeServer&> typeServer();
+
         /// @brief Resets the application to its initial state.
         ///
         /// Equivalent to constructing a new Cubos object.
@@ -229,6 +237,14 @@ namespace cubos::core::ecs
         ///
         /// Equivalent to calling @ref start() followed by @ref update() until it returns false.
         void run();
+
+        /// @brief Returns whether the application has been started.
+        /// @return Whether the application has been started.
+        bool started() const;
+
+        /// @brief Returns whether the application should quit.
+        /// @return Whether the application should quit.
+        bool shouldQuit() const;
 
     private:
         /// @brief Stores information regarding a plugin.
@@ -267,6 +283,13 @@ namespace cubos::core::ecs
 
             /// @brief Plugin which registered the tag.
             Plugin plugin;
+        };
+
+        /// @brief Stores debugging-related state.
+        struct Debug
+        {
+            uint16_t port{};
+            reflection::TypeServer typeServer{};
         };
 
         /// @brief Stores runtime application state.
@@ -327,6 +350,9 @@ namespace cubos::core::ecs
 
         /// @brief Maps registered tags to their data.
         std::unordered_map<std::string, TagInfo> mTags;
+
+        /// @brief Debugging state, in case it is enabled.
+        memory::Opt<Debug> mDebug;
     };
 
     class CUBOS_CORE_API Cubos::TagBuilder

--- a/core/include/cubos/core/memory/opt.hpp
+++ b/core/include/cubos/core/memory/opt.hpp
@@ -54,6 +54,63 @@ namespace cubos::core::memory
             }
         }
 
+        /// @brief Move constructor.
+        /// @param other Other optional.
+        Opt(Opt<T>&& other) noexcept
+            : mContains{other.mContains}
+        {
+            if (mContains)
+            {
+                new (&mValue) T(memory::move(other.mValue));
+                other.reset();
+            }
+        }
+
+        /// @brief Copy assignment.
+        /// @param other Other optional.
+        /// @return Reference to this.
+        Opt<T>& operator=(const Opt<T>& other)
+        {
+            if (this != &other)
+            {
+                if (mContains)
+                {
+                    mValue.~T();
+                }
+
+                mContains = other.mContains;
+                if (mContains)
+                {
+                    new (&mValue) T(other.mValue);
+                }
+            }
+
+            return *this;
+        }
+
+        /// @brief Move assignment.
+        /// @param other Other optional.
+        /// @return Reference to this.
+        Opt<T>& operator=(Opt<T>&& other) noexcept
+        {
+            if (this != &other)
+            {
+                if (mContains)
+                {
+                    mValue.~T();
+                }
+
+                mContains = other.mContains;
+                if (mContains)
+                {
+                    new (&mValue) T(memory::move(other.mValue));
+                    other.reset();
+                }
+            }
+
+            return *this;
+        }
+
         /// @brief Moves the given value into the optional, destroying any previously stored value.
         /// @param value Value.
         void replace(T value)

--- a/core/src/data/des/binary.cpp
+++ b/core/src/data/des/binary.cpp
@@ -141,7 +141,7 @@ bool BinaryDeserializer::decompose(const Type& type, void* value)
 
         if (!trait.contains(name))
         {
-            CUBOS_ERROR("Could not deserialize enum, no such variant '{}'", name);
+            CUBOS_ERROR("Could not deserialize enum, no such variant {}", name);
             return false;
         }
 
@@ -174,7 +174,7 @@ bool BinaryDeserializer::decompose(const Type& type, void* value)
 
             if (!trait.contains(bit))
             {
-                CUBOS_ERROR("Could not deserialize mask, no such bit '{}'", bit);
+                CUBOS_ERROR("Could not deserialize mask, no such bit {}", bit);
                 return false;
             }
 
@@ -188,7 +188,7 @@ bool BinaryDeserializer::decompose(const Type& type, void* value)
         {
             if (!this->read(field->type(), fieldValue))
             {
-                CUBOS_ERROR("Could not deserialize field '{}'", field->name());
+                CUBOS_ERROR("Could not deserialize field {}", field->name());
                 return false;
             }
         }
@@ -206,7 +206,7 @@ bool BinaryDeserializer::decompose(const Type& type, void* value)
 
         if (!trait.from(value, string))
         {
-            CUBOS_ERROR("Could not deserialize string conversion, string '{}' is not a valid conversion", string);
+            CUBOS_ERROR("Could not deserialize string conversion, string {} is not a valid conversion", string);
             return false;
         }
     }

--- a/core/src/data/ser/binary.cpp
+++ b/core/src/data/ser/binary.cpp
@@ -146,7 +146,7 @@ bool BinarySerializer::decompose(const Type& type, const void* value)
         {
             if (!this->write(field->type(), fieldValue))
             {
-                CUBOS_WARN("Could not serialize field '{}'", field->name());
+                CUBOS_WARN("Could not serialize field {}", field->name());
                 return false;
             }
         }

--- a/core/src/ecs/debugger.cpp
+++ b/core/src/ecs/debugger.cpp
@@ -1,0 +1,195 @@
+#include "debugger.hpp"
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <cubos/core/data/des/binary.hpp>
+#include <cubos/core/data/ser/binary.hpp>
+#include <cubos/core/ecs/cubos.hpp>
+#include <cubos/core/log.hpp>
+#include <cubos/core/memory/function.hpp>
+
+using namespace cubos::core;
+
+namespace
+{
+    struct Command
+    {
+        memory::Function<void()> action;
+        bool shouldDisconnect = false;
+        bool shouldCloseApplication = false;
+
+        static Command makeAction(memory::Function<void()> action)
+        {
+            return {std::move(action)};
+        }
+
+        static Command makeDisconnect()
+        {
+            return {nullptr, true, false};
+        }
+
+        static Command makeCloseApplication()
+        {
+            return {nullptr, true, true};
+        }
+    };
+
+    struct State
+    {
+        std::mutex mutex;
+        std::condition_variable onPush;
+        std::condition_variable onPop;
+        memory::Opt<Command> command;
+    };
+
+    void controller(State& state, memory::Stream& stream, ecs::Cubos& cubos)
+    {
+        bool shouldCloseApplication = false;
+
+        // Setup serializers.
+        data::BinarySerializer ser{stream};
+        data::BinaryDeserializer des{stream};
+
+        while (true)
+        {
+            std::string command;
+            if (!des.read(command))
+            {
+                CUBOS_ERROR("Failed to read command from debugger client, closing connection");
+                break;
+            }
+
+            // Lock the runner so that we can update the command safely.
+            CUBOS_INFO("Received command {} from debugger client", command);
+            std::unique_lock lock{state.mutex};
+            state.onPop.wait(lock, [&] { return !state.command.contains(); });
+
+            if (command == "run")
+            {
+                // Run the application continuously, until some other command is received.
+                state.command.replace(Command::makeAction([&] {
+                    if (!cubos.started())
+                    {
+                        cubos.start();
+                    }
+
+                    if (!cubos.shouldQuit())
+                    {
+                        cubos.update();
+                    }
+                }));
+            }
+            else if (command == "pause")
+            {
+                // Simply clear the action so that the runner does not do anything.
+                state.command.replace(Command::makeAction(nullptr));
+            }
+            else if (command == "update")
+            {
+                // Update the application a certain number of times.
+                std::size_t count;
+                if (!des.read(count))
+                {
+                    CUBOS_ERROR("Failed to read update count from debugger client, closing connection");
+                    break;
+                }
+
+                state.command.replace(Command::makeAction([&, count]() mutable {
+                    if (!cubos.started())
+                    {
+                        cubos.start();
+                    }
+
+                    if (cubos.shouldQuit())
+                    {
+                        count = 0;
+                    }
+
+                    if (count > 0)
+                    {
+                        cubos.update();
+                        count--;
+                    }
+                }));
+            }
+            else if (command == "close")
+            {
+                shouldCloseApplication = true;
+                break;
+            }
+            else if (command == "disconnect")
+            {
+                break;
+            }
+            else
+            {
+                CUBOS_ERROR("Unknown command {} from debugger client, closing connection", command);
+                break;
+            }
+
+            state.onPush.notify_one();
+        }
+
+        // Notify the application to disconnect.
+        {
+            std::unique_lock lock{state.mutex};
+            state.onPop.wait(lock, [&] { return !state.command.contains(); });
+            if (shouldCloseApplication)
+            {
+                state.command.replace(Command::makeCloseApplication());
+            }
+            else
+            {
+                state.command.replace(Command::makeDisconnect());
+            }
+            state.onPush.notify_one();
+        }
+    }
+} // namespace
+
+bool cubos::core::ecs::debugger(memory::Stream& stream, Cubos& cubos)
+{
+    auto typeConnection = cubos.typeServer()->connect(stream);
+    if (!typeConnection.contains())
+    {
+        CUBOS_ERROR("Failed to share reflection data with client, closing connection");
+        return true;
+    }
+
+    CUBOS_INFO("Successfully shared reflection data with client, waiting for commands");
+
+    // Launch the thread which will control the application.
+    State state{};
+    std::thread controllerThread{controller, std::ref(state), std::ref(stream), std::ref(cubos)};
+
+    memory::Function<void()> action;
+    bool shouldDisconnect = false;
+    bool shouldContinueRunning = true;
+    while (!shouldDisconnect)
+    {
+        {
+            std::unique_lock lock{state.mutex};
+            state.onPush.wait(lock, [&] { return state.command.contains() || action != nullptr; });
+
+            if (state.command.contains())
+            {
+                state.onPop.notify_one();
+
+                action = std::move(state.command->action);
+                shouldDisconnect = state.command->shouldDisconnect;
+                shouldContinueRunning = !state.command->shouldCloseApplication;
+                state.command.reset();
+            }
+        }
+
+        if (action != nullptr)
+        {
+            action();
+        }
+    }
+
+    controllerThread.join();
+
+    return shouldContinueRunning && !cubos.shouldQuit();
+}

--- a/core/src/ecs/debugger.hpp
+++ b/core/src/ecs/debugger.hpp
@@ -1,0 +1,18 @@
+/// @file
+/// @brief Implements the debugger functionality of Cubos.
+
+#include <cubos/core/memory/stream.hpp>
+
+namespace cubos::core::ecs
+{
+    class Cubos;
+
+    /// @brief Receives debugging commands from the given stream and executes them on the given application.
+    ///
+    /// This function will block until the stream is closed or the application is stopped.
+    ///
+    /// @param stream Stream to receive debugging commands from and send responses to.
+    /// @param cubos Application to debug.
+    /// @return Whether the application should continue running.
+    bool debugger(memory::Stream& stream, Cubos& cubos);
+} // namespace cubos::core::ecs

--- a/engine/samples/assets/bridge/main.cpp
+++ b/engine/samples/assets/bridge/main.cpp
@@ -48,9 +48,9 @@ public:
 };
 /// [TextBridge::saveToFile]
 
-int main()
+int main(int argc, char** argv)
 {
-    auto cubos = Cubos();
+    auto cubos = Cubos(argc, argv);
 
     cubos.plugin(settingsPlugin);
     cubos.plugin(assetsPlugin);

--- a/engine/samples/assets/json/main.cpp
+++ b/engine/samples/assets/json/main.cpp
@@ -33,9 +33,9 @@ CUBOS_REFLECT_IMPL(Strings)
 }
 /// [Asset type]
 
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
 
     cubos.plugin(settingsPlugin);
     cubos.plugin(assetsPlugin);

--- a/engine/samples/assets/saving/main.cpp
+++ b/engine/samples/assets/saving/main.cpp
@@ -29,9 +29,9 @@ CUBOS_REFLECT_IMPL(IntegerAsset)
 }
 /// [Asset type]
 
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
 
     cubos.plugin(settingsPlugin);
     cubos.plugin(assetsPlugin);

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -67,9 +67,9 @@ struct State
     glm::vec3 bRotationAxis;
 };
 
-int main()
+int main(int argc, char** argv)
 {
-    auto cubos = Cubos();
+    auto cubos = Cubos(argc, argv);
 
     cubos.plugin(settingsPlugin);
     cubos.plugin(windowPlugin);

--- a/engine/samples/events/main.cpp
+++ b/engine/samples/events/main.cpp
@@ -31,9 +31,9 @@ struct State
     int step;
 };
 
-int main()
+int main(int argc, char** argv)
 {
-    cubos::engine::Cubos cubos;
+    cubos::engine::Cubos cubos(argc, argv);
     cubos.resource<State>(State{.step = 0});
 
     /// [Adding event]

--- a/engine/samples/games/cubosurfers/main.cpp
+++ b/engine/samples/games/cubosurfers/main.cpp
@@ -18,9 +18,9 @@ static const Asset<Scene> SceneAsset = AnyAsset("ee5bb451-05b7-430f-a641-a746f70
 static const Asset<VoxelPalette> PaletteAsset = AnyAsset("101da567-3d23-46ae-a391-c10ec00e8718");
 static const Asset<InputBindings> InputBindingsAsset = AnyAsset("b20900a4-20ee-4caa-8830-14585050bead");
 
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
 
     cubos.plugin(defaultsPlugin);
     cubos.plugin(spawnerPlugin);

--- a/engine/samples/hello-cubos/main.cpp
+++ b/engine/samples/hello-cubos/main.cpp
@@ -45,9 +45,9 @@ CUBOS_DEFINE_TAG(cubos::engine::helloTag);
 CUBOS_DEFINE_TAG(cubos::engine::worldTag);
 
 /// [Engine]
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
     /// [Engine]
 
     /// [Hello Cubos]

--- a/engine/samples/imgui/main.cpp
+++ b/engine/samples/imgui/main.cpp
@@ -85,9 +85,9 @@ CUBOS_REFLECT_IMPL(DummyResource)
 }
 /// [Creating a dummy resource]
 
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
 
     /// [Adding the plugin]
     cubos.plugin(settingsPlugin);

--- a/engine/samples/input/main.cpp
+++ b/engine/samples/input/main.cpp
@@ -189,9 +189,9 @@ static void showcaseMouseButtons(const Input& input, bool& explained)
 }
 /// [Showcase Mouse Buttons]
 
-int main()
+int main(int argc, char** argv)
 {
-    auto cubos = Cubos();
+    auto cubos = Cubos(argc, argv);
 
     /// [Adding the plugin]
     cubos.plugin(settingsPlugin);

--- a/engine/samples/render/main/main.cpp
+++ b/engine/samples/render/main/main.cpp
@@ -15,9 +15,9 @@ using namespace cubos::engine;
 static const Asset<Scene> SceneAsset = AnyAsset("05db7643-a8b8-49cd-8c16-0992136cfacf");
 static const Asset<VoxelPalette> PaletteAsset = AnyAsset("1aa5e234-28cb-4386-99b4-39386b0fc215");
 
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
 
     /// [Adding the plugins]
     cubos.plugin(settingsPlugin);

--- a/engine/samples/render/shadows/main.cpp
+++ b/engine/samples/render/shadows/main.cpp
@@ -28,9 +28,9 @@ CUBOS_REFLECT_IMPL(Spin)
     return cubos::core::ecs::TypeBuilder<Spin>("Spin").build();
 }
 
-int main()
+int main(int argc, char** argv)
 {
-    Cubos cubos{};
+    Cubos cubos{argc, argv};
 
     cubos.component<Spin>();
 

--- a/tools/tesseratos/CMakeLists.txt
+++ b/tools/tesseratos/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 set(TESSERATOS_SOURCE
 	"src/tesseratos/main.cpp"
+	"src/tesseratos/debugger/plugin.cpp"
+	"src/tesseratos/debugger/debugger.cpp"
 	"src/tesseratos/asset_explorer/plugin.cpp"
 	"src/tesseratos/asset_explorer/popup.cpp"
 	"src/tesseratos/settings_inspector/plugin.cpp"

--- a/tools/tesseratos/src/tesseratos/asset_explorer/popup.hpp
+++ b/tools/tesseratos/src/tesseratos/asset_explorer/popup.hpp
@@ -1,6 +1,3 @@
-/// @dir
-/// @brief @ref Function @ref tesseratos::assetSelectionPopup.
-
 /// @file
 /// @brief Utility function to show up a popup containing assets with given type.
 /// @ingroup tesseratos-asset-explorer

--- a/tools/tesseratos/src/tesseratos/debugger/debugger.cpp
+++ b/tools/tesseratos/src/tesseratos/debugger/debugger.cpp
@@ -1,0 +1,157 @@
+#include "debugger.hpp"
+
+#include <cubos/core/data/des/binary.hpp>
+#include <cubos/core/data/ser/binary.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::data::BinaryDeserializer;
+using cubos::core::data::BinarySerializer;
+using cubos::core::memory::Opt;
+using cubos::core::net::Address;
+using cubos::core::net::TcpStream;
+using cubos::core::reflection::ConstructibleTrait;
+using cubos::core::reflection::Type;
+using cubos::core::reflection::TypeClient;
+using tesseratos::Debugger;
+
+CUBOS_REFLECT_IMPL(Debugger)
+{
+    return Type::create("tesseratos::Debugger")
+        .with(ConstructibleTrait::typed<Debugger>().withDefaultConstructor().withMoveConstructor().build());
+}
+
+TypeClient& Debugger::typeClient()
+{
+    return mTypeClient;
+}
+
+const TypeClient& Debugger::typeClient() const
+{
+    return mTypeClient;
+}
+
+bool Debugger::isConnected() const
+{
+    return mConnection.contains();
+}
+
+bool Debugger::connect(const Address& address, uint16_t port)
+{
+    this->disconnect();
+
+    if (!mStream.connect(address, port))
+    {
+        CUBOS_ERROR("Failed to connect to debugger at {}:{}", address, port);
+        return false;
+    }
+
+    CUBOS_INFO("Connected to debugger at {}:{}", address, port);
+
+    if (auto connection = mTypeClient.connect(mStream))
+    {
+        CUBOS_INFO("Received shared reflection data from debugger successfully");
+        mConnection.replace(std::move(*connection));
+        return true;
+    }
+
+    CUBOS_ERROR("Failed to receive shared reflection data from debugger, closing connection");
+    mStream.disconnect();
+    return false;
+}
+
+void Debugger::disconnect()
+{
+    if (mConnection.contains())
+    {
+        CUBOS_INFO("Disconnecting from debugger");
+        BinarySerializer{mStream}.write<const char*>("disconnect");
+        mStream.disconnect();
+        mConnection.reset();
+    }
+}
+
+const TypeClient::Connection& Debugger::connection() const
+{
+    CUBOS_ASSERT(mConnection.contains(), "Debugger is not connected");
+    return mConnection.value();
+}
+
+bool Debugger::run()
+{
+    if (!mConnection.contains())
+    {
+        CUBOS_ERROR("Cannot issue start command, not connected to debugger");
+        return false;
+    }
+
+    if (!BinarySerializer{mStream}.write<const char*>("run"))
+    {
+        CUBOS_ERROR("Failed to serialize run command");
+        this->disconnect();
+        return false;
+    }
+
+    return true;
+}
+
+bool Debugger::pause()
+{
+    if (!mConnection.contains())
+    {
+        CUBOS_ERROR("Cannot issue pause command, not connected to debugger");
+        return false;
+    }
+
+    if (!BinarySerializer{mStream}.write<const char*>("pause"))
+    {
+        CUBOS_ERROR("Failed to serialize pause command");
+        this->disconnect();
+        return false;
+    }
+
+    return true;
+}
+
+bool Debugger::update(std::size_t count)
+{
+    if (!mConnection.contains())
+    {
+        CUBOS_ERROR("Cannot issue update command, not connected to debugger");
+        return false;
+    }
+
+    BinarySerializer ser{mStream};
+    if (!ser.write<const char*>("update") || !ser.write(count))
+    {
+        CUBOS_ERROR("Failed to serialize update command");
+        this->disconnect();
+        return false;
+    }
+
+    return true;
+}
+
+bool Debugger::close()
+{
+    if (!mConnection.contains())
+    {
+        CUBOS_ERROR("Cannot issue close command, not connected to debugger");
+        return false;
+    }
+
+    BinarySerializer ser{mStream};
+    if (!ser.write<const char*>("close"))
+    {
+        CUBOS_ERROR("Failed to serialize close command");
+        this->disconnect();
+        return false;
+    }
+
+    CUBOS_INFO("Sent close command, disconnecting from debugger");
+    mStream.disconnect();
+    mConnection.reset();
+    return true;
+}

--- a/tools/tesseratos/src/tesseratos/debugger/debugger.hpp
+++ b/tools/tesseratos/src/tesseratos/debugger/debugger.hpp
@@ -1,0 +1,66 @@
+/// @file
+/// @brief Resource @ref tesseratos::Debugger.
+/// @ingroup tesseratos-debugger-plugin
+
+#pragma once
+
+#include <cubos/core/net/tcp_stream.hpp>
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/type_client.hpp>
+
+namespace tesseratos
+{
+    class Debugger
+    {
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief Returns the type client.
+        /// @return Type client.
+        cubos::core::reflection::TypeClient& typeClient();
+
+        /// @brief Returns the type client.
+        /// @return Type client.
+        const cubos::core::reflection::TypeClient& typeClient() const;
+
+        /// @brief Checks if the debugger is connected.
+        /// @return Whether the debugger is connected.
+        bool isConnected() const;
+
+        /// @brief Connects to a debugger.
+        /// @param address Address of the debugger.
+        /// @param port Port of the debugger.
+        /// @return Whether the connection was successful.
+        bool connect(const cubos::core::net::Address& address, uint16_t port);
+
+        /// @brief Disconnects from the debugger, if connected.
+        void disconnect();
+
+        /// @brief Returns the connection information.
+        /// @note Aborts if the debugger is not connected.
+        /// @return Connection information.
+        const cubos::core::reflection::TypeClient::Connection& connection() const;
+
+        /// @brief Issues a run command to the connected debugger.
+        /// @return Whether the command was sent successfully.
+        bool run();
+
+        /// @brief Issues a pause command to the connected debugger.
+        /// @return Whether the command was sent successfully.
+        bool pause();
+
+        /// @brief Issues an update command to the connected debugger.
+        /// @param count Number of frames to update.
+        /// @return Whether the command was sent successfully.
+        bool update(std::size_t count);
+
+        /// @brief Issues a close command to the connected debugger.
+        /// @return Whether the command was sent successfully.
+        bool close();
+
+    private:
+        cubos::core::reflection::TypeClient mTypeClient;
+        cubos::core::memory::Opt<cubos::core::reflection::TypeClient::Connection> mConnection;
+        cubos::core::net::TcpStream mStream;
+    };
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/debugger/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/debugger/plugin.cpp
@@ -1,0 +1,100 @@
+#include "plugin.hpp"
+
+#include <imgui.h>
+#include <imgui_stdlib.h>
+
+#include <cubos/engine/imgui/plugin.hpp>
+
+#include "../toolbox/plugin.hpp"
+
+using cubos::core::net::Address;
+
+using namespace cubos::engine;
+
+namespace
+{
+    struct State
+    {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
+        std::string address{"127.0.0.1"};
+        uint16_t port = 9335;
+
+        uint32_t updateCount = 1;
+    };
+} // namespace
+
+void tesseratos::debuggerPlugin(Cubos& cubos)
+{
+    cubos.depends(toolboxPlugin);
+    cubos.depends(imguiPlugin);
+
+    cubos.resource<Debugger>();
+    cubos.resource<State>();
+
+    cubos.system("show Debugger").tagged(imguiTag).call([](Toolbox& toolbox, State& state, Debugger& debugger) {
+        if (!toolbox.isOpen("Debugger"))
+        {
+            return;
+        }
+
+        if (!ImGui::Begin("Debugger"))
+        {
+            ImGui::End();
+            return;
+        }
+
+        // If the debugger isn't currently connected, show the connection form UI.
+        if (!debugger.isConnected())
+        {
+            ImGui::InputText("Address", &state.address);
+            ImGui::InputScalar("Port", ImGuiDataType_U16, &state.port);
+
+            if (ImGui::Button("Connect"))
+            {
+                if (auto address = Address::from(state.address))
+                {
+                    debugger.connect(*address, state.port);
+                }
+                else
+                {
+                    CUBOS_ERROR("Failed to parse address from {}", state.address);
+                }
+            }
+
+            ImGui::End();
+            return;
+        }
+
+        // Otherwise, show the debugger control UI.
+
+        if (ImGui::Button("Run"))
+        {
+            debugger.run();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Pause"))
+        {
+            debugger.pause();
+        }
+
+        if (ImGui::Button("Update"))
+        {
+            debugger.update(static_cast<std::size_t>(state.updateCount));
+        }
+        ImGui::SameLine();
+        ImGui::InputScalar("Update count", ImGuiDataType_U32, &state.updateCount);
+
+        if (ImGui::Button("Close"))
+        {
+            debugger.close();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Disconnect"))
+        {
+            debugger.disconnect();
+        }
+
+        ImGui::End();
+    });
+}

--- a/tools/tesseratos/src/tesseratos/debugger/plugin.hpp
+++ b/tools/tesseratos/src/tesseratos/debugger/plugin.hpp
@@ -1,0 +1,30 @@
+/// @dir
+/// @brief @ref tesseratos-debugger-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup tesseratos-debugger-plugin
+
+#pragma once
+
+#include <cubos/core/ecs/entity/entity.hpp>
+#include <cubos/core/gl/render_device.hpp>
+
+#include <cubos/engine/prelude.hpp>
+
+#include "debugger.hpp"
+
+namespace tesseratos
+{
+    /// @defgroup tesseratos-debugger-plugin Debugger
+    /// @ingroup tesseratos
+    /// @brief Adds a resource used to manage a connection to a Cubos debugger.
+    ///
+    /// ## Resources
+    /// - @ref Debugger - contains connection information.
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b Cubos main class
+    /// @ingroup tesseratos-debugger-plugin
+    void debuggerPlugin(cubos::engine::Cubos& cubos);
+} // namespace tesseratos

--- a/tools/tesseratos/src/tesseratos/main.cpp
+++ b/tools/tesseratos/src/tesseratos/main.cpp
@@ -10,6 +10,7 @@
 #include "collider_gizmos/plugin.hpp"
 #include "console/plugin.hpp"
 #include "debug_camera/plugin.hpp"
+#include "debugger/plugin.hpp"
 #include "ecs_statistics/plugin.hpp"
 #include "entity_inspector/plugin.hpp"
 #include "entity_selector/plugin.hpp"
@@ -42,6 +43,7 @@ int main(int argc, char** argv)
     cubos.plugin(toolboxPlugin);
     cubos.plugin(entitySelectorPlugin);
 
+    cubos.plugin(debuggerPlugin);
     cubos.plugin(assetExplorerPlugin);
     cubos.plugin(entityInspectorPlugin);
     cubos.plugin(worldInspectorPlugin);


### PR DESCRIPTION
# Description

Adds remote debugging to Cubos. Basically, the Cubos class now parses its incoming command line arguments.
If `--debug <port>` is passed, then, instead of immediately starting and running the game, it waits for a TCP connection on that port. When a connection is accepted, it listens for commands, such as:
- `run` - makes the application resume running.
- `pause` - makes the application stop and wait for further commands.
- `update <N>` - makes the application run its update systems `N` times.
- `close` - closes the application.
- `disconnect` - closes the connection. The application starts listening again for another connection.

Also adds a simple UI tool to test this functionality inside Tesseratos.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~ (too troublesome to test right now, we don't have time for that in 0.4 :pensive:)
- [x] ~~Write new samples.~~ (works with any existing sample)
- [x] Add entry to the changelog's unreleased section.
