### PR TITLE
feat(data): Allow wrapped fields to be read as normal object with a single field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decomposition of 4x4 matrices into translation, scale and rotation on the inspector (#1179, **@RiscadoA**).
 - Default entities on blueprints, used as roots for scenes (#1398, **@RiscadoA**).
 - Automatically add ColliderAABB when adding a Collision Shape to an entity (#1444, **@fallenatlas**).
+- Wrapper trait to distinguish between single-field structs and wrapper structs (**SrGesus**, **@RiscadoA**).
 
 ### Changed
 - Move Tesseratos' tools' status to their respective plugins and remove them from the Toolbox (#1234, **@jdbaracho**).

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CUBOS_CORE_SOURCE
 	"src/reflection/traits/mask.cpp"
 	"src/reflection/traits/inherits.cpp"
 	"src/reflection/traits/vector.cpp"
+	"src/reflection/traits/wrapper.cpp"
 	"src/reflection/external/primitives.cpp"
 	"src/reflection/external/cstring.cpp"
 	"src/reflection/external/string.cpp"

--- a/core/include/cubos/core/ecs/reflection.hpp
+++ b/core/include/cubos/core/ecs/reflection.hpp
@@ -6,6 +6,7 @@
 
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 namespace cubos::core::ecs
@@ -88,7 +89,7 @@ namespace cubos::core::ecs
         /// @param pointer Field pointer.
         /// @return Builder.
         template <typename F>
-        TypeBuilder&& withField(std::string name, F T::*pointer) &&
+        TypeBuilder&& withField(std::string name, F T::* pointer) &&
         {
             mFields.addField(std::move(name), pointer);
             return std::move(*this);
@@ -99,6 +100,18 @@ namespace cubos::core::ecs
         reflection::Type& build() &&
         {
             mType.with(std::move(mFields));
+            return mType;
+        }
+
+        /// @brief Creates a type with a single field.
+        /// @tparam F Field type.
+        /// @param pointer Field pointer.
+        /// @return Type.
+        template <typename F>
+        reflection::Type& wrap(F T::* pointer) &&
+        {
+            CUBOS_ASSERT(mFields.size() == 0);
+            mType.with(reflection::WrapperTrait(pointer));
             return mType;
         }
 

--- a/core/include/cubos/core/reflection/traits/wrapper.hpp
+++ b/core/include/cubos/core/reflection/traits/wrapper.hpp
@@ -1,0 +1,64 @@
+/// @file
+/// @brief Class @ref cubos::core::reflection::WrapperTrait.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/tel/logging.hpp>
+
+namespace cubos::core::reflection
+{
+    /// @brief Describes the single field of a reflected type.
+    /// @ingroup core-reflection
+    class CUBOS_CORE_API WrapperTrait
+    {
+    public:
+        CUBOS_REFLECT;
+
+        ~WrapperTrait()
+        {
+            delete mAddressOf;
+        };
+
+        /// @brief Constructs.
+        WrapperTrait(WrapperTrait&& other) noexcept
+            : mType(other.mType)
+            , mAddressOf(other.mAddressOf)
+        {
+            other.mAddressOf = nullptr;
+        }
+
+        /// @brief Constructs.
+        template <typename F, typename O>
+        WrapperTrait(F O::*pointer)
+            : mType(reflect<F>())
+            , mAddressOf(new FieldsTrait::AddressOfImpl<O, F>(pointer))
+        {
+        }
+
+        /// @brief Gets the type of the single field.
+        /// @return Type.
+        const Type& type() const
+        {
+            return mType;
+        }
+
+        /// @brief Gets a pointer to the field on a given instance of the reflected type.
+        /// @param instance Pointer to the instance.
+        /// @return Pointer to the field on the given instance.
+        void* value(const void* instance) const
+        {
+            return reinterpret_cast<void*>(this->mAddressOf->get(instance));
+        }
+
+    private:
+        const Type& mType;
+        const FieldsTrait::AddressOf* mAddressOf;
+    };
+} // namespace cubos::core::reflection

--- a/core/src/data/des/binary.cpp
+++ b/core/src/data/des/binary.cpp
@@ -9,6 +9,7 @@
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/traits/mask.hpp>
 #include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 #include <cubos/core/tel/logging.hpp>
 
@@ -21,6 +22,7 @@ using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::MaskTrait;
 using cubos::core::reflection::StringConversionTrait;
 using cubos::core::reflection::Type;
+using cubos::core::reflection::WrapperTrait;
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define AUTO_HOOK(casted, type)                                                                                        \
@@ -191,6 +193,14 @@ bool BinaryDeserializer::decompose(const Type& type, void* value)
                 CUBOS_ERROR("Could not deserialize field {}", field->name());
                 return false;
             }
+        }
+    }
+    else if (type.has<WrapperTrait>())
+    {
+        const auto& trait = type.get<WrapperTrait>();
+        if (!this->read(trait.type(), trait.value(value))) {
+                CUBOS_ERROR("Could not deserialize wrapper of type {}", trait.type().name());
+                return false;
         }
     }
     else if (type.has<StringConversionTrait>())

--- a/core/src/data/ser/binary.cpp
+++ b/core/src/data/ser/binary.cpp
@@ -8,6 +8,7 @@
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/traits/mask.hpp>
 #include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 #include <cubos/core/tel/logging.hpp>
 
@@ -19,6 +20,7 @@ using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::MaskTrait;
 using cubos::core::reflection::StringConversionTrait;
 using cubos::core::reflection::Type;
+using cubos::core::reflection::WrapperTrait;
 
 #define AUTO_HOOK(casted, type)                                                                                        \
     this->hook<type>([this](const type& value) {                                                                       \
@@ -149,6 +151,15 @@ bool BinarySerializer::decompose(const Type& type, const void* value)
                 CUBOS_WARN("Could not serialize field {}", field->name());
                 return false;
             }
+        }
+    }
+    else if (type.has<WrapperTrait>())
+    {
+        const auto& trait = type.get<WrapperTrait>();
+        if (!this->write(trait.type(), trait.value(value)))
+        {
+            CUBOS_ERROR("Could not serialize wrapper of type {}", trait.type().name());
+            return false;
         }
     }
     else if (type.has<StringConversionTrait>())

--- a/core/src/data/ser/debug.cpp
+++ b/core/src/data/ser/debug.cpp
@@ -6,6 +6,7 @@
 #include <cubos/core/reflection/traits/enum.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/traits/string_conversion.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 #include <cubos/core/tel/logging.hpp>
 
@@ -16,6 +17,7 @@ using cubos::core::reflection::EnumTrait;
 using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::StringConversionTrait;
 using cubos::core::reflection::Type;
+using cubos::core::reflection::WrapperTrait;
 
 #define AUTO_HOOK(type, ...)                                                                                           \
     this->hook<type>([this](const type& value) {                                                                       \
@@ -168,6 +170,15 @@ bool DebugSerializer::decompose(const Type& type, const void* value)
         mLevel -= 1;
         this->separate(true);
         mStream.put(')');
+    }
+    else if (type.has<WrapperTrait>())
+    {
+        const auto& trait = type.get<WrapperTrait>();
+        if (!this->write(trait.type(), trait.value(value)))
+        {
+            CUBOS_ERROR("Could not serialize wrapper of type {}", trait.type().name());
+            return false;
+        }
     }
     else if (type.has<StringConversionTrait>())
     {

--- a/core/src/data/ser/serializer.cpp
+++ b/core/src/data/ser/serializer.cpp
@@ -17,6 +17,7 @@ bool Serializer::write(const reflection::Type& type, const void* value)
     }
     else if (!this->decompose(type, value))
     {
+
         CUBOS_WARN("Serialization decomposition for type {} failed", type.name());
         return false;
     }

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -38,12 +38,12 @@ CUBOS_REFLECT_IMPL(DeltaTime)
 
 CUBOS_REFLECT_IMPL(ShouldQuit)
 {
-    return TypeBuilder<ShouldQuit>("cubos::core::ecs::ShouldQuit").withField("value", &ShouldQuit::value).build();
+    return TypeBuilder<ShouldQuit>("cubos::core::ecs::ShouldQuit").wrap(&ShouldQuit::value);
 }
 
 CUBOS_REFLECT_IMPL(Arguments)
 {
-    return TypeBuilder<Arguments>("cubos::core::ecs::Arguments").withField("value", &Arguments::value).build();
+    return TypeBuilder<Arguments>("cubos::core::ecs::Arguments").wrap(&Arguments::value);
 }
 
 struct Cubos::State

--- a/core/src/ecs/name.cpp
+++ b/core/src/ecs/name.cpp
@@ -4,5 +4,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::core::ecs::Name)
 {
-    return core::ecs::TypeBuilder<Name>("cubos::core::ecs::Name").ephemeral().withField("value", &Name::value).build();
+    return core::ecs::TypeBuilder<Name>("cubos::core::ecs::Name").ephemeral().wrap(&Name::value);
 }

--- a/core/src/geom/box.cpp
+++ b/core/src/geom/box.cpp
@@ -1,7 +1,7 @@
 #include <cubos/core/geom/box.hpp>
 #include <cubos/core/reflection/external/glm.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
-#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 
 CUBOS_REFLECT_IMPL(cubos::core::geom::Box)
@@ -10,5 +10,5 @@ CUBOS_REFLECT_IMPL(cubos::core::geom::Box)
 
     return Type::create("cubos::core::geom::Box")
         .with(ConstructibleTrait::typed<Box>().withBasicConstructors().build())
-        .with(FieldsTrait().withField("halfSize", &Box::halfSize));
+        .with(WrapperTrait(&Box::halfSize));
 }

