### PR TITLE
1030 rotate debug camera with middle mouse button hold instead of key toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collision detection with VoxelCollisionShapes (#994, **@joaomanita**).
 - Allow identifying assets in code from their path (#1177. **@GalaxyCrush**).
 - Added an Audio asset (#230, **@Dageus**, **@diogomsmiranda**).
+- Hold function for debug_camera (#1030, **@jdbaracho**).
 
 ### Changed
 

--- a/engine/samples/games/cubosurfers/assets/input.bind
+++ b/engine/samples/games/cubosurfers/assets/input.bind
@@ -10,6 +10,46 @@
         ],
         "restart": [
             {"keys": ["R"]}
+        ],
+        "debug-camera-toggle": [
+            {"keys": ["LControl"]}
+        ],
+        "debug-camera-hold": [
+            {"mouseButtons": ["Middle"]}
         ]
+    },
+    "axes": {
+        "debug-move-lateral": {
+            "positive": [
+                {"keys": ["D"]}
+            ],
+            "negative": [
+                {"keys": ["A"]}
+            ]
+        },
+        "debug-move-vertical": {
+            "positive": [
+                {"keys": ["E"]}
+            ],
+            "negative": [
+                {"keys": ["Q"]}
+            ]
+        },
+        "debug-move-longitudinal": {
+            "positive": [
+                {"keys": ["W"]}
+            ],
+            "negative": [
+                {"keys": ["S"]}
+            ]
+        },
+        "debug-change-speed": {
+            "positive": [
+                {"keys": ["Tab"]}
+            ],
+            "negative": [
+                {"keys": ["LShift"]}
+            ]
+        }
     }
 }

--- a/engine/src/tools/debug_camera/plugin.cpp
+++ b/engine/src/tools/debug_camera/plugin.cpp
@@ -34,6 +34,12 @@ namespace
 
         // Whether the debug camera is currently active.
         bool active;
+
+        // Whether the debug camera's toggle mode is currently active.
+        bool toggled;
+
+        // Whether the debug camera's hold mode is currently active.
+        bool holding;
     };
 } // namespace
 
@@ -66,12 +72,31 @@ void cubos::engine::debugCameraPlugin(Cubos& cubos)
 
     cubos.system("toggle Debug Camera controller")
         .call([](Input& input, State& state, Query<FreeCameraController&> entities) {
-            if (auto match = entities.at(state.entity); match && state.active)
+            if (auto match = entities.at(state.entity); match && state.active && !state.holding)
             {
                 auto [controller] = *match;
                 if (input.justPressed("debug-camera-toggle"))
                 {
+                    state.toggled = !state.toggled;
                     controller.enabled = !controller.enabled;
+                }
+            }
+        });
+
+    cubos.system("hold Debug Camera controller")
+        .call([](Input& input, State& state, Query<FreeCameraController&> entities) {
+            if (auto match = entities.at(state.entity); match && state.active && !state.toggled)
+            {
+                auto [controller] = *match;
+                if (input.pressed("debug-camera-hold"))
+                {
+                    state.holding = true;
+                    controller.enabled = true;
+                }
+                else
+                {
+                    state.holding = false;
+                    controller.enabled = false;
                 }
             }
         });


### PR DESCRIPTION
# Description

Added a hold function to allow using the debug_camera holding a button as well as a toggle.
Added the input bindings to use the debug_camera on the cubosurfers sample.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
