### PR TITLE
-O3 flag causes compiler error on ECS QueryFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash in ecs when removing or destroying components with observers (#1348, **@SrGesus**).
 - Crash when opening the Play Pause menu (**SrGesus**).
 - Duplicated destructor call in AnyVector which caused double free crashes on multiple samples (**@RiscadoA**).
+- Compiler Error when using -O3 flag (#1351, **@SrGesus**).
 
 ## [v0.4.0] - 2024-10-13
 

--- a/core/src/ecs/query/filter.cpp
+++ b/core/src/ecs/query/filter.cpp
@@ -134,7 +134,10 @@ void QueryFilter::update()
 
     // Update the pin masks with which each node will run.
     mNodePins[0] = 0;
-    for (int i = 1; i < mNodeCount; ++i)
+    // Copy mNodeCount since the compiler thinks it will change. See issue #1351
+    int nodeCount = this->mNodeCount;
+    CUBOS_ASSERT(nodeCount <= QueryNode::MaxCursorCount);
+    for (int i = 1; i < nodeCount; ++i)
     {
         mNodePins[i] = mNodePins[i - 1] | mNodes[i - 1]->pins();
     }


### PR DESCRIPTION
# Description

Added an assert that mNodeCount is smaller than the array size.
Had to also add some kind of "aliasing" to mNodeCount because the compiler thinks it might be mutated.
```cpp
 138   │     int mNodeCount = this->mNodeCount;
 139   │     CUBOS_ASSERT(mNodeCount <= QueryNode::MaxCursorCount);
 140   │     for (int i = 1; i < mNodeCount; ++i)
 141   │     {
 142   │         mNodePins[i] = mNodePins[i - 1] | mNodes[i - 1]->pins();
 143   │     }
```

## Context
- #1351

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