--- a/core/src/reflection/traits/wrapper.cpp
+++ b/core/src/reflection/traits/wrapper.cpp
@@ -1,0 +1,9 @@
+#include <cubos/core/reflection/traits/wrapper.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using namespace cubos::core::reflection;
+
+CUBOS_REFLECT_IMPL(WrapperTrait)
+{
+    return Type::create("cubos::core::ecs::WrapperTrait");
+}

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
 	reflection/type_client_server.cpp
 	reflection/type_registry.cpp
 	reflection/traits/constructible.cpp
+	reflection/traits/wrapper.cpp
 	reflection/traits/fields.cpp
 	reflection/traits/nullable.cpp
 	reflection/traits/enum.cpp

--- a/core/tests/data/des/json.cpp
+++ b/core/tests/data/des/json.cpp
@@ -12,6 +12,7 @@
 #include <cubos/core/reflection/traits/enum.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/traits/nullable.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/tel/logging.hpp>
 
 #include "../utils.hpp"
@@ -23,6 +24,7 @@ using cubos::core::reflection::FieldsTrait;
 using cubos::core::reflection::NullableTrait;
 using cubos::core::reflection::reflect;
 using cubos::core::reflection::Type;
+using cubos::core::reflection::WrapperTrait;
 using cubos::core::tel::Level;
 using cubos::core::tel::Logger;
 
