### PR TITLE
fix(memory): prevent double destruction in AnyVector::swapMove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Collision detection with VoxelCollisionShapes (#994, **@joaomanita**).
-
-### Added
-
 - Allow identifying assets in code from their path (#1177. **@GalaxyCrush**).
 - Added an Audio asset (#230, **@Dageus**, **@diogomsmiranda**).
 
@@ -22,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Crash in ecs when removing or destroying components with observers (#1348, **@SrGesus**)
-- Crash when opening the Play Pause menu (**SrGesus**)
-  
+- Crash in ecs when removing or destroying components with observers (#1348, **@SrGesus**).
+- Crash when opening the Play Pause menu (**SrGesus**).
+- Duplicated destructor call in AnyVector which caused double free crashes on multiple samples (**@RiscadoA**).
+
 ## [v0.4.0] - 2024-10-13
 
 ### Added

--- a/core/src/memory/any_vector.cpp
+++ b/core/src/memory/any_vector.cpp
@@ -227,11 +227,12 @@ void AnyVector::swapMove(std::size_t index, void* destination)
     CUBOS_ASSERT(index < mSize, "Index must be less than size");
 
     mConstructibleTrait->moveConstruct(destination, static_cast<char*>(mData) + mStride * index);
-    mConstructibleTrait->destruct(static_cast<char*>(mData) + mStride * index);
 
     if (index + 1 != mSize)
     {
         // If the element isn't the last one, we move the last element to its place.
+        // We must also destruct the element in the removed position before constructing the new one on top.
+        mConstructibleTrait->destruct(static_cast<char*>(mData) + mStride * index);
         mConstructibleTrait->moveConstruct(static_cast<char*>(mData) + mStride * index,
                                            static_cast<char*>(mData) + mStride * (mSize - 1));
     }


### PR DESCRIPTION
# Description

This happened only when the last element of an AnyVector was removed in a swapMove.
The destructor of the last element was called in the swapMove itself, and once again on pop.
So, simply moved the extra destructor call to within the if itself.

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
