### PR TITLE
docs(ecs): flip SystemBuilder::before and SystemBuilder::after docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when opening the Play Pause menu (**SrGesus**).
 - Duplicated destructor call in AnyVector which caused double free crashes on multiple samples (**@RiscadoA**).
 - Compiler Error when using -O3 flag (#1351, **@SrGesus**).
+- Flipped documentation of SystemBuilder::before and SystemBuilder::after (#1371, **@RiscadoA**).
 
 ## [v0.4.0] - 2024-10-13
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -441,12 +441,12 @@ namespace cubos::core::ecs
         /// @return Builder.
         SystemBuilder&& tagged(const Tag& tag) &&;
 
-        /// @brief Forces this system to only run after all systems with the given tag have finished.
+        /// @brief Forces all systems with the given tag to run only after this system has finished.
         /// @param tag Tag.
         /// @return Builder.
         SystemBuilder&& before(const Tag& tag) &&;
 
-        /// @brief Forces all systems with the given tag to run only after this system has finished.
+        /// @brief Forces this system to only run after all systems with the given tag have finished.
         /// @param tag Tag.
         /// @return Builder.
         SystemBuilder&& after(const Tag& tag) &&;


### PR DESCRIPTION
# Description

TL;DR the documentation was wrong, ty @SrGesus for the find

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