@@ -86,7 +88,7 @@ CUBOS_REFLECT_IMPL(Empty)
 
 CUBOS_REFLECT_IMPL(Wrapper)
 {
-    return Type::create("Wrapper").with(FieldsTrait{}.withField("inner", &Wrapper::inner));
+    return Type::create("Wrapper").with(WrapperTrait{&Wrapper::inner});
 }
 
 CUBOS_REFLECT_EXTERNAL_DECL(CUBOS_EMPTY, Color);
@@ -195,7 +197,7 @@ TEST_CASE("data::JSONDeserializer")
     const auto& nullable = reflect<Nullable>();
     const auto& nullableTrait = nullable.get<NullableTrait>();
     Nullable null{144};
-    AUTO_SUCCESS(144, null);
+    AUTO_SUCCESS((Json::object({{"value", 144}})), null);
 
     nullableTrait.setToNull(&null);
     AUTO_SUCCESS(nlohmann::json::value_t::null, null);

--- a/core/tests/reflection/traits/wrapper.cpp
+++ b/core/tests/reflection/traits/wrapper.cpp
@@ -1,0 +1,42 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/traits/wrapper.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::reflect;
+using cubos::core::reflection::Type;
+using cubos::core::reflection::WrapperTrait;
+
+namespace
+{
+    struct InnerType
+    {
+        CUBOS_REFLECT;
+    };
+
+    CUBOS_REFLECT_IMPL(InnerType)
+    {
+        return Type::create("InnerType");
+    }
+
+    struct MyWrapperType
+    {
+        CUBOS_REFLECT;
+        InnerType inner;
+    };
+
+    CUBOS_REFLECT_IMPL(MyWrapperType)
+    {
+        return Type::create("MyWrapperType").with(WrapperTrait{&MyWrapperType::inner});
+    }
+} // namespace
+
+TEST_CASE("reflection::WrapperTrait")
+{
+    MyWrapperType val{InnerType{}};
+    const auto& type = reflect<MyWrapperType>();
+    REQUIRE(type.has<WrapperTrait>());
+    const auto& trait = type.get<WrapperTrait>();
+    CHECK(trait.type().is<InnerType>());
+    CHECK(trait.value(&val) == &val.inner);
+}

