### PR TITLE
fix(engine): add missing CUBOS_ENGINE_API to new tool functions

### DIFF
--- a/engine/include/cubos/engine/tools/console/plugin.hpp
+++ b/engine/include/cubos/engine/tools/console/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup console-tool-plugin
-    void consolePlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void consolePlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/debug_camera/plugin.hpp
+++ b/engine/include/cubos/engine/tools/debug_camera/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup debug-camera-tool-plugin
-    void debugCameraPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void debugCameraPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/ecs_statistics/plugin.hpp
+++ b/engine/include/cubos/engine/tools/ecs_statistics/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup ecs-statistics-tool-plugin
-    void ecsStatisticsPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void ecsStatisticsPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/entity_inspector/plugin.hpp
+++ b/engine/include/cubos/engine/tools/entity_inspector/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup entity-inspector-tool-plugin
-    void entityInspectorPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void entityInspectorPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/metrics_panel/plugin.hpp
+++ b/engine/include/cubos/engine/tools/metrics_panel/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup metrics-panel-tool-plugin
-    void metricsPanelPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void metricsPanelPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/play_pause/plugin.hpp
+++ b/engine/include/cubos/engine/tools/play_pause/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup play-pause-tool-plugin
-    void playPauseToolPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void playPauseToolPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/plugin.hpp
+++ b/engine/include/cubos/engine/tools/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -20,5 +21,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup tool-plugins
-    void toolsPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void toolsPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/selection/plugin.hpp
+++ b/engine/include/cubos/engine/tools/selection/plugin.hpp
@@ -24,5 +24,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup selection-tool-plugin
-    void selectionPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void selectionPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/selection/selection.hpp
+++ b/engine/include/cubos/engine/tools/selection/selection.hpp
@@ -6,11 +6,13 @@
 
 #include <cubos/core/ecs/entity/entity.hpp>
 
+#include <cubos/engine/api.hpp>
+
 namespace cubos::engine
 {
     /// @brief Resource which identifies the current selection.
     /// @ingroup selection-tool-plugin
-    struct Selection
+    struct CUBOS_ENGINE_API Selection
     {
         CUBOS_REFLECT;
 

--- a/engine/include/cubos/engine/tools/settings_inspector/plugin.hpp
+++ b/engine/include/cubos/engine/tools/settings_inspector/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup settings-inspector-tool-plugin
-    void settingsInspectorPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void settingsInspectorPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/toolbox/plugin.hpp
+++ b/engine/include/cubos/engine/tools/toolbox/plugin.hpp
@@ -22,5 +22,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup toolbox-tool-plugin
-    void toolboxPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void toolboxPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/toolbox/toolbox.hpp
+++ b/engine/include/cubos/engine/tools/toolbox/toolbox.hpp
@@ -4,13 +4,14 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
 {
     /// @brief Manages the visibility of each tool.
     /// @ingroup toolbox-tool-plugin
-    class Toolbox final
+    class CUBOS_ENGINE_API Toolbox final
     {
     public:
         CUBOS_REFLECT;

--- a/engine/include/cubos/engine/tools/transform_gizmo/plugin.hpp
+++ b/engine/include/cubos/engine/tools/transform_gizmo/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -23,5 +24,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup transform-gizmo-tool-plugin
-    void transformGizmoPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void transformGizmoPlugin(Cubos& cubos);
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/tools/world_inspector/plugin.hpp
+++ b/engine/include/cubos/engine/tools/world_inspector/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/api.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine
@@ -18,5 +19,5 @@ namespace cubos::engine
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class
     /// @ingroup world-inspector-tool-plugin
-    void worldInspectorPlugin(Cubos& cubos);
+    CUBOS_ENGINE_API void worldInspectorPlugin(Cubos& cubos);
 } // namespace cubos::engine


### PR DESCRIPTION
# Description

Turns out in #1324 I forgot to add the CUBOS_ENGINE_API macro to most of the tool functions.
This leads to weird crashes when building with shared libraries enabled (e.g. plugin missing error)
This PR just fixes that.

## Checklist

- [x] Self-review changes.
