### PR TITLE
Make SSAO optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Make SSAO optional (#1396, **@tomas7770**).
+
 ## [v0.5.0] - 2024-12-01
 
 ### Added

--- a/engine/assets/render/deferred_shading.fs
+++ b/engine/assets/render/deferred_shading.fs
@@ -78,6 +78,7 @@ layout(std140) uniform PerScene
     uint numSpotLights;
     
     int directionalLightWithShadowsId; // index of directional light that casts shadows, or -1 if none
+    int useSSAO;
 };
 
 layout(location = 0) out vec3 color;
@@ -318,7 +319,7 @@ void main()
     {
         vec3 albedo = texture(albedoTexture, uv).rgb;
         vec3 position = texture(positionTexture, uv).xyz;
-        float ssao = texture(ssaoTexture, uv).r;
+        float ssao = useSSAO == 1 ? texture(ssaoTexture, uv).r : 1.0;
 
         // Calculate lighting from each light source.
         vec3 lighting = ambientLight.rgb * ssao;

--- a/engine/include/cubos/engine/render/defaults/target.hpp
+++ b/engine/include/cubos/engine/render/defaults/target.hpp
@@ -22,11 +22,14 @@
 #include <cubos/engine/render/tone_mapping/fxaa.hpp>
 #include <cubos/engine/render/tone_mapping/tone_mapping.hpp>
 
-
+// Export types so that code using the engine shared library can share reflection data,
+// otherwise we may end up with e.g. a Opt<cubos::engine::SplitScreen> type in the engine
+// and another one in the external code.
 namespace cubos::core::memory
 {
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::SplitScreen>;
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::Bloom>;
+    CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::SSAO>;
 } // namespace cubos::core::memory
 
 namespace cubos::engine
@@ -56,7 +59,7 @@ namespace cubos::engine
         GBufferRasterizer gBufferRasterizer{};
 
         /// @brief SSAO component.
-        SSAO ssao{};
+        core::memory::Opt<SSAO> ssao{SSAO{}};
 
         /// @brief Tone Mapping component.
         ToneMapping toneMapping{};

--- a/engine/src/render/defaults/plugin.cpp
+++ b/engine/src/render/defaults/plugin.cpp
@@ -74,7 +74,6 @@ void cubos::engine::renderDefaultsPlugin(Cubos& cubos)
                     .add(entity, defaults.picker)
                     .add(entity, defaults.depth)
                     .add(entity, defaults.gBufferRasterizer)
-                    .add(entity, defaults.ssao)
                     .add(entity, defaults.toneMapping)
                     .add(entity, defaults.fxaa)
                     .add(entity, defaults.deferredShading);
@@ -87,6 +86,11 @@ void cubos::engine::renderDefaultsPlugin(Cubos& cubos)
                 if (defaults.bloom)
                 {
                     cmds.add(entity, defaults.bloom.value());
+                }
+
+                if (defaults.ssao)
+                {
+                    cmds.add(entity, defaults.ssao.value());
                 }
             }
         });

--- a/engine/src/render/defaults/target.cpp
+++ b/engine/src/render/defaults/target.cpp
@@ -5,6 +5,7 @@
 
 template class cubos::core::memory::Opt<cubos::engine::SplitScreen>;
 template class cubos::core::memory::Opt<cubos::engine::Bloom>;
+template class cubos::core::memory::Opt<cubos::engine::SSAO>;
 
 CUBOS_REFLECT_IMPL(cubos::engine::RenderTargetDefaults)
 {

--- a/engine/src/render/deferred_shading/plugin.cpp
+++ b/engine/src/render/deferred_shading/plugin.cpp
@@ -116,6 +116,7 @@ namespace
         glm::uint numSpotLights{0};
 
         int directionalLightWithShadowsId;
+        int useSSAO;
     };
 
     struct State
@@ -218,7 +219,7 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
                      directionalLights,
                  Query<const LocalToWorld&, const PointLight&, Opt<const PointShadowCaster&>> pointLights,
                  Query<const LocalToWorld&, const SpotLight&, Opt<const SpotShadowCaster&>> spotLights,
-                 Query<Entity, const HDR&, const GBuffer&, const SSAO&, DeferredShading&> targets,
+                 Query<Entity, const HDR&, const GBuffer&, Opt<const SSAO&>, DeferredShading&> targets,
                  Query<Entity, const LocalToWorld&, const Camera&, const DrawsTo&> cameras) {
             auto& rd = window->renderDevice();
 
@@ -441,7 +442,15 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
                     state.positionBP->bind(gBuffer.position);
                     state.normalBP->bind(gBuffer.normal);
                     state.albedoBP->bind(gBuffer.albedo);
-                    state.ssaoBP->bind(ssao.blurTexture);
+                    if (ssao.contains())
+                    {
+                        state.ssaoBP->bind(ssao.value().blurTexture);
+                        perScene.useSSAO = 1;
+                    }
+                    else
+                    {
+                        perScene.useSSAO = 0;
+                    }
                     state.spotShadowAtlasBP->bind(spotShadowAtlas.atlas);
                     state.pointShadowAtlasBP->bind(pointShadowAtlas.atlas);
                     // directionalShadowMap needs to be bound even if it's null, or else errors may occur on some GPUs


### PR DESCRIPTION
# Description

Changes deferred shading to work without SSAO. If the SSAO component isn't present in the render target, the feature is disabled.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