--- a/engine/include/cubos/engine/scene/scene.hpp
+++ b/engine/include/cubos/engine/scene/scene.hpp
@@ -33,7 +33,7 @@ namespace cubos::engine
     ///     "game::Player": {},
     ///     "#camera": {
     ///         "cubos::engine::PerspectiveCamera": {
-    ///             "fov": 90,
+    ///             "fovY": 90,
     ///         }
     ///     },
     ///     "#gun": {

--- a/engine/samples/games/cubosurfers/assets/scenes/main.cubos
+++ b/engine/samples/games/cubosurfers/assets/scenes/main.cubos
@@ -88,7 +88,9 @@
         }
     },
     "#camera": {
-        "cubos::engine::PerspectiveCamera": 60.0,
+        "cubos::engine::PerspectiveCamera": {
+            "fovY": 60.0
+        },
         "cubos::engine::DrawsTo#render-target": {},
         "cubos::engine::Position": {
             "x": 0,

--- a/engine/samples/render/main/assets/main.cubos
+++ b/engine/samples/render/main/assets/main.cubos
@@ -3,7 +3,9 @@
         "cubos::engine::RenderTargetDefaults": {}
     },
     "#camera": {
-        "cubos::engine::PerspectiveCamera": 60.0,
+        "cubos::engine::PerspectiveCamera": {
+            "fovY": 60.0
+        },
         "cubos::engine::DrawsTo#render-target": {},
         "cubos::engine::Position": {
             "x": 0,
@@ -12,7 +14,9 @@
         }
     },
     "#camera2": {
-        "cubos::engine::PerspectiveCamera": 60.0,
+        "cubos::engine::PerspectiveCamera": {
+            "fovY": 60.0
+        },
         "cubos::engine::DrawsTo#render-target": {},
         "cubos::engine::Position": {
             "x": 3,

--- a/engine/samples/render/profiling/assets/main.cubos
+++ b/engine/samples/render/profiling/assets/main.cubos
@@ -3,7 +3,9 @@
         "cubos::engine::RenderTargetDefaults": {}
     },
     "#camera": {
-        "cubos::engine::PerspectiveCamera": 60.0,
+        "cubos::engine::PerspectiveCamera": {
+            "fovY": 60.0
+        },
         "cubos::engine::DrawsTo#render-target": {},
         "cubos::engine::Position": {
             "x": 64,

--- a/engine/samples/render/shadows/assets/main.cubos
+++ b/engine/samples/render/shadows/assets/main.cubos
@@ -3,7 +3,9 @@
         "cubos::engine::RenderTargetDefaults": {}
     },
     "#camera": {
-        "cubos::engine::PerspectiveCamera": 60.0,
+        "cubos::engine::PerspectiveCamera": {
+            "fovY": 60.0
+        },
         "cubos::engine::DrawsTo#render-target": {},
         "cubos::engine::Position": {
             "x": 0,

--- a/engine/samples/scene/main.cpp
+++ b/engine/samples/scene/main.cpp
@@ -27,7 +27,7 @@ CUBOS_DEFINE_TAG(cubos::engine::spawnTag);
 
 CUBOS_REFLECT_IMPL(Num)
 {
-    return cubos::core::ecs::TypeBuilder<Num>("Num").withField("value", &Num::value).build();
+    return cubos::core::ecs::TypeBuilder<Num>("Num").wrap(&Num::value);
 }
 
 CUBOS_REFLECT_IMPL(OwnedBy)
@@ -37,10 +37,7 @@ CUBOS_REFLECT_IMPL(OwnedBy)
 
 CUBOS_REFLECT_IMPL(DistanceTo)
 {
-    return cubos::core::ecs::TypeBuilder<DistanceTo>("DistanceTo")
-        .symmetric()
-        .withField("value", &DistanceTo::value)
-        .build();
+    return cubos::core::ecs::TypeBuilder<DistanceTo>("DistanceTo").symmetric().wrap(&DistanceTo::value);
 }
 /// [Component Refl]
 

--- a/engine/src/assets/asset.cpp
+++ b/engine/src/assets/asset.cpp
@@ -1,8 +1,9 @@
+#include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/reflection/external/string.hpp>
 #include <cubos/core/reflection/external/string_view.hpp>
 #include <cubos/core/reflection/external/uuid.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
-#include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 #include <cubos/core/tel/logging.hpp>
 
@@ -158,7 +159,7 @@ cubos::core::reflection::Type& AnyAsset::makeType(std::string name)
 
     return Type::create(std::move(name))
         .with(ConstructibleTrait::typed<AnyAsset>().withBasicConstructors().build())
-        .with(FieldsTrait().withField("id", &AnyAsset::pathOrId));
+        .with(WrapperTrait(&AnyAsset::pathOrId));
 }
 
 void AnyAsset::incRef() const

--- a/engine/src/collisions/interface/collision_layers.cpp
+++ b/engine/src/collisions/interface/collision_layers.cpp
@@ -5,9 +5,7 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::CollisionLayers)
 {
-    return core::ecs::TypeBuilder<CollisionLayers>("cubos::engine::CollisionLayers")
-        .withField("value", &CollisionLayers::value)
-        .build();
+    return core::ecs::TypeBuilder<CollisionLayers>("cubos::engine::CollisionLayers").wrap(&CollisionLayers::value);
 }
 
 void cubos::engine::CollisionLayers::setLayerValue(unsigned int layerNumber, bool newValue)

--- a/engine/src/collisions/interface/collision_mask.cpp
+++ b/engine/src/collisions/interface/collision_mask.cpp
@@ -5,9 +5,7 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::CollisionMask)
 {
-    return core::ecs::TypeBuilder<CollisionMask>("cubos::engine::CollisionMask")
-        .withField("value", &CollisionMask::value)
-        .build();
+    return core::ecs::TypeBuilder<CollisionMask>("cubos::engine::CollisionMask").wrap(&CollisionMask::value);
 }
 
 void cubos::engine::CollisionMask::setLayerValue(unsigned int layerNumber, bool newValue)

--- a/engine/src/collisions/interface/contact_manifold.cpp
+++ b/engine/src/collisions/interface/contact_manifold.cpp
@@ -7,9 +7,7 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::ContactFeatureId)
 {
-    return core::ecs::TypeBuilder<ContactFeatureId>("cubos::engine::ContactFeatureId")
-        .withField("id", &ContactFeatureId::id)
-        .build();
+    return core::ecs::TypeBuilder<ContactFeatureId>("cubos::engine::ContactFeatureId").wrap(&ContactFeatureId::id);
 }
 
 CUBOS_REFLECT_IMPL(cubos::engine::ContactPointData)

--- a/engine/src/collisions/interface/shapes/box.cpp
+++ b/engine/src/collisions/interface/shapes/box.cpp
@@ -6,6 +6,5 @@
 CUBOS_REFLECT_IMPL(cubos::engine::BoxCollisionShape)
 {
     return core::ecs::TypeBuilder<BoxCollisionShape>("cubos::engine::BoxCollisionShape")
-        .withField("box", &BoxCollisionShape::box)
-        .build();
+        .wrap(&BoxCollisionShape::box);
 }

--- a/engine/src/collisions/interface/shapes/capsule.cpp
+++ b/engine/src/collisions/interface/shapes/capsule.cpp
@@ -5,6 +5,5 @@
 CUBOS_REFLECT_IMPL(cubos::engine::CapsuleCollisionShape)
 {
     return core::ecs::TypeBuilder<CapsuleCollisionShape>("cubos::engine::CapsuleCollisionShape")
-        .withField("capsule", &CapsuleCollisionShape::capsule)
-        .build();
+        .wrap(&CapsuleCollisionShape::capsule);
 }

--- a/engine/src/collisions/interface/shapes/voxel.cpp
+++ b/engine/src/collisions/interface/shapes/voxel.cpp
@@ -5,6 +5,5 @@
 CUBOS_REFLECT_IMPL(cubos::engine::VoxelCollisionShape)
 {
     return core::ecs::TypeBuilder<VoxelCollisionShape>("cubos::engine::VoxelCollisionShape")
-        .withField("grid", &VoxelCollisionShape::grid)
-        .build();
+        .wrap(&VoxelCollisionShape::grid);
 }

--- a/engine/src/imgui/inspector.cpp
+++ b/engine/src/imgui/inspector.cpp
@@ -682,39 +682,38 @@ ImGuiInspector::State::State()
                     return ImGuiInspector::HookResult::Unhandled;
                 }
 
