### PR TITLE
fix: two small fixes to crash causing bugs

### DIFF
--- a/core/src/ecs/world.cpp
+++ b/core/src/ecs/world.cpp
@@ -806,11 +806,18 @@ auto World::Components::remove(const reflection::Type& type) -> Components&
         return *this;
     }
 
-    // Trigger any observers that are interested in this change.
+    // Trigger any observers that are interested in this change, before component is removed.
     CommandBuffer cmdBuffer{mWorld};
     if (mWorld.mObservers->notifyRemove(cmdBuffer, mEntity, columnId))
     {
         cmdBuffer.commit();
+    }
+
+    // Update old archetype since observers might have modified it.
+    oldArchetype = mWorld.mEntityPool.archetype(mEntity.index);
+    if (!mWorld.mArchetypeGraph.contains(oldArchetype, columnId))
+    {
+        return *this;
     }
 
     auto& oldTable = mWorld.mTables.dense().at(oldArchetype);

--- a/engine/src/tools/play_pause/plugin.cpp
+++ b/engine/src/tools/play_pause/plugin.cpp
@@ -54,9 +54,8 @@ void cubos::engine::playPauseToolPlugin(Cubos& cubos)
             {
                 state.scale = 1.0F;
             }
-
-            ImGui::End();
         }
+        ImGui::End();
 
         if (!state.paused)
         {


### PR DESCRIPTION
# Description

- Play Pause plugin was missing a ImGui::End() call when ImGui::Begin() returns false.

- ECS would crash when an onRemove observer made a change to the entity

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
