### PR TITLE
Implement contact caching for box-box collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added method to save Settings to file (#1349, **@SrGesus**).
 - Added resource to easily configure magic numbers in solver (#1281, **@GCeSilva**).
 - Audio Plugin (#1004, **@Dageus**, **@diogomsmiranda**).
+- Contact caching for collision between box shapes (#1355, **@fallenatlas**).
 
 ### Changed
 

--- a/core/include/cubos/core/geom/intersections.hpp
+++ b/core/include/cubos/core/geom/intersections.hpp
@@ -11,6 +11,7 @@
 #include <cubos/core/ecs/entity/entity.hpp>
 #include <cubos/core/geom/box.hpp>
 #include <cubos/core/geom/plane.hpp>
+#include <cubos/core/geom/polygonal_feature.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 namespace cubos::core::geom
@@ -34,15 +35,13 @@ namespace cubos::core::geom
                                    const glm::mat4& localToWorld2, Intersection& intersect);
 
     /// @brief Performs the Sutherland-Hodgman Clipping algorithm.
-    /// @param inputPolygon The polygon to perform the clipping on.
+    /// @param polygon The polygon to perform the clipping on.
     /// @param numClipPlanes Number of cliping planes.
     /// @param clipPlanes Clipping planes
     /// @param removeNotClipToPlane Whether to remove the points if they're outside the plane.
-    /// @return The polygon resulting from the clipping.
-    CUBOS_CORE_API std::vector<glm::vec3> sutherlandHodgmanClipping(const std::vector<glm::vec3>& inputPolygon,
-                                                                    int numClipPlanes,
-                                                                    const cubos::core::geom::Plane* clipPlanes,
-                                                                    bool removeNotClipToPlane);
+    CUBOS_CORE_API void sutherlandHodgmanClipping(PolygonalFeature& polygon, int numClipPlanes,
+                                                  const cubos::core::geom::Plane* clipPlanes,
+                                                  bool removeNotClipToPlane);
 
     /// @brief Compute the intersection between a plane and an edge.
     /// @param plane The plane.

--- a/core/include/cubos/core/geom/polygonal_feature.hpp
+++ b/core/include/cubos/core/geom/polygonal_feature.hpp
@@ -1,0 +1,22 @@
+/// @file
+/// @brief Struct @ref cubos::core::geom::PolygonalFeature.
+/// @ingroup core-geom
+
+#pragma once
+
+#include <vector>
+
+#include <glm/vec3.hpp>
+
+namespace cubos::core::geom
+{
+    /// @brief Represents a polygonal feature. Used internally for manifold computation.
+    /// @ingroup core-geom
+    struct PolygonalFeature
+    {
+        uint32_t faceId;
+        std::vector<uint32_t> vertexIds;
+        std::vector<glm::vec3> vertices;
+        glm::vec3 normal;
+    };
+} // namespace cubos::core::geom

--- a/core/include/cubos/core/geom/utils.hpp
+++ b/core/include/cubos/core/geom/utils.hpp
@@ -11,6 +11,7 @@
 #include <cubos/core/ecs/entity/entity.hpp>
 #include <cubos/core/geom/box.hpp>
 #include <cubos/core/geom/plane.hpp>
+#include <cubos/core/geom/polygonal_feature.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 namespace cubos::core::geom
@@ -31,14 +32,15 @@ namespace cubos::core::geom
     /// @brief Computes the candidate face of the polygon to be reference, as well as it's normal and adjacent planes.
     /// @param shape Collider shape.
     /// @param normal The reference normal in world coordinates.
-    /// @param outPoints The points of the resulting face.
-    /// @param outNormal The resulting normal.
+    /// @param outPolygon The polygon of the resulting face.
     /// @param outAdjacentPlanes The resulting adjacent planes (4).
+    /// @param outAdjacentPlanesIds The resulting adjacent planes ids (4).
     /// @param localToWorld The localToWorld matrix of the body.
     /// @param scale The scale of the body.
     CUBOS_CORE_API void getIncidentReferencePolygon(const cubos::core::geom::Box& shape, const glm::vec3& normal,
-                                                    std::vector<glm::vec3>& outPoints, glm::vec3& outNormal,
+                                                    PolygonalFeature& outPolygon,
                                                     std::vector<cubos::core::geom::Plane>& outAdjacentPlanes,
+                                                    std::vector<uint32_t> outAdjacentPlanesIds,
                                                     const glm::mat4& localToWorld, float scale);
 
     /// @brief Computes the closest point on the line (edge) to point.

--- a/engine/include/cubos/engine/collisions/contact_manifold.hpp
+++ b/engine/include/cubos/engine/collisions/contact_manifold.hpp
@@ -15,8 +15,94 @@
 
 namespace cubos::engine
 {
+    /// @brief Indicates the type of a geometric feature (vertex, edge, or face) and the feature index. Currently each
+    /// feature index is simply the index in the array with that information in the shape.
+    class CUBOS_ENGINE_API ContactFeatureId
+    {
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief Feature id identifying an undefined feature.
+        static const uint32_t UNDEFINED = 0x0;
+
+        /// @brief Container of the current feature Id.
+        uint32_t id = UNDEFINED;
+
+        /// @brief Assign a vertex feature id.
+        /// @param vertexId index of the vertex on the shape.
+        void setAsVertex(uint32_t vertexId)
+        {
+            if ((vertexId & TypeMask) != 0)
+            {
+                return;
+            }
+            id = TypeVertex | vertexId;
+        }
+
+        /// @brief Assign an edge feature id.
+        /// @param edgeId index of the edge on the shape.
+        void setAsEdge(uint32_t edgeId)
+        {
+            if ((edgeId & TypeMask) != 0)
+            {
+                return;
+            }
+            id = TypeEdge | edgeId;
+        }
+
+        /// @brief Assign a face feature id.
+        /// @param faceId index of the face on the shape.
+        void setAsFace(uint32_t faceId)
+        {
+            if ((faceId & TypeMask) != 0)
+            {
+                return;
+            }
+            id = TypeFace | faceId;
+        }
+
+        /// @brief Check if the feature type is a vertex.
+        /// @return true if it identifies a vertex.
+        inline bool isVertex() const
+        {
+            return (id & TypeMask) == TypeVertex;
+        }
+
+        /// @brief Check if the feature type is an edge.
+        /// @return true if it identifies an edge.
+        inline bool isEdge() const
+        {
+            return (id & TypeMask) == TypeEdge;
+        }
+
+        /// @brief Check if the feature type is a face.
+        /// @return true if it identifies a face.
+        inline bool isFace() const
+        {
+            return (id & TypeMask) == TypeFace;
+        }
+
+        inline constexpr bool operator==(const ContactFeatureId& other) const
+        {
+            return id != UNDEFINED && other.id != UNDEFINED && id == other.id;
+        }
+
+    private:
+        /// TODO: reduce size of the id to less bits?
+        /// For now our id has 32 bits (2 bits for the feature type, 30 for the feature index). If we need to change it
+        /// in the future change the CODE_MASK and the each of the types' header to the adequate size.
+        /// Identifies the part of the id that corresponds to the feature index. 0011'1111'1111'1111'1111'1111'1111'1111
+        static const std::uint32_t IdMask = 0x3fffffff;
+        /// Identifies the part of the id that corresponds to the feature type. 1100'0000'0000'0000'0000'0000'0000'0000
+        static const std::uint32_t TypeMask = ~IdMask;
+        /// The index corresponding to each feature type.
+        static const std::uint32_t TypeVertex = 0x40000000; // 0b01 << 30
+        static const std::uint32_t TypeEdge = 0x80000000;   // 0b10 << 30
+        static const std::uint32_t TypeFace = 0xC0000000;   // 0b11 << 30
+    };
+
     /// @brief Contains info regarding a contact point of a @ContactManifold.
-    struct ContactPointData
+    struct CUBOS_ENGINE_API ContactPointData
     {
         CUBOS_REFLECT;
 
@@ -26,13 +112,18 @@ namespace cubos::engine
         glm::vec3 localOn1;              ///< Position on the entity of the contact in local coordinates.
         glm::vec3 localOn2;              ///< Position on the other entity of the contact in local coordinates.
         float penetration;               ///< Penetration of the contact point. Always positive.
+
+        float normalImpulse;
+        float frictionImpulse1;
+        float frictionImpulse2;
         /// The contact feature ID on the first shape. This indicates the ID of
         /// the vertex, edge, or face of the contact, if one can be determined.
-        int id; /// TODO: use this
+        ContactFeatureId fid1;
+        ContactFeatureId fid2;
     };
 
     /// @brief Represents a contact interface between two bodies.
-    struct ContactManifold
+    struct CUBOS_ENGINE_API ContactManifold
     {
         CUBOS_REFLECT;
 

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -249,11 +249,13 @@ int main(int argc, char** argv)
                 {
                     for (auto point : manifold.points)
                     {
-                        gizmos.color({0.0F, 0.0F, 1.0F});
+                        // Have a set color for each of the entities for an easier distinction
+                        bool isEnt1 = ent1 == manifold.entity;
+                        gizmos.color((isEnt1 ? glm::vec3(0.0F, 0.0F, 1.0F) : glm::vec3(1.0F, 0.0F, 1.0F)));
                         gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F, 1.0F,
                                          0.05F, Gizmos::Space::World);
 
-                        gizmos.color({1.0F, 0.0F, 1.0F});
+                        gizmos.color((isEnt1 ? glm::vec3(1.0F, 0.0F, 1.0F) : glm::vec3(0.0F, 0.0F, 1.0F)));
                         gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F, 1.0F,
                                          0.05F, Gizmos::Space::World);
                     }

--- a/engine/src/collisions/interface/contact_manifold.cpp
+++ b/engine/src/collisions/interface/contact_manifold.cpp
@@ -5,6 +5,13 @@
 
 #include <cubos/engine/collisions/contact_manifold.hpp>
 
+CUBOS_REFLECT_IMPL(cubos::engine::ContactFeatureId)
+{
+    return core::ecs::TypeBuilder<ContactFeatureId>("cubos::engine::ContactFeatureId")
+        .withField("id", &ContactFeatureId::id)
+        .build();
+}
+
 CUBOS_REFLECT_IMPL(cubos::engine::ContactPointData)
 {
     return core::ecs::TypeBuilder<ContactPointData>("cubos::engine::ContactPointData")
@@ -14,7 +21,11 @@ CUBOS_REFLECT_IMPL(cubos::engine::ContactPointData)
         .withField("localOn1", &ContactPointData::localOn1)
         .withField("localOn2", &ContactPointData::localOn2)
         .withField("penetration", &ContactPointData::penetration)
-        .withField("id", &ContactPointData::id)
+        .withField("normalImpulse", &ContactPointData::normalImpulse)
+        .withField("frictionImpulse1", &ContactPointData::frictionImpulse1)
+        .withField("frictionImpulse2", &ContactPointData::frictionImpulse2)
+        .withField("fid1", &ContactPointData::fid1)
+        .withField("fid2", &ContactPointData::fid2)
         .build();
 }
 


### PR DESCRIPTION
# Description

Add contact caching for box-box collisions (can't do for voxel before refactor)
- changed when and how the unrelate of the CollidingWith happens
- added a new "shape" type to geom to contain the feature info and the ids
- changed functions to use this ^
- added a new struct to contain the feature id
- added new sections in systems to check if the collisions were already happening in the previous section and if so update them instead of replacing them

This doesn't have warm starting yet, so it looks just like before.

References:
- [https://box2d.org/files/[ErinCatto_IterativeDynamics_GDC2005.pdf](https://box2d.org/files/ErinCatto_IterativeDynamics_GDC2005.pdf)
- Avian/Parry for inspiration on 3D feature IDs

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [ ] Add entry to the changelog's unreleased section.