-                if (!ImGui::CollapsingHeader(name.c_str()))
+                bool modified = false;
+                if (ImGui::CollapsingHeader(name.c_str()))
                 {
-                    return ImGuiInspector::HookResult::Shown;
+                    ImGui::PushID(name.c_str());
+                    ImGui::Indent();
+
+                    modified |= inspector.inspect("scale", readOnly, reflect<glm::dvec3>(), &scale);
+                    modified |= inspector.inspect("rotation", readOnly, reflect<glm::dquat>(), &orientation);
+                    modified |= inspector.inspect("translation", readOnly, reflect<glm::dvec3>(), &translation);
+                    inspector.show("skew", skew);
+                    inspector.show("perspective", perspective);
+                    if (modified)
+                    {
+                        mat = glm::translate(glm::dmat4(1.0F), translation) * glm::toMat4(orientation) *
+                              glm::scale(glm::dmat4(1.0F), scale);
+                        if (type.is<glm::mat4>())
+                        {
+                            *static_cast<glm::mat4*>(value) = static_cast<glm::mat4>(mat);
+                        }
+                        else
+                        {
+                            *static_cast<glm::dmat4*>(value) = mat;
+                        }
+                    }
+
+                    ImGui::Unindent();
+                    ImGui::PopID();
                 }
                 if (ImGui::IsItemHovered())
                 {
                     ImGui::SetTooltip("Matrix of type %s", type.shortName().c_str());
                 }
