### PR TITLE
Avoid copying light structs in deferred shading for performance reasons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 **/engine/gizmos/ @RiscadoA @tomas7770 @GameDevTecnico/cubos-graphics-team
 **/engine/render/ @RiscadoA @tomas7770 @GameDevTecnico/cubos-graphics-team
 **/engine/ui/ @RiscadoA @tomas7770 @GameDevTecnico/cubos-graphics-team
+**/engine/assets/render/ @RiscadoA @tomas7770 @GameDevTecnico/cubos-graphics-team
+**/engine/assets/ui/ @RiscadoA @tomas7770 @GameDevTecnico/cubos-graphics-team
 
 **/core/geom/ @RiscadoA @fallenatlas @GameDevTecnico/cubos-physics-team
 **/engine/collisions/ @RiscadoA @fallenatlas @GameDevTecnico/cubos-physics-team

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow identifying assets in code from their path (#1177. **@GalaxyCrush**).
 - Added an Audio asset (#230, **@Dageus**, **@diogomsmiranda**).
 
+### Changed
+
+- Reduced performance overhead of directional shadow support (#1345, **@tomas7770**).
+
 ### Fixed
 
 - Crash in ecs when removing or destroying components with observers (#1348, **@SrGesus**)


### PR DESCRIPTION
# Description

Avoid copying light structs in the deferred shading's fragment shader when calling functions, passing an index to the lights array instead.

This fixes the performance issue in #1345.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
