### PR TITLE
feat(rendering): Add Shadow Normal Offset Bias in the deferred shading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audio asset (#230, **@Dageus**, **@diogomsmiranda**).
 - Compatibility with CMake find_package (#1326, **@RiscadoA**).
 - A proper Nix package which can be used to install Cubos and Tesseratos (#1327, **RiscadoA**).
+- Added the option to use Shadow Normal Offset Bias algorithm (#1308, **@GalaxyCrush**)
 
 ### Changed
 

--- a/engine/include/cubos/engine/render/shadows/caster.hpp
+++ b/engine/include/cubos/engine/render/shadows/caster.hpp
@@ -18,8 +18,9 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        float bias = 0.002F;     ///< Shadow bias.
-        float blurRadius = 1.0F; ///< Shadow blur radius.
-        int id = -1;             ///< Caster id for the shadow atlas.
+        float bias = 0.001F;              ///< Shadow bias.
+        float blurRadius = 0.005F;        ///< Shadow blur radius.
+        int id = -1;                      ///< Caster id for the shadow atlas.
+        float normalOffsetScale = 0.007F; ///< Scale of the normal offset.
     };
 } // namespace cubos::engine

--- a/engine/src/render/deferred_shading/plugin.cpp
+++ b/engine/src/render/deferred_shading/plugin.cpp
@@ -60,7 +60,8 @@ namespace
                                           4]; // intended to be a float array, but std140 layout aligns array elements
                                               // to vec4 size; number of vec4s = ceiling(MaxCascades / 4 components)
         int numCascades;
-        int padding2[3];
+        float normalOffsetScale;
+        int padding2[2];
     };
 
     struct PerPointLight
@@ -86,7 +87,8 @@ namespace
         glm::vec2 shadowMapSize;
         float shadowBias;
         float shadowBlurRadius;
-        float padding[2];
+        float normalOffsetScale;
+        float padding[1];
     };
 
     struct PerScene
@@ -332,6 +334,7 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
                             perLight.shadowBlurRadius = caster.value().baseSettings.blurRadius;
                             perLight.numCascades = numCascades;
                             perScene.directionalLightWithShadowsId = directionalLightIndex;
+                            perLight.normalOffsetScale = caster.value().baseSettings.normalOffsetScale;
                             directionalShadowMap = caster.value().shadowMaps.at(cameraEntity)->cascades;
                         }
                         directionalLightIndex++;
@@ -375,6 +378,7 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
                             perLight.shadowMapSize = slot->size;
                             perLight.shadowBias = caster.value().baseSettings.bias;
                             perLight.shadowBlurRadius = caster.value().baseSettings.blurRadius;
+                            perLight.normalOffsetScale = caster.value().baseSettings.normalOffsetScale;
                         }
                         else
                         {

--- a/engine/src/render/shadows/caster.cpp
+++ b/engine/src/render/shadows/caster.cpp
@@ -9,5 +9,6 @@ CUBOS_REFLECT_IMPL(cubos::engine::ShadowCaster)
     return core::ecs::TypeBuilder<ShadowCaster>("cubos::engine::ShadowCaster")
         .withField("bias", &ShadowCaster::bias)
         .withField("blurRadius", &ShadowCaster::blurRadius)
+        .withField("normalOffsetScale", &ShadowCaster::normalOffsetScale)
         .build();
 }


### PR DESCRIPTION
# Description

I added the Shadow Normal Offset Bias to the deferred shading and gave the user the option to use or not use this bias.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