-                ImGui::PushID(name.c_str());
-                ImGui::Indent();
-
-                bool modified = false;
-                modified |= inspector.inspect("scale", readOnly, reflect<glm::dvec3>(), &scale);
-                modified |= inspector.inspect("rotation", readOnly, reflect<glm::dquat>(), &orientation);
-                modified |= inspector.inspect("translation", readOnly, reflect<glm::dvec3>(), &translation);
-                inspector.show("skew", skew);
-                inspector.show("perspective", perspective);
-                if (modified)
-                {
-                    mat = glm::translate(glm::dmat4(1.0F), translation) * glm::toMat4(orientation) *
-                          glm::scale(glm::dmat4(1.0F), scale);
-                    if (type.is<glm::mat4>())
-                    {
-                        *static_cast<glm::mat4*>(value) = static_cast<glm::mat4>(mat);
-                    }
-                    else
-                    {
-                        *static_cast<glm::dmat4*>(value) = mat;
-                    }
-                }
-
-                ImGui::Unindent();
-                ImGui::PopID();
 
                 return modified ? ImGuiInspector::HookResult::Modified : ImGuiInspector::HookResult::Shown;
             }

--- a/engine/src/imgui/inspector.cpp
+++ b/engine/src/imgui/inspector.cpp
@@ -14,6 +14,7 @@
 #include <cubos/core/reflection/traits/mask.hpp>
 #include <cubos/core/reflection/traits/string_conversion.hpp>
 #include <cubos/core/reflection/traits/vector.hpp>
+#include <cubos/core/reflection/traits/wrapper.hpp>
 
 #include <cubos/engine/imgui/inspector.hpp>
 
@@ -719,5 +720,18 @@ ImGuiInspector::State::State()
             }
 
             return ImGuiInspector::HookResult::Unhandled;
