### PR TITLE
fix(core): Fix ECS onRemove observer bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow identifying assets in code from their path (#1177. **@GalaxyCrush**).
+
+### Fixed
+
+- Crash in ecs when removing or destroying components with observers (#1348, **@SrGesus**)
   
 ## [v0.4.0] - 2024-10-13
 


### PR DESCRIPTION
# Description
ECS crashes when an onRemove observer makes a change to the entity

## Changes
- Added test coverage for removing components with onRemove observers that edit their entity.
- Added refetching of archetypes after observers are called

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
- [x] Add entry to the changelog's unreleased section.
