### PR TITLE
Add warm starting

### DIFF
--- a/.github/workflows/build-doxygen-docs.yml
+++ b/.github/workflows/build-doxygen-docs.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-engine-linux.yml
+++ b/.github/workflows/build-engine-linux.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-engine-web.yml
+++ b/.github/workflows/build-engine-web.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
   
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy-lint.yml
+++ b/.github/workflows/clang-tidy-lint.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
   
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/copy-labels.yml
+++ b/.github/workflows/copy-labels.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   copy-labels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Copy labels from linked issues
     steps:
       - name: copy-labels

--- a/.github/workflows/create-coverage-report.yml
+++ b/.github/workflows/create-coverage-report.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -11,7 +11,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - SSAO resolution scale (#1423, **@tomas7770**).
+- Warm starting for collision solving (#1248, **@fallenatlas**).
 
 ### Changed
 

--- a/engine/include/cubos/engine/physics/components/angular_impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/angular_impulse.hpp
@@ -35,7 +35,7 @@ namespace cubos::engine
         }
 
     private:
-        glm::vec3 mAngularImpulse;
+        glm::vec3 mAngularImpulse = {0.0F, 0.0F, 0.0F};
     };
 
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/angular_velocity.hpp
+++ b/engine/include/cubos/engine/physics/components/angular_velocity.hpp
@@ -19,6 +19,6 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 vec;
+        glm::vec3 vec = {0.0F, 0.0F, 0.0F};
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/impulse.hpp
+++ b/engine/include/cubos/engine/physics/components/impulse.hpp
@@ -49,8 +49,8 @@ namespace cubos::engine
         }
 
     private:
-        glm::vec3 mImpulse;
-        glm::vec3 mAngularImpulse;
+        glm::vec3 mImpulse = {0.0F, 0.0F, 0.0F};
+        glm::vec3 mAngularImpulse = {0.0F, 0.0F, 0.0F};
     };
 
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/components/velocity.hpp
+++ b/engine/include/cubos/engine/physics/components/velocity.hpp
@@ -19,6 +19,6 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 vec;
+        glm::vec3 vec = {0.0F, 0.0F, 0.0F};
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/physics/resources/solver_constants.hpp
+++ b/engine/include/cubos/engine/physics/resources/solver_constants.hpp
@@ -24,7 +24,7 @@ namespace cubos::engine
         /// @brief Minimum inverse inertia for a body to rotate.
         glm::mat3 minInvInertia = glm::mat3(0.0F);
 
-        /// @brief The maximum "boost" for the initial solving of the constraint. 
+        /// @brief The maximum "boost" for the initial solving of the constraint.
         float maxBias = -4.0F;
 
         /// @brief The minimum update frequency of the collision solving.
@@ -36,17 +36,23 @@ namespace cubos::engine
         /// @brief The minimum value for KFriction (to avoid divisions by zero).
         float minKFriction = 0.0F;
 
-        /// @brief The minimum length of the tangent vector in the direction of the relative velocity (if it's below this we recalculate a basis for the tangents).
+        /// @brief The minimum length of the tangent vector in the direction of the relative velocity (if it's below
+        /// this we recalculate a basis for the tangents).
         float minTangentLenSq = 1e-6F * 1e-6F;
 
         /// @brief The minimum restitution value to calculate restitution for a body (restitution is bounciness).
         float minRestitution = 0.0F;
 
-        /// @brief The minimum speed in the normal direction to calculate restitution for a body (lower is closer to elastic collisions).
+        /// @brief The minimum speed in the normal direction to calculate restitution for a body (lower is closer to
+        /// elastic collisions).
         float minNormalSpeed = -0.01F;
 
-        /// @brief The minimum impulse being applied in the normal direction to calculate restitution for a body (to avoid applying restitution when body position didn't change).
+        /// @brief The minimum impulse being applied in the normal direction to calculate restitution for a body (to
+        /// avoid applying restitution when body position didn't change).
         float minNormalImpulse = 0.0F;
+
+        /// @brief Coefficient for how much of the impulse of the previous frame will be used for warm-starting.
+        float warmStartCoefficient = 1.0F;
     };
 
 } // namespace cubos::engine

--- a/engine/samples/complex_physics/main.cpp
+++ b/engine/samples/complex_physics/main.cpp
@@ -158,7 +158,7 @@ int main(int argc, char** argv)
     });
 
     cubos.system("shoot cube")
-        .tagged(physicsApplyForcesTag)
+        .before(transformUpdateTag)
         .call([](Commands cmds, const DeltaTime& dt, const Assets& assets, TimeBetweenShoots& time) {
             time.current += dt.value();
 

--- a/engine/src/physics/solver/integration/plugin.cpp
+++ b/engine/src/physics/solver/integration/plugin.cpp
@@ -126,8 +126,7 @@ void cubos::engine::physicsIntegrationPlugin(Cubos& cubos)
 
     cubos.system("finalize position")
         .tagged(physicsFinalizePositionTag)
-        .call([](Query<Position&, AccumulatedCorrection&, const Mass&> query,
-                 const SolverConstants& solverConstants) {
+        .call([](Query<Position&, AccumulatedCorrection&, const Mass&> query, const SolverConstants& solverConstants) {
             for (auto [position, correction, mass] : query)
             {
                 if (mass.inverseMass <= solverConstants.minInvMass)

--- a/engine/src/physics/solver/penetration_constraint/plugin.hpp
+++ b/engine/src/physics/solver/penetration_constraint/plugin.hpp
@@ -14,6 +14,7 @@ namespace cubos::engine
     /// @brief Adds solver for penetration constraint.
 
     extern Tag addPenetrationConstraintTag;
+    extern Tag penetrationConstraintWarmStartTag;
     extern Tag penetrationConstraintCleanTag;
     extern Tag penetrationConstraintSolveTag;
     extern Tag penetrationConstraintRestitutionTag;


### PR DESCRIPTION
# Description

Add warm starting to physics. Takes the impulses applied in the previous frame to apply them at the beggining of the next for increased stability in stacking scenarios.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