+        });
+
+    // Handle wrapper types.
+    hooks.emplace_back(
+        [](const std::string& name, bool readOnly, ImGuiInspector& inspector, const Type& type, void* value) {
+            if (!type.has<WrapperTrait>())
+            {
+                return ImGuiInspector::HookResult::Unhandled;
+            }
+
+            const auto& wrapper = type.get<WrapperTrait>();
+            bool modified = inspector.inspect(name, readOnly, wrapper.type(), wrapper.value(value));
+            return modified ? ImGuiInspector::HookResult::Modified : ImGuiInspector::HookResult::Shown;
         });
 }

--- a/engine/src/input/action.cpp
+++ b/engine/src/input/action.cpp
@@ -1,3 +1,4 @@
+#include <cubos/core/ecs/reflection.hpp>
 #include <cubos/core/reflection/external/vector.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/type.hpp>
@@ -8,9 +9,8 @@ using namespace cubos::engine;
 
 CUBOS_REFLECT_IMPL(cubos::engine::InputAction)
 {
-    using namespace cubos::core::reflection;
-    return Type::create("cubos::engine::InputAction")
-        .with(FieldsTrait{}.withField("combinations", &InputAction::mCombinations));
+    return cubos::core::ecs::TypeBuilder<cubos::engine::InputAction>("cubos::engine::InputAction")
+        .wrap(&InputAction::mCombinations);
 }
 
 const std::vector<InputCombination>& InputAction::combinations() const

--- a/engine/src/physics/components/accumulated_correction.cpp
+++ b/engine/src/physics/components/accumulated_correction.cpp
@@ -7,6 +7,5 @@
 CUBOS_REFLECT_IMPL(cubos::engine::AccumulatedCorrection)
 {
     return cubos::core::ecs::TypeBuilder<AccumulatedCorrection>("cubos::engine::AccumulatedCorrection")
-        .withField("position", &AccumulatedCorrection::position)
-        .build();
+        .wrap(&AccumulatedCorrection::position);
 }

--- a/engine/src/physics/components/angular_velocity.cpp
+++ b/engine/src/physics/components/angular_velocity.cpp
@@ -6,7 +6,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::AngularVelocity)
 {
-    return cubos::core::ecs::TypeBuilder<AngularVelocity>("cubos::engine::AngularVelocity")
-        .withField("vec", &AngularVelocity::vec)
-        .build();
+    return cubos::core::ecs::TypeBuilder<AngularVelocity>("cubos::engine::AngularVelocity").wrap(&AngularVelocity::vec);
 }

--- a/engine/src/physics/components/center_of_mass.cpp
+++ b/engine/src/physics/components/center_of_mass.cpp
@@ -6,7 +6,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::CenterOfMass)
 {
-    return cubos::core::ecs::TypeBuilder<CenterOfMass>("cubos::engine::CenterOfMass")
-        .withField("vec", &CenterOfMass::vec)
-        .build();
+    return cubos::core::ecs::TypeBuilder<CenterOfMass>("cubos::engine::CenterOfMass").wrap(&CenterOfMass::vec);
 }

--- a/engine/src/physics/components/velocity.cpp
+++ b/engine/src/physics/components/velocity.cpp
@@ -6,7 +6,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::Velocity)
 {
-    return cubos::core::ecs::TypeBuilder<Velocity>("cubos::engine::Velocity")
-        .withField("velocity", &Velocity::vec)
-        .build();
+    return cubos::core::ecs::TypeBuilder<Velocity>("cubos::engine::Velocity").wrap(&Velocity::vec);
 }

--- a/engine/src/physics/fixed_substep/substeps.cpp
+++ b/engine/src/physics/fixed_substep/substeps.cpp
@@ -5,5 +5,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::Substeps)
 {
-    return core::ecs::TypeBuilder<Substeps>("cubos::engine::Substeps").withField("value", &Substeps::value).build();
+    return core::ecs::TypeBuilder<Substeps>("cubos::engine::Substeps").wrap(&Substeps::value);
 }

--- a/engine/src/render/voxels/palette.cpp
+++ b/engine/src/render/voxels/palette.cpp
@@ -5,6 +5,5 @@
 CUBOS_REFLECT_IMPL(cubos::engine::RenderPalette)
 {
     return core::ecs::TypeBuilder<RenderPalette>("cubos::engine::RenderPalette")
-        .withField("asset", &RenderPalette::asset)
-        .build();
+        .wrap(&RenderPalette::asset);
 }

