### PR TITLE
fix(engine): move ImGui::End call to outside of if body

### DIFF
--- a/engine/src/tools/play_pause/plugin.cpp
+++ b/engine/src/tools/play_pause/plugin.cpp
@@ -54,9 +54,8 @@ void cubos::engine::playPauseToolPlugin(Cubos& cubos)
             {
                 state.scale = 1.0F;
             }
-
-            ImGui::End();
         }
+        ImGui::End();
 
         if (!state.paused)
         {


### PR DESCRIPTION
# Description

Moved ImGui::End call to outside of if body.

## Context

ImGui::End call was inside an if statement, meaning it would not be executed sometimes despite ImGui::Begin being called, this results in a crash due to an assertion failing.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
