### PR TITLE
Added generic camera component to hold projection matrix and replaced…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary Serializer and Deserializer (#1306, **@RiscadoA**).
 - Type Client and Type Server (#1302, **@RiscadoA**).
 - Deadzone for input axis (#844, **@kuukitenshi**)
+- Generic Camera component to hold projection matrix (#1331, **@mkuritsu**)
 
 ### Fixed
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -129,6 +129,7 @@ set(CUBOS_ENGINE_SOURCE
 	"src/render/camera/plugin.cpp"
 	"src/render/camera/perspective_camera.cpp"
 	"src/render/camera/draws_to.cpp"
+	"src/render/camera/camera.cpp"
 	"src/render/voxels/plugin.cpp"
 	"src/render/voxels/load.cpp"
 	"src/render/voxels/grid.cpp"

--- a/engine/include/cubos/engine/render/camera/camera.hpp
+++ b/engine/include/cubos/engine/render/camera/camera.hpp
@@ -1,0 +1,28 @@
+/// @file
+/// @brief Component @ref cubos::engine::Camera
+/// @ingroup render-camera-plugin
+
+#pragma once
+
+#include <glm/mat4x4.hpp>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Generic component to hold the projection matrix of a specific camera (either perspective or orthogonal).
+    /// @note Added automatically once a specific camera is added (e.g @ref cubos::engine::PerspectiveCamera).
+    /// @ingroup render-camera-plugin
+    struct CUBOS_ENGINE_API Camera
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Whether the camera is drawing to a target.
+        bool active{true};
+
+        /// @brief Projection matrix of the camera.
+        glm::mat4 projection{};
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/render/camera/perspective_camera.hpp
+++ b/engine/include/cubos/engine/render/camera/perspective_camera.hpp
@@ -17,9 +17,6 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        /// @brief Whether the camera is drawing to a target.
-        bool active = true;
-
         /// @brief Vertical field of view in degrees.
         float fovY = 60.0F;
 

--- a/engine/src/gizmos/plugin.cpp
+++ b/engine/src/gizmos/plugin.cpp
@@ -6,8 +6,8 @@
 
 #include <cubos/engine/gizmos/plugin.hpp>
 #include <cubos/engine/gizmos/target.hpp>
+#include <cubos/engine/render/camera/camera.hpp>
 #include <cubos/engine/render/camera/draws_to.hpp>
-#include <cubos/engine/render/camera/perspective_camera.hpp>
 #include <cubos/engine/render/camera/plugin.hpp>
 #include <cubos/engine/render/picker/picker.hpp>
 #include <cubos/engine/render/picker/plugin.hpp>
@@ -106,7 +106,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
         .tagged(drawToRenderPickerTag)
         .call([](Gizmos& gizmos, GizmosRenderer& gizmosRenderer, const DeltaTime& deltaTime,
                  Query<Entity, RenderTarget&, RenderPicker&, GizmosTarget&> targets,
-                 Query<const LocalToWorld&, const PerspectiveCamera&, const DrawsTo&> cameras) {
+                 Query<const LocalToWorld&, const Camera&, const DrawsTo&> cameras) {
             auto& rd = *gizmosRenderer.renderDevice;
             auto orthoVP =
                 glm::translate(glm::mat4(1.0F), glm::vec3(-1.0F, -1.0F, 0.0F)) * glm::ortho(-0.5F, 0.5F, -0.5F, 0.5F);
@@ -156,11 +156,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                                   static_cast<int>(drawsTo.viewportSize.y * static_cast<float>(target.size.y)));
 
                     // Prepare camera projection (TODO: fetch this matrix from a Camera component).
-                    auto worldVP = glm::perspective(glm::radians(camera.fovY),
-                                                    (drawsTo.viewportSize.x * static_cast<float>(target.size.x)) /
-                                                        (drawsTo.viewportSize.y * static_cast<float>(target.size.y)),
-                                                    camera.zNear, camera.zFar) *
-                                   glm::inverse(localToWorld.mat);
+                    auto worldVP = camera.projection * glm::inverse(localToWorld.mat);
 
                     // Draw world-space gizmos.
                     rd.setDepthStencilState(gizmosRenderer.doDepthCheckStencilState);
@@ -209,11 +205,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                                   static_cast<int>(drawsTo.viewportSize.y * static_cast<float>(target.size.y)));
 
                     // Prepare camera projection (TODO: fetch this matrix from a Camera component).
-                    auto worldVP = glm::perspective(glm::radians(camera.fovY),
-                                                    (drawsTo.viewportSize.x * static_cast<float>(target.size.x)) /
-                                                        (drawsTo.viewportSize.y * static_cast<float>(target.size.y)),
-                                                    camera.zNear, camera.zFar) *
-                                   glm::inverse(localToWorld.mat);
+                    auto worldVP = camera.projection * glm::inverse(localToWorld.mat);
 
                     // Draw world-space gizmos.
                     rd.setDepthStencilState(gizmosRenderer.doDepthCheckStencilState);

--- a/engine/src/render/camera/camera.cpp
+++ b/engine/src/render/camera/camera.cpp
@@ -1,0 +1,13 @@
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/render/camera/camera.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::Camera)
+{
+    return core::ecs::TypeBuilder<Camera>("cubos::engine::Camera")
+        .withField("active", &Camera::active)
+        .withField("projection", &Camera::projection)
+        .build();
+}

--- a/engine/src/render/camera/draws_to.cpp
+++ b/engine/src/render/camera/draws_to.cpp
@@ -6,6 +6,7 @@
 CUBOS_REFLECT_IMPL(cubos::engine::DrawsTo)
 {
     return core::ecs::TypeBuilder<DrawsTo>("cubos::engine::DrawsTo")
+        .tree()
         .withField("viewportOffset", &DrawsTo::viewportOffset)
         .withField("viewportSize", &DrawsTo::viewportSize)
         .build();

--- a/engine/src/render/camera/perspective_camera.cpp
+++ b/engine/src/render/camera/perspective_camera.cpp
@@ -6,7 +6,6 @@
 CUBOS_REFLECT_IMPL(cubos::engine::PerspectiveCamera)
 {
     return core::ecs::TypeBuilder<PerspectiveCamera>("cubos::engine::PerspectiveCamera")
-        .withField("active", &PerspectiveCamera::active)
         .withField("fovY", &PerspectiveCamera::fovY)
         .withField("zNear", &PerspectiveCamera::zNear)
         .withField("zFar", &PerspectiveCamera::zFar)

--- a/engine/src/render/camera/plugin.cpp
+++ b/engine/src/render/camera/plugin.cpp
@@ -1,10 +1,44 @@
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <cubos/engine/render/camera/camera.hpp>
 #include <cubos/engine/render/camera/draws_to.hpp>
 #include <cubos/engine/render/camera/perspective_camera.hpp>
 #include <cubos/engine/render/camera/plugin.hpp>
+#include <cubos/engine/render/target/plugin.hpp>
+#include <cubos/engine/render/target/target.hpp>
+
+using namespace cubos::engine;
 
 void cubos::engine::cameraPlugin(Cubos& cubos)
 {
+    cubos.depends(renderTargetPlugin);
+
     cubos.component<PerspectiveCamera>();
+    cubos.component<Camera>();
 
     cubos.relation<DrawsTo>();
+
+    cubos.observer("add Camera on add PerspectiveCamera")
+        .onAdd<PerspectiveCamera>()
+        .without<Camera>()
+        .call([](Commands cmds, Query<Entity> query) {
+            for (auto [ent] : query)
+            {
+                cmds.add(ent, Camera{});
+            }
+        });
+
+    cubos.system("update Camera projection by PerspectiveCamera")
+        .call([](Query<Camera&, const PerspectiveCamera&, const DrawsTo&, const RenderTarget&> query) {
+            for (auto [camera, perspective, drawsTo, target] : query)
+            {
+                float aspect = (static_cast<float>(target.size.x) * drawsTo.viewportSize.x) /
+                               (static_cast<float>(target.size.y) * drawsTo.viewportSize.y);
+                if (aspect > 0)
+                {
+                    camera.projection =
+                        glm::perspective(glm::radians(perspective.fovY), aspect, perspective.zNear, perspective.zFar);
+                }
+            }
+        });
 }

--- a/tools/tesseratos/src/tesseratos/debug_camera/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/debug_camera/plugin.cpp
@@ -6,6 +6,7 @@
 #include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/input/input.hpp>
 #include <cubos/engine/input/plugin.hpp>
+#include <cubos/engine/render/camera/camera.hpp>
 #include <cubos/engine/render/camera/draws_to.hpp>
 #include <cubos/engine/render/camera/perspective_camera.hpp>
 #include <cubos/engine/render/camera/plugin.hpp>
@@ -20,6 +21,7 @@ using namespace cubos::core::io;
 
 using cubos::core::ecs::EntityHash;
 
+using cubos::engine::Camera;
 using cubos::engine::Commands;
 using cubos::engine::Cubos;
 using cubos::engine::DrawsTo;
@@ -63,9 +65,8 @@ void tesseratos::debugCameraPlugin(Cubos& cubos)
     cubos.startupSystem("create Debug Camera").call([](Commands commands, State& debugCamera) {
         debugCamera.entity = commands.create()
                                  .named("debug-camera")
-                                 .add(PerspectiveCamera{
-                                     .active = false,
-                                 })
+                                 .add(Camera{.active = false})
+                                 .add(PerspectiveCamera{})
                                  .add(Position{{}})
                                  .add(FreeCameraController{
                                      .enabled = false,
@@ -103,8 +104,7 @@ void tesseratos::debugCameraPlugin(Cubos& cubos)
     cubos.system("update Debug Camera")
         .tagged(cubos::engine::imguiTag)
         .onlyIf([](Toolbox& toolbox) { return toolbox.isOpen("Debug Camera"); })
-        .call([](State& state, Commands cmds,
-                 Query<Entity, PerspectiveCamera&, const DrawsTo&, const RenderTarget&> cameras,
+        .call([](State& state, Commands cmds, Query<Entity, Camera&, const DrawsTo&, const RenderTarget&> cameras,
                  Query<Entity, const RenderTarget&> targets) {
             ImGui::Begin("Debug Camera");
 

--- a/tools/tesseratos/src/tesseratos/transform_gizmo/plugin.cpp
+++ b/tools/tesseratos/src/tesseratos/transform_gizmo/plugin.cpp
@@ -8,7 +8,7 @@
 
 #include <cubos/engine/gizmos/plugin.hpp>
 #include <cubos/engine/input/plugin.hpp>
-#include <cubos/engine/render/camera/perspective_camera.hpp>
+#include <cubos/engine/render/camera/camera.hpp>
 #include <cubos/engine/render/camera/plugin.hpp>
 #include <cubos/engine/settings/plugin.hpp>
 #include <cubos/engine/transform/plugin.hpp>
@@ -24,11 +24,11 @@ using cubos::core::ecs::World;
 using cubos::core::io::Window;
 using cubos::core::memory::Opt;
 
+using cubos::engine::Camera;
 using cubos::engine::Cubos;
 using cubos::engine::Gizmos;
 using cubos::engine::Input;
 using cubos::engine::LocalToWorld;
-using cubos::engine::PerspectiveCamera;
 using cubos::engine::Position;
 using cubos::engine::Rotation;
 using cubos::engine::Scale;
@@ -111,7 +111,7 @@ static void checkRotation(Rotation& rotation, glm::vec3 globalPosition, glm::vec
     rotation.quat = glm::angleAxis(angle, axisVector) * rotation.quat;
 }
 
-static void drawPositionGizmo(Query<Position&, LocalToWorld&> positionQuery, const PerspectiveCamera& camera,
+static void drawPositionGizmo(Query<Position&, LocalToWorld&> positionQuery, const Camera& camera,
                               const LocalToWorld& cameraLtw, Gizmos& gizmos, const Input& input, const Window& window,
                               Entity selectedEntity, bool useLocalAxis, double distance)
 {
@@ -123,9 +123,7 @@ static void drawPositionGizmo(Query<Position&, LocalToWorld&> positionQuery, con
 
     pv = glm::inverse(pv);
 
-    pv = glm::perspective(glm::radians(camera.fovY), (float)window->size().x / (float)window->size().y, camera.zNear,
-                          camera.zFar) *
-         pv;
+    pv = camera.projection * pv;
 
     glm::vec3 xColor = {1, 0, 0};
     glm::vec3 yColor = {0, 1, 0};
@@ -229,7 +227,7 @@ static void drawPositionGizmo(Query<Position&, LocalToWorld&> positionQuery, con
                      0.7F);
 }
 
-static void drawRotationGizmo(Query<Rotation&, LocalToWorld&> positionQuery, const PerspectiveCamera& camera,
+static void drawRotationGizmo(Query<Rotation&, LocalToWorld&> positionQuery, const Camera& camera,
                               const LocalToWorld& cameraLtw, Gizmos& gizmos, const Input& input, const Window& window,
                               Entity selectedEntity, bool useLocalAxis, double distance)
 {
@@ -241,9 +239,7 @@ static void drawRotationGizmo(Query<Rotation&, LocalToWorld&> positionQuery, con
 
     pv = glm::inverse(pv);
 
-    pv = glm::perspective(glm::radians(camera.fovY), (float)window->size().x / (float)window->size().y, camera.zNear,
-                          camera.zFar) *
-         pv;
+    pv = camera.projection * pv;
 
     glm::vec3 xColor = {1, 0, 0};
     glm::vec3 yColor = {0, 1, 0};
@@ -306,7 +302,7 @@ void tesseratos::transformGizmoPlugin(Cubos& cubos)
         .call([](const EntitySelector& entitySelector, const Window& window, const Input& input, Settings& settings,
                  Gizmos& gizmos, Query<Position&, LocalToWorld&> positionQuery,
                  Query<Rotation&, LocalToWorld&> rotationQuery,
-                 Query<Entity, const PerspectiveCamera&, LocalToWorld&> cameraQuery) {
+                 Query<Entity, const Camera&, LocalToWorld&> cameraQuery) {
             if (entitySelector.selection.isNull())
             {
                 return;


### PR DESCRIPTION
… uses os PerspectiveCamera

# Description

Created a generic Camera component that just holds the projection matrix of the camera that will be updated every frame by the specific camera used (either perspective or orthographic).  
Also replaced usages of PerspectiveCamera to use the generic one along with its projection matrix.
As a note, the active parameter of the PerspectiveCamera was also moved to the generic Camera component.

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