--- a/engine/src/tools/selection/selection.cpp
+++ b/engine/src/tools/selection/selection.cpp
@@ -4,7 +4,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::Selection)
 {
-    return cubos::core::ecs::TypeBuilder<Selection>("cubos::engine::::Selection")
-        .withField("entity", &Selection::entity)
-        .build();
+    return cubos::core::ecs::TypeBuilder<Selection>("cubos::engine::::Selection").wrap(&Selection::entity);
 }

--- a/engine/src/transform/local_to_parent.cpp
+++ b/engine/src/transform/local_to_parent.cpp
@@ -5,8 +5,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::LocalToParent)
 {
-    return core::ecs::TypeBuilder<LocalToParent>("cubos::engine::LocalToParent")
-        .ephemeral()
-        .withField("mat", &LocalToParent::mat)
-        .build();
+    return core::ecs::TypeBuilder<LocalToParent>("cubos::engine::LocalToParent").ephemeral().wrap(&LocalToParent::mat);
 }

--- a/engine/src/transform/local_to_world.cpp
+++ b/engine/src/transform/local_to_world.cpp
@@ -7,10 +7,7 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::LocalToWorld)
 {
-    return core::ecs::TypeBuilder<LocalToWorld>("cubos::engine::LocalToWorld")
-        .ephemeral()
-        .withField("mat", &LocalToWorld::mat)
-        .build();
+    return core::ecs::TypeBuilder<LocalToWorld>("cubos::engine::LocalToWorld").ephemeral().wrap(&LocalToWorld::mat);
 }
 
 glm::mat4 cubos::engine::LocalToWorld::inverse() const

--- a/engine/src/transform/position.cpp
+++ b/engine/src/transform/position.cpp
@@ -5,5 +5,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::Position)
 {
-    return core::ecs::TypeBuilder<Position>("cubos::engine::Position").withField("vec", &Position::vec).build();
+    return core::ecs::TypeBuilder<Position>("cubos::engine::Position").wrap(&Position::vec);
 }

--- a/engine/src/transform/rotation.cpp
+++ b/engine/src/transform/rotation.cpp
@@ -5,7 +5,7 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::Rotation)
 {
-    return core::ecs::TypeBuilder<Rotation>("cubos::engine::Rotation").withField("quat", &Rotation::quat).build();
+    return core::ecs::TypeBuilder<Rotation>("cubos::engine::Rotation").wrap(&Rotation::quat);
 }
 
 auto cubos::engine::Rotation::lookingAt(glm::vec3 direction, glm::vec3 up) -> Rotation

--- a/engine/src/transform/scale.cpp
+++ b/engine/src/transform/scale.cpp
@@ -5,5 +5,5 @@
 
 CUBOS_REFLECT_IMPL(cubos::engine::Scale)
 {
-    return core::ecs::TypeBuilder<Scale>("cubos::engine::Scale").withField("mat", &Scale::factor).build();
+    return core::ecs::TypeBuilder<Scale>("cubos::engine::Scale").wrap(&Scale::factor);
 }

--- a/tools/tesseratos/templates/simple/assets/scenes/main.cubos
+++ b/tools/tesseratos/templates/simple/assets/scenes/main.cubos
@@ -4,7 +4,9 @@
         "cubos::engine::GizmosTarget": {}
     },
     "#camera": {
-        "cubos::engine::PerspectiveCamera": 70.0,
+        "cubos::engine::PerspectiveCamera": {
+            "fovY": 70.0
+        },
         "cubos::engine::DrawsTo#render-target": {},
         "cubos::engine::Position": {
             "x": 0,


### PR DESCRIPTION
# Description

Previously in a scene if you had an object with a single fields you would be forced to type it as a value like so:
```cpp
"object": "value1"
```
But that can be inconvenient so now you can also type it like any other object:
```cpp
"object": {
    "field1": "value1"
}
```

If we want to preserve the old behavior for a given type, we use the new WrapperTrait instead of a FieldsTrait.

## Checklist
- [x] Self-review changes.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.