### PR TITLE
Fix crash when using ImGui across DLL boundaries on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inconsistent behavior on ECS queries on symmetric self-relations (**@RiscadoA**).
 - Undefined behavior on ECS entity removal due to creating tables while iterating over tables (#1363, **@RiscadoA**).
 - Made canvas draw calls sorted by layer in order to prevent undeterministic behavior when drawing elements with transparency (**@mkuritsu**).
+- Crash when using ImGui across DLL boundaries (#1144, **@RiscadoA**).
 
 ## [v0.4.0] - 2024-10-13
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CUBOS_ENGINE_SOURCE
 	"src/imgui/plugin.cpp"
 	"src/imgui/imgui.cpp"
 	"src/imgui/data_inspector.cpp"
+	"src/imgui/context.cpp"
 
 	"src/transform/plugin.cpp"
 	"src/transform/child_of.cpp"

--- a/engine/include/cubos/engine/imgui/context.hpp
+++ b/engine/include/cubos/engine/imgui/context.hpp
@@ -1,0 +1,36 @@
+/// @file
+/// @brief Resource @ref cubos::engine::ImGuiContextHolder.
+/// @ingroup imgui-plugin
+
+#pragma once
+
+#include <imgui.h>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Resource which stores a pointer to the ImGui context created by the ImGui plugin.
+    ///
+    /// This resource is inserted by the @ref imgui-plugin during @ref imguiInitTag.
+    ///
+    /// When linking dynamically the engine library from an application or another library, although this plugin
+    /// initializes the context, it might not be set automatically on the client side - particularly, this happens on
+    /// Windows, as global variables are not shared between DLLs and applications.
+    ///
+    /// So, if you're using ImGui in your application or library, to ensure dynamic linking capability in all platforms,
+    /// you should call `ImGui::SetCurrentContext(ImGuiContextHolder::context)` before using any ImGui functions.
+    ///
+    /// This resource is not named ImGuiContext because ImGui already has a type with that name.
+    ///
+    /// @ingroup imgui-plugin
+    struct CUBOS_ENGINE_API ImGuiContextHolder
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Pointer to the ImGui context.
+        ImGuiContext* context;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/imgui/plugin.hpp
+++ b/engine/include/cubos/engine/imgui/plugin.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cubos/engine/imgui/context.hpp>
 #include <cubos/engine/prelude.hpp>
 
 namespace cubos::engine

--- a/engine/samples/imgui/main.cpp
+++ b/engine/samples/imgui/main.cpp
@@ -96,6 +96,12 @@ int main(int argc, char** argv)
     cubos.plugin(imguiPlugin);
     /// [Adding the plugin]
 
+    /// [ImGui initialization]
+    cubos.startupSystem("set ImGui context").after(imguiInitTag).call([](ImGuiContextHolder& holder) {
+        ImGui::SetCurrentContext(holder.context);
+    });
+    /// [ImGui initialization]
+
     /// [ImGui Demo]
     cubos.system("show ImGui demo").tagged(imguiTag).call([]() {
         ImGui::Begin("Dear ImGui + Cubos");

--- a/engine/samples/imgui/page.md
+++ b/engine/samples/imgui/page.md
@@ -16,7 +16,13 @@ Then, make sure to add the plugin.
 
 @snippet imgui/main.cpp Adding the plugin
 
-Once the ImGui plugin is added, you can create systems to display ImGui windows and widgets. Here's a system which opens an ImGui window, and its demo.
+When you're using ImGui directly in an application or a library, you must also make sure to initialize the ImGui context on it.
+To do so, you can add a startup system just like the one below:
+
+@snippet imgui/main.cpp ImGui initialization
+
+You can read more about this in the documentation of @ref cubos::engine::ImGuiContextHolder.
+Now, you can create systems to display ImGui windows and widgets. Here's a system which opens an ImGui window, and its demo.
 
 @snippet imgui/main.cpp ImGui Demo
 

--- a/engine/src/imgui/context.cpp
+++ b/engine/src/imgui/context.cpp
@@ -1,0 +1,8 @@
+#include <cubos/core/ecs/reflection.hpp>
+
+#include <cubos/engine/imgui/context.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::ImGuiContextHolder)
+{
+    return core::ecs::TypeBuilder<ImGuiContextHolder>("cubos::engine::ImGuiContextHolder").build();
+}

--- a/tools/tesseratos/src/tesseratos/main.cpp
+++ b/tools/tesseratos/src/tesseratos/main.cpp
@@ -1,5 +1,6 @@
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/defaults/plugin.hpp>
+#include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/input/input.hpp>
 #include <cubos/engine/input/plugin.hpp>
 #include <cubos/engine/settings/plugin.hpp>
@@ -53,6 +54,10 @@ int main(int argc, char** argv)
             auto bindings = assets.read<InputBindings>(BindingsAsset);
             input.bind(*bindings);
         });
+
+    cubos.startupSystem("set ImGui context").after(imguiInitTag).call([](ImGuiContextHolder& holder) {
+        ImGui::SetCurrentContext(holder.context);
+    });
 
     cubos.run();
 }


### PR DESCRIPTION
# Description

You can read the documentation I included in the PR changes to understand what I'm fixing here.
If you're running Windows, previously with `CUBOS_ENGINE_SHARED` set to `ON` on CMake you probably got a crash on both Tesseratos and on the ImGui sample. With this change, that should no longer happen, so **please test that before approving**.

## Checklist

- [x] Self-review changes.
- [x] Updated imgui plugin documentation.
- [x] Update sample.
- [x] Add entry to the changelog's unreleased section.
