### PR TITLE
Show stacktrace on CUBOS_FAIL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "engine/lib/implot"]
 	path = engine/lib/implot
 	url = https://github.com/epezent/implot.git
+[submodule "core/lib/cpptrace"]
+	path = core/lib/cpptrace
+	url = git@github.com:jeremy-rifkin/cpptrace.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deadzone for input axis (#844, **@kuukitenshi**)
 - Generic Camera component to hold projection matrix (#1331, **@mkuritsu**)
 - Initial application debugging through Tesseratos (#1303, **@RiscadoA**).
+- Print stacktrace with *cpptrace* on calls to CUBOS_FAIL (#1172, **@RiscadoA**).
 
 ### Fixed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -217,6 +217,9 @@ add_subdirectory(lib/json)
 add_subdirectory(lib/stduuid)
 target_link_libraries(cubos-core PUBLIC stduuid)
 
+add_subdirectory(lib/cpptrace)
+target_link_libraries(cubos-core PRIVATE cpptrace::cpptrace)
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 

--- a/core/include/cubos/core/log.hpp
+++ b/core/include/cubos/core/log.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <cstdlib>
-
 #include <cubos/core/memory/buffer_stream.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
@@ -172,7 +170,7 @@
         {                                                                                                              \
             CUBOS_CRITICAL("" __VA_ARGS__);                                                                            \
         }                                                                                                              \
-        std::abort();                                                                                                  \
+        ::cubos::core::abort();                                                                                        \
     } while (false)
 
 /// @brief Marks a code path as supposedly unreachable. Aborts the program when reached.
@@ -238,6 +236,10 @@
 
 namespace cubos::core
 {
+    /// @brief Aborts the program and prints a pretty stack trace.
+    /// @ingroup core
+    [[noreturn]] void abort();
+
     /// @brief Singleton which holds the logging state.
     /// @ingroup core
     class CUBOS_CORE_API Logger final

--- a/core/src/gl/ogl_render_device.cpp
+++ b/core/src/gl/ogl_render_device.cpp
@@ -247,7 +247,7 @@ static void addressToGL(AddressMode mode, GLenum& address)
         address = GL_CLAMP_TO_BORDER;
         break;
     default:
-        abort(); // Invalid addressing mode
+        CUBOS_FAIL("Invalid addressing mode");
     }
 }
 
@@ -275,7 +275,7 @@ static void cubeFaceToGL(CubeFace cubeFace, GLenum& face)
         face = GL_TEXTURE_CUBE_MAP_NEGATIVE_Z;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -294,7 +294,7 @@ static void faceToGL(Face face, GLenum& glFace)
         glFace = GL_FRONT_AND_BACK;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -310,7 +310,7 @@ static void windingToGL(Winding winding, GLenum& glWinding)
         glWinding = GL_CCW;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -326,7 +326,7 @@ static void rasterModeToGL(RasterMode rasterMode, GLenum& polygonMode)
         polygonMode = GL_LINE;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -360,7 +360,7 @@ static void compareToGL(Compare compare, GLenum& glCompare)
         glCompare = GL_ALWAYS;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -394,7 +394,7 @@ static void stencilActionToGL(StencilAction action, GLenum& glAction)
         glAction = GL_INVERT;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -434,7 +434,7 @@ static void blendFactorToGL(BlendFactor blendFactor, GLenum& glBlendFactor)
         glBlendFactor = GL_ONE_MINUS_DST_ALPHA;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -459,7 +459,7 @@ static void blendOpToGL(BlendOp blendOp, GLenum& glBlendOp)
         glBlendOp = GL_MIN;
         break;
     default:
-        abort(); // Invalid enum
+        CUBOS_FAIL("Invalid enum");
     }
 }
 
@@ -1167,7 +1167,7 @@ public:
             glAccess = GL_READ_WRITE;
             break;
         default:
-            abort();
+            CUBOS_FAIL("Invalid enum");
         }
 
         glUniform1i(this->loc, this->tex);

--- a/core/src/log.cpp
+++ b/core/src/log.cpp
@@ -4,6 +4,8 @@
 #include <mutex>
 #include <vector>
 
+#include <cpptrace/cpptrace.hpp>
+
 #include <cubos/core/data/fs/file.hpp>
 #include <cubos/core/data/fs/file_system.hpp>
 #include <cubos/core/data/fs/standard_archive.hpp>
@@ -86,6 +88,12 @@ static const char* levelColor(Logger::Level level)
     default:
         return ColorResetCode;
     }
+}
+
+void cubos::core::abort()
+{
+    cpptrace::generate_trace(1).print();
+    std::abort();
 }
 
 std::string Logger::Location::string() const


### PR DESCRIPTION
# Description

Adds yet another dependency to the core lib, *cpptrace*.
This one is really necessary - turns out implementing this ourselves is a giant hassle, as there a lot of platform and compiler quirks.
In the future it might no longer be necessary, as C++23 comes with a `<stacktrace>` include - not all compilers support it yet.

To use this, I simply call our own `abort` function, which first prints the stacktrace using `cpptrace`, and then calls the usual `std::abort` function.

The result looks like this:
![image](https://github.com/user-attachments/assets/a43574a6-cfde-4ba8-8dae-f7372401f364)

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
