### PR TITLE
Add SSAO resolution scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SSAO resolution scale (#1423, **@tomas7770**).
+
 ### Changed
 
 - Make SSAO optional (#1396, **@tomas7770**).

--- a/engine/assets/render/ssao_blur.fs
+++ b/engine/assets/render/ssao_blur.fs
@@ -5,11 +5,13 @@ uniform sampler2D ssaoTexture;
 uniform vec2 viewportOffset;
 uniform vec2 viewportSize;
 
+uniform float resolutionScale;
+
 layout (location = 0) out float color;
 
 void main() {
     vec2 uv = fragUv * viewportSize + viewportOffset;
-    vec2 texelSize = 1.0 / vec2(textureSize(ssaoTexture, 0));
+    vec2 texelSize = resolutionScale / vec2(textureSize(ssaoTexture, 0));
     float result = 0.0;
     for (int x = -2; x < 2; ++x)
     {

--- a/engine/include/cubos/engine/render/ssao/ssao.hpp
+++ b/engine/include/cubos/engine/render/ssao/ssao.hpp
@@ -22,6 +22,9 @@ namespace cubos::engine
         /// @brief Size of the SSAO textures, in pixels.
         glm::uvec2 size = {0, 0};
 
+        /// @brief Scale value to configure SSAO texture size.
+        float resolutionScale = 0.5F;
+
         /// @brief Number of samples to use.
         int samples = 64;
 

--- a/engine/src/render/ssao/ssao.cpp
+++ b/engine/src/render/ssao/ssao.cpp
@@ -8,6 +8,7 @@ CUBOS_REFLECT_IMPL(cubos::engine::SSAO)
 {
     return core::ecs::TypeBuilder<SSAO>("cubos::engine::SSAO")
         .withField("size", &SSAO::size)
+        .withField("resolutionScale", &SSAO::resolutionScale)
         .withField("samples", &SSAO::samples)
         .withField("radius", &SSAO::radius)
         .withField("bias", &SSAO::bias)


### PR DESCRIPTION
# Description

Adds a resolution scale value to the SSAO component to adjust the SSAO texture size. The default value of 0.5 provides a good quality with much better performance than full resolution (1.0).

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
