### PR TITLE
Allow opening projects through Tesseratos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global telemetry level (for tracing/logging) (#1265, **@roby2014**).
 - Spans for tracing and profiling (#1265, **@roby2014**).
 - Simple cross-platform multi-process utilities (**@RiscadoA**).
+- Project opening and closing on Tesseratos (#1218, **@RiscadoA**).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cascaded shadow maps (#1187, **@tomas7770**).
 - Global telemetry level (for tracing/logging) (#1265, **@roby2014**).
 - Spans for tracing and profiling (#1265, **@roby2014**).
+- Simple cross-platform multi-process utilities (**@RiscadoA**).
 
 ### Changed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CUBOS_CORE_SOURCE
 	"src/tel/level.cpp"
 
 	"src/thread/pool.cpp"
+	"src/thread/process.cpp"
 	"src/thread/task.cpp"
 
 	"src/memory/stream.cpp"

--- a/core/include/cubos/core/data/fs/standard_archive.hpp
+++ b/core/include/cubos/core/data/fs/standard_archive.hpp
@@ -35,6 +35,10 @@ namespace cubos::core::data
         /// @param readOnly True if the archive is read-only, false otherwise.
         StandardArchive(const std::filesystem::path& osPath, bool isDirectory, bool readOnly);
 
+        /// @brief Checks if the archive was successfully initialized.
+        /// @return True if the archive was successfully initialized, false otherwise.
+        bool initialized() const;
+
         std::size_t create(std::size_t parent, std::string_view name, bool directory = false) override;
         bool destroy(std::size_t id) override;
         std::string name(std::size_t id) const override;

--- a/core/include/cubos/core/thread/process.hpp
+++ b/core/include/cubos/core/thread/process.hpp
@@ -1,0 +1,58 @@
+/// @file
+/// @brief Class @ref cubos::core::thread::Process.
+/// @ingroup core-thread
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::core::thread
+{
+    /// @brief Provides a cross-platform way to spawn child processes.
+    /// @ingroup core-thread
+    class Process final
+    {
+    public:
+        CUBOS_REFLECT;
+
+        ~Process();
+
+        /// @brief Default constructor.
+        Process() = default;
+
+        /// @brief Move constructor.
+        Process(Process&& other) noexcept;
+
+        /// @brief Move assignment operator.
+        Process& operator=(Process&& other) noexcept;
+
+        /// @brief Starts a new process.
+        /// @param command Command to execute.
+        /// @param args Arguments to pass to the command.
+        /// @param cwd Working directory for the new process.
+        /// @return Whether the process was started successfully.
+        bool start(const std::string& command, const std::vector<std::string>& args = {}, const std::string& cwd = "");
+
+        /// @brief Kills the process.
+        void kill();
+
+        /// @brief Waits for the process to finish.
+        /// @return Whether the process exited normally.
+        bool wait();
+
+        /// @brief Waits for the process to finish.
+        /// @param status Exit code of the process, if it exited normally.
+        /// @return Whether the process exited normally.
+        bool wait(int& status);
+
+        /// @brief Checks whether the process has been started.
+        /// @return Whether the process has been started.
+        bool started() const;
+
+    private:
+        void* mHandle{nullptr};
+    };
+} // namespace cubos::core::thread

--- a/core/include/cubos/core/thread/task.hpp
+++ b/core/include/cubos/core/thread/task.hpp
@@ -29,6 +29,15 @@ namespace cubos::core::thread
             mData = new Data();
         }
 
+        /// @brief Constructs a finished task.
+        /// @param value Task result.
+        /// @return Task.
+        Task(T value)
+            : Task{}
+        {
+            this->finish(std::move(value));
+        }
+
         /// @brief Copy constructs.
         /// @param other Task.
         Task(const Task& other)

--- a/core/src/data/fs/standard_archive.cpp
+++ b/core/src/data/fs/standard_archive.cpp
@@ -109,6 +109,11 @@ void StandardArchive::generate(std::size_t parent)
     }
 }
 
+bool StandardArchive::initialized() const
+{
+    return !mFiles.empty();
+}
+
 std::size_t StandardArchive::create(std::size_t parent, std::string_view name, bool directory)
 {
     INIT_OR_RETURN(0);

--- a/core/src/thread/process.cpp
+++ b/core/src/thread/process.cpp
@@ -1,0 +1,197 @@
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/tel/logging.hpp>
+#include <cubos/core/thread/process.hpp>
+
+using cubos::core::thread::Process;
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
+#include <csignal>
+#include <cstring>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+CUBOS_REFLECT_IMPL(Process)
+{
+    return reflection::Type::create("cubos::core::thread::Process")
+        .with(reflection::ConstructibleTrait::typed<Process>().withDefaultConstructor().withMoveConstructor().build());
+}
+
+Process::~Process()
+{
+    this->kill();
+    this->wait();
+}
+
+Process::Process(Process&& other) noexcept
+    : mHandle{other.mHandle}
+{
+    other.mHandle = nullptr;
+}
+
+Process& Process::operator=(Process&& other) noexcept
+{
+    if (this == &other)
+    {
+        return *this;
+    }
+
+    this->wait();
+    mHandle = other.mHandle;
+    other.mHandle = nullptr;
+    return *this;
+}
+
+bool Process::start(const std::string& command, const std::vector<std::string>& args, const std::string& cwd)
+{
+    this->wait();
+
+#ifdef _WIN32
+    // Launch the binary with appropriate arguments.
+    std::string finalCommand = command;
+    for (const auto& arg : args)
+    {
+        finalCommand += " " + arg;
+    }
+    STARTUPINFOA si = {sizeof(si)};
+    PROCESS_INFORMATION pi;
+    if (!CreateProcessA(nullptr, const_cast<char*>(finalCommand.c_str()), nullptr, nullptr, FALSE, 0, nullptr,
+                        cwd.empty() ? nullptr : cwd.c_str(), &si, &pi))
+    {
+        CUBOS_ERROR("Failed to start process {} with error {}", command, GetLastError());
+        return false;
+    }
+
+    mHandle = new PROCESS_INFORMATION{pi};
+    CUBOS_INFO("Started process {} with PID {}", command, pi.dwProcessId);
+#else
+    auto pid = fork();
+    if (pid == -1)
+    {
+        CUBOS_ERROR("Failed to fork process");
+        return false;
+    }
+
+    if (pid == 0) // Are we the child process?
+    {
+        if (!cwd.empty())
+        {
+            // Change the working directory.
+            if (chdir(cwd.c_str()) == -1)
+            {
+                CUBOS_CRITICAL("Failed to change working directory to {}", cwd);
+                exit(1);
+            }
+        }
+
+        // Launch the binary with appropriate arguments.
+        std::vector<std::string> argsCopy = args;
+        argsCopy.insert(argsCopy.begin(), command);
+        std::vector<char*> argv{};
+        argv.reserve(argsCopy.size() + 1);
+        for (const auto& arg : argsCopy)
+        {
+            argv.push_back(const_cast<char*>(arg.c_str()));
+        }
+        argv.push_back(nullptr);
+        execvp(command.c_str(), argv.data());
+
+        // If we reach this point, execv failed. Get the error message and log it.
+        CUBOS_CRITICAL("Failed to start process {} with error {}", command, strerror(errno));
+        exit(1);
+    }
+
+    // We are the parent process.
+    mHandle = new pid_t{pid};
+    CUBOS_INFO("Started process {} with PID {}", command, pid);
+#endif
+
+    return true;
+}
+
+void Process::kill()
+{
+    if (mHandle == nullptr)
+    {
+        return;
+    }
+
+#ifdef _WIN32
+    auto* pi = static_cast<PROCESS_INFORMATION*>(mHandle);
+    ::TerminateProcess(pi->hProcess, 1);
+    CUBOS_DEBUG("Process {} killed", pi->dwProcessId);
+#else
+    auto* pid = static_cast<pid_t*>(mHandle);
+    ::kill(*pid, SIGKILL);
+    CUBOS_DEBUG("Process {} killed", *pid);
+#endif
+}
+
+bool Process::wait()
+{
+    int status;
+    return this->wait(status);
+}
+
+bool Process::wait(int& status)
+{
+    if (mHandle == nullptr)
+    {
+        return false;
+    }
+
+#ifdef _WIN32
+    auto* pi = static_cast<PROCESS_INFORMATION*>(mHandle);
+    mHandle = nullptr;
+
+    ::WaitForSingleObject(pi->hProcess, INFINITE);
+
+    DWORD exitCode;
+    GetExitCodeProcess(pi->hProcess, &exitCode);
+    status = static_cast<int>(exitCode);
+    CUBOS_DEBUG("Process {} exited with status {}", pi->dwProcessId, status);
+
+    ::CloseHandle(pi->hProcess);
+    ::CloseHandle(pi->hThread);
+    delete pi;
+
+    return true;
+#else
+    auto pid = *static_cast<pid_t*>(mHandle);
+    delete static_cast<pid_t*>(mHandle);
+    mHandle = nullptr;
+
+    int waitStatus;
+    ::waitpid(pid, &waitStatus, 0);
+
+    if (WIFEXITED(waitStatus))
+    {
+        status = WEXITSTATUS(waitStatus);
+        CUBOS_DEBUG("Process {} exited with status {}", pid, status);
+        return true;
+    }
+
+    if (WIFSIGNALED(waitStatus))
+    {
+        CUBOS_WARN("Process {} terminated by signal {}", pid, WTERMSIG(waitStatus));
+        return false;
+    }
+
+    CUBOS_WARN("Process {} terminated abnormally", pid);
+    return false;
+#endif
+}
+
+bool Process::started() const
+{
+    return mHandle != nullptr;
+}

--- a/core/tests/data/fs/standard_archive.cpp
+++ b/core/tests/data/fs/standard_archive.cpp
@@ -16,6 +16,7 @@ using cubos::core::memory::Stream;
 static void assertInitializationFailed(StandardArchive& archive)
 {
     REQUIRE_FALSE(archive.directory(1)); // Independently of it was created as a directory or not.
+    REQUIRE_FALSE(archive.initialized());
     REQUIRE(archive.parent(1) == 0);
     REQUIRE(archive.sibling(1) == 0);
     REQUIRE(archive.child(1) == 0);
@@ -62,6 +63,7 @@ TEST_CASE("data::StandardArchive") // NOLINT(readability-function-size)
 
         // Check if the structure is correct.
         CHECK(archive.readOnly() == readOnly);
+        CHECK(archive.initialized());
         CHECK(archive.parent(1) == 0);
         CHECK(archive.sibling(1) == 0);
         CHECK(archive.child(1) == 0);
@@ -133,6 +135,7 @@ TEST_CASE("data::StandardArchive") // NOLINT(readability-function-size)
         {
             archive = std::make_unique<StandardArchive>(path, true, false);
             CHECK_FALSE(archive->readOnly());
+            CHECK(archive->initialized());
 
             // Check initial structure.
             CHECK(archive->parent(1) == 0);
@@ -220,6 +223,7 @@ TEST_CASE("data::StandardArchive") // NOLINT(readability-function-size)
             // Create a read-only archive on the generated directory.
             archive = std::make_unique<StandardArchive>(path, true, true);
             CHECK(archive->readOnly());
+            CHECK(archive->initialized());
 
             // Check root.
             CHECK(archive->directory(1));

--- a/core/tests/thread/task.cpp
+++ b/core/tests/thread/task.cpp
@@ -10,6 +10,13 @@ using cubos::core::thread::Task;
 
 TEST_CASE("thread::Task")
 {
+    SUBCASE("finished task")
+    {
+        Task<int> task{42};
+        REQUIRE(task.isDone());
+        REQUIRE(task.result() == 42);
+    }
+
     SUBCASE("task which produces an int")
     {
         Task<int> task{};

--- a/engine/include/cubos/engine/assets/assets.hpp
+++ b/engine/include/cubos/engine/assets/assets.hpp
@@ -98,6 +98,14 @@ namespace cubos::engine
         /// @param path Path to load metadata from.
         void loadMeta(std::string_view path);
 
+        /// @brief Unloads all asset metadata from assets within the given path.
+        ///
+        /// If an asset from the given path is currently loaded, it will not be unloaded, but it will be dissociated
+        /// from its original metadata path.
+        ///
+        /// @param path Path to unload metadata from.
+        void unloadMeta(std::string_view path);
+
         /// @brief Loads the asset with the given handle, upgrading the handle to a strong one.
         ///
         /// This method doesn't block, thus the asset may have not yet been loaded when it returns.

--- a/engine/include/cubos/engine/collisions/shapes/box.hpp
+++ b/engine/include/cubos/engine/collisions/shapes/box.hpp
@@ -19,6 +19,6 @@ namespace cubos::engine
 
         cubos::core::geom::Box box; ///< Box shape.
 
-        bool changed = true;
+        bool changed{true};
     };
 } // namespace cubos::engine

--- a/engine/samples/complex_physics/assets/scenes/red_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/red_cube.cubos
@@ -2,17 +2,14 @@
   "entities": {
     "cube": {
       "cubos::engine::AccumulatedCorrection": {
-          "x": 0.0,
-          "y": 0.0,
-          "z": 0.0
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
       },
       "cubos::engine::BoxCollisionShape": {
-        "box" : {
-          "x": 0.5,
-          "y": 0.5,
-          "z": 0.5 
-        },
-        "changed" : true
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5 
       },
       "cubos::engine::Collider": {
         "a": {

--- a/engine/samples/complex_physics/assets/scenes/white_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/white_cube.cubos
@@ -7,12 +7,9 @@
           "z": 0.0
       },
       "cubos::engine::BoxCollisionShape": {
-        "box" : {
-          "x": 0.5,
-          "y": 0.5,
-          "z": 0.5 
-        },
-        "changed" : true
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5 
       },
       "cubos::engine::Collider": {
         "a": {

--- a/engine/samples/games/cubosurfers/assets/scenes/main.cubos
+++ b/engine/samples/games/cubosurfers/assets/scenes/main.cubos
@@ -19,11 +19,9 @@
                 "z": 0
             },
             "cubos::engine::BoxCollisionShape": {
-                "box": {
-                    "x": 3.0,
-                    "y": 7.0,
-                    "z": 2.0
-                }
+                "x": 3.0,
+                "y": 7.0,
+                "z": 2.0
             },
             "cubos::engine::Collider": {},
             "Player": {

--- a/engine/samples/games/cubosurfers/assets/scenes/obstacle.cubos
+++ b/engine/samples/games/cubosurfers/assets/scenes/obstacle.cubos
@@ -16,11 +16,9 @@
                 "w": 0
             },
             "cubos::engine::BoxCollisionShape": {
-                "box": {
-                    "x": 3.0,
-                    "y": 7.0,
-                    "z": 2.0
-                }
+                "x": 3.0,
+                "y": 7.0,
+                "z": 2.0
             },
             "cubos::engine::Collider": {},
             "Obstacle": {

--- a/engine/src/collisions/interface/shapes/box.cpp
+++ b/engine/src/collisions/interface/shapes/box.cpp
@@ -7,6 +7,5 @@ CUBOS_REFLECT_IMPL(cubos::engine::BoxCollisionShape)
 {
     return core::ecs::TypeBuilder<BoxCollisionShape>("cubos::engine::BoxCollisionShape")
         .withField("box", &BoxCollisionShape::box)
-        .withField("changed", &BoxCollisionShape::changed)
         .build();
 }

--- a/tools/tesseratos/CMakeLists.txt
+++ b/tools/tesseratos/CMakeLists.txt
@@ -5,6 +5,8 @@ set(TESSERATOS_SOURCE
 	"src/tesseratos/main.cpp"
 	"src/tesseratos/debugger/plugin.cpp"
 	"src/tesseratos/debugger/debugger.cpp"
+	"src/tesseratos/project/plugin.cpp"
+	"src/tesseratos/project/manager.cpp"
 	"src/tesseratos/asset_explorer/plugin.cpp"
 	"src/tesseratos/asset_explorer/popup.cpp"
 	"src/tesseratos/scene_editor/plugin.cpp"

--- a/tools/tesseratos/src/tesseratos/debugger/plugin.hpp
+++ b/tools/tesseratos/src/tesseratos/debugger/plugin.hpp
@@ -7,9 +7,6 @@
 
 #pragma once
 
-#include <cubos/core/ecs/entity/entity.hpp>
-#include <cubos/core/gl/render_device.hpp>
-
 #include <cubos/engine/prelude.hpp>
 
 #include "debugger.hpp"

--- a/tools/tesseratos/src/tesseratos/main.cpp
+++ b/tools/tesseratos/src/tesseratos/main.cpp
@@ -10,6 +10,7 @@
 #include "asset_explorer/plugin.hpp"
 #include "debugger/plugin.hpp"
 #include "importer/plugin.hpp"
+#include "project/plugin.hpp"
 #include "scene_editor/plugin.hpp"
 #include "voxel_palette_editor/plugin.hpp"
 
@@ -34,6 +35,8 @@ int main(int argc, char** argv)
 
     cubos.plugin(debuggerPlugin);
     cubos.plugin(assetExplorerPlugin);
+
+    cubos.plugin(projectPlugin);
 
     cubos.plugin(sceneEditorPlugin);
     cubos.plugin(voxelPaletteEditorPlugin);

--- a/tools/tesseratos/src/tesseratos/project/manager.cpp
+++ b/tools/tesseratos/src/tesseratos/project/manager.cpp
@@ -1,0 +1,145 @@
+#include "manager.hpp"
+#include <thread>
+
+#include <cubos/core/data/fs/file_system.hpp>
+#include <cubos/core/data/fs/standard_archive.hpp>
+#include <cubos/core/reflection/external/cstring.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::data::FileSystem;
+using cubos::core::data::StandardArchive;
+using cubos::core::net::Address;
+
+CUBOS_REFLECT_IMPL(tesseratos::ProjectManager::State)
+{
+    using namespace cubos::core::reflection;
+    return Type::create("tesseratos::ProjectManager::State")
+        .with(ConstructibleTrait::typed<State>().withMoveConstructor().build());
+}
+
+tesseratos::ProjectManager::ProjectManager(State& state, cubos::engine::Assets& assets, Debugger& debugger)
+    : mState(state)
+    , mAssets(assets)
+    , mDebugger(debugger)
+{
+}
+
+bool tesseratos::ProjectManager::open(std::string projectOSPath, std::string binaryOSPath)
+{
+    if (projectOSPath.empty())
+    {
+        CUBOS_ERROR("Project path is empty");
+        return false;
+    }
+
+    this->close();
+
+    // Prepare the project directory for mounting.
+    auto archive = std::make_unique<StandardArchive>(projectOSPath, /*isDirectory=*/true, /*readOnly=*/false);
+    if (!archive->initialized())
+    {
+        CUBOS_ERROR("Could not open project at {}", projectOSPath);
+        return false;
+    }
+
+    if (!FileSystem::mount("/project", std::move(archive)))
+    {
+        CUBOS_ERROR("Could not mount project archive to /project");
+        return false;
+    }
+
+    // Load asset metadata from the project assets directory.
+    mAssets.loadMeta("/project/assets");
+
+    // We managed to open the project's directory, store the paths.
+    mState.mProjectOSPath = std::move(projectOSPath);
+    mState.mBinaryOSPath = std::move(binaryOSPath);
+
+    // Try to launch the project.
+    // If we can't, we can still keep the project open, but we won't be able to use its types.
+    this->launch();
+
+    return true;
+}
+
+bool tesseratos::ProjectManager::open() const
+{
+    return !mState.mProjectOSPath.empty();
+}
+
+void tesseratos::ProjectManager::close()
+{
+    if (mState.mProjectOSPath.empty())
+    {
+        return;
+    }
+
+    this->terminate();
+
+    // Unload asset metadata from the project.
+    mAssets.unloadMeta("/project/assets");
+
+    // Unmount its directory from the virtual file system.
+    if (!FileSystem::unmount("/project"))
+    {
+        CUBOS_ERROR("Failed to unmount previously open project directory");
+    }
+
+    mState.mProjectOSPath.clear();
+}
+
+bool tesseratos::ProjectManager::launch()
+{
+    // Stop the binary if it is already running.
+    this->terminate();
+
+    if (!mState.mProcess.start(mState.mBinaryOSPath, {"--debug", std::to_string(mState.mPort)}))
+    {
+        CUBOS_ERROR("Could not start project's process at {}", mState.mBinaryOSPath);
+        return false;
+    }
+
+    // Try to connect to the child process's debugger.
+    for (int i = 1, sleep = 100; i <= 3; ++i, sleep *= 2)
+    {
+        if (i > 0)
+        {
+            CUBOS_WARN("CCould not connect to project's process debugger in try {}, retrying in {} ms", i - 1, sleep);
+            std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
+        }
+
+        if (mDebugger.connect(Address::LocalHost, mState.mPort))
+        {
+            CUBOS_INFO("Successfully connected to project's process debugger in try {}", i);
+            break;
+        }
+    }
+
+    // Check if we successfully connected to the child process's debugger.
+    // If we didn't, kill the child process.
+    if (!mDebugger.isConnected())
+    {
+        CUBOS_ERROR("Could not connect to the project's process debugger, terminating the process");
+        mState.mProcess.kill();
+        return false;
+    }
+
+    return true;
+}
+
+void tesseratos::ProjectManager::terminate()
+{
+    if (mDebugger.isConnected())
+    {
+        mDebugger.close(); // Issue a close command to the process' debugger.
+    }
+    else
+    {
+        mState.mProcess.kill();
+    }
+
+    mState.mProcess.wait(); // Wait for the process to finish.
+}

--- a/tools/tesseratos/src/tesseratos/project/manager.hpp
+++ b/tools/tesseratos/src/tesseratos/project/manager.hpp
@@ -1,0 +1,115 @@
+/// @file
+/// @brief System argument @ref tesseratos::ProjectManager.
+/// @ingroup tesseratos-debugger-plugin
+
+#pragma once
+
+#include <string>
+
+#include <cubos/core/ecs/system/fetcher.hpp>
+#include <cubos/core/thread/process.hpp>
+
+#include <cubos/engine/assets/plugin.hpp>
+
+#include "../debugger/debugger.hpp"
+
+namespace tesseratos
+{
+    /// @brief System argument which can be used to manage the currently loaded project.
+    class ProjectManager
+    {
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief Resource which holds the state of the project manager.
+        class State;
+
+        /// @brief Constructs.
+        /// @param state State of the project manager.
+        /// @param assets Asset manager.
+        /// @param debugger Debugger.
+        ProjectManager(State& state, cubos::engine::Assets& assets, Debugger& debugger);
+
+        /// @brief Opens a project directory.
+        ///
+        /// The given project directory is mounted in the /project directory in the virtual file system.
+        /// Unmounts any previously opened project directory.
+        ///
+        /// @param projectOSPath Project's directory path in the operating system.
+        /// @param binaryOSPath Project's binary directory path in the operating system.
+        /// @return Whether the project could be opened successfully.
+        bool open(std::string projectOSPath, std::string binaryOSPath);
+
+        /// @brief Checks whether a project is currently open.
+        /// @return Whether a project is currently open.
+        bool open() const;
+
+        /// @brief Closes the currently open project.
+        void close();
+
+        /// @brief Launches the project's binary and attaches the debugger.
+        ///
+        /// If the binary is already running, it is stopped first.
+        ///
+        /// @return Whether the project could be launched successfully.
+        bool launch();
+
+        /// @brief Stops the project's binary.
+        void terminate();
+
+    private:
+        State& mState;
+        cubos::engine::Assets& mAssets;
+        Debugger& mDebugger;
+    };
+
+    class ProjectManager::State
+    {
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief Default constructs.
+        State() = default;
+
+    private:
+        friend ProjectManager;
+
+        std::string mProjectOSPath{};
+        std::string mBinaryOSPath{};
+        cubos::core::thread::Process mProcess{};
+        uint16_t mPort{9335};
+    };
+} // namespace tesseratos
+
+namespace cubos::core::ecs
+{
+    template <>
+    class SystemFetcher<tesseratos::ProjectManager>
+    {
+    public:
+        static inline constexpr bool ConsumesOptions = false;
+
+        SystemFetcher<tesseratos::ProjectManager::State&> state;
+        SystemFetcher<cubos::engine::Assets&> assets;
+        SystemFetcher<tesseratos::Debugger&> debugger;
+
+        SystemFetcher(World& world, const SystemOptions& options)
+            : state{world, options}
+            , assets{world, options}
+            , debugger{world, options}
+        {
+        }
+
+        void analyze(SystemAccess& access) const
+        {
+            state.analyze(access);
+            assets.analyze(access);
+            debugger.analyze(access);
+        }
+
+        tesseratos::ProjectManager fetch(const SystemContext& ctx)
+        {
+            return {state.fetch(ctx), assets.fetch(ctx), debugger.fetch(ctx)};
+        }
+    };
+} // namespace cubos::core::ecs

--- a/tools/tesseratos/src/tesseratos/project/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/project/plugin.cpp
@@ -1,0 +1,85 @@
+#include "plugin.hpp"
+#include <sstream>
+
+#include <imgui.h>
+#include <imgui_stdlib.h>
+
+#include <cubos/core/data/fs/file_system.hpp>
+#include <cubos/core/data/fs/standard_archive.hpp>
+#include <cubos/core/reflection/external/string.hpp>
+
+#include <cubos/engine/imgui/plugin.hpp>
+#include <cubos/engine/settings/plugin.hpp>
+#include <cubos/engine/tools/toolbox/plugin.hpp>
+
+#include "../debugger/plugin.hpp"
+
+using namespace cubos::core::data;
+using namespace cubos::engine;
+
+void tesseratos::projectPlugin(Cubos& cubos)
+{
+    cubos.depends(toolboxPlugin);
+    cubos.depends(imguiPlugin);
+    cubos.depends(settingsPlugin);
+    cubos.depends(assetsPlugin);
+    cubos.depends(debuggerPlugin);
+
+    cubos.resource<ProjectManager::State>();
+
+    cubos.system("show Project")
+        .tagged(imguiTag)
+        .call([](ProjectManager project, Toolbox& toolbox, Settings& settings) {
+            if (!toolbox.isOpen("Project"))
+            {
+                return;
+            }
+
+            if (!ImGui::Begin("Project"))
+            {
+                ImGui::End();
+                return;
+            }
+
+            if (!project.open())
+            {
+                // If the project is not open, only show the open dialog.
+                auto projectOSPath = settings.getString("project.path", "");
+                if (ImGui::InputText("Project Path", &projectOSPath))
+                {
+                    settings.setString("project.path", projectOSPath);
+                }
+
+                auto binaryOSPath = settings.getString("project.binary.path", "");
+                if (ImGui::InputText("Binary Path", &binaryOSPath))
+                {
+                    settings.setString("project.binary.path", binaryOSPath);
+                }
+
+                if (ImGui::Button("Open") && !project.open(projectOSPath, binaryOSPath))
+                {
+                    CUBOS_ERROR("Failed to open project");
+                }
+
+                ImGui::End();
+                return;
+            }
+
+            if (ImGui::Button("Launch"))
+            {
+                project.launch();
+            }
+
+            if (ImGui::Button("Terminate"))
+            {
+                project.terminate();
+            }
+
+            if (ImGui::Button("Close"))
+            {
+                project.close();
+            }
+
+            ImGui::End();
+        });
+}

--- a/tools/tesseratos/src/tesseratos/project/plugin.hpp
+++ b/tools/tesseratos/src/tesseratos/project/plugin.hpp
@@ -1,0 +1,24 @@
+/// @dir
+/// @brief @ref tesseratos-project-plugin plugin directory.
+
+/// @file
+/// @brief Plugin entry point.
+/// @ingroup tesseratos-project-plugin
+
+#pragma once
+
+#include <cubos/engine/prelude.hpp>
+
+#include "manager.hpp"
+
+namespace tesseratos
+{
+    /// @defgroup tesseratos-project-plugin Project
+    /// @ingroup tesseratos
+    /// @brief Adds a resource used to manage the currently loaded project.
+
+    /// @brief Plugin entry function.
+    /// @param cubos @b Cubos main class
+    /// @ingroup tesseratos-project-plugin
+    void projectPlugin(cubos::engine::Cubos& cubos);
+} // namespace tesseratos


### PR DESCRIPTION
# Description

Adds the project plugin, which adds support for the `ProjectManager` system argument, along with an ImGui window for opening and closing projects + launching them and terminating them.
Also adds an utility class Process to the core to handle multiple processes in a cross-platform way.

There are also some other random fixes or simple methods that I needed to add to other areas in order to make this possible. Looking at the commit history probably gives a better view of what I changed.

**I need people with Windows and MacOS to check if this also works in other operating systems**

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] ~~Ensure test coverage.~~ The only part that we could in theory could (easily) test of this is the cross-platform multi process utilities I added, but sadly doctest doesn't handle multi process stuff well at all.
- [x] ~~Write new samples.~~ You can test it by opening tesseratos, opening the Project window, setting a project folder and a binary/executable path, and launching it. Then you can use the debugger tool to step, run or terminate the game.
- [x] Add entry to the changelog's unreleased section.
