### PR TITLE
Add conditional shader compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SSAO resolution scale (#1423, **@tomas7770**).
 - Warm starting for collision solving (#1248, **@fallenatlas**).
+- Conditional shader compilation (#1406, **@tomas7770**).
 
 ### Changed
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -150,6 +150,7 @@ set(CUBOS_ENGINE_SOURCE
 	"src/render/defaults/target.cpp"
 	"src/render/shader/plugin.cpp"
 	"src/render/shader/shader.cpp"
+	"src/render/shader/shader_builder.cpp"
 	"src/render/shader/bridge.cpp"
 	"src/render/g_buffer/plugin.cpp"
 	"src/render/g_buffer/g_buffer.cpp"

--- a/engine/include/cubos/engine/render/shader/shader.hpp
+++ b/engine/include/cubos/engine/render/shader/shader.hpp
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include <utility>
+
 #include <cubos/core/gl/render_device.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
+#include <cubos/engine/render/shader/shader_builder.hpp>
 
 namespace cubos::engine
 {
@@ -21,15 +24,25 @@ namespace cubos::engine
         ~Shader() = default;
 
         /// @brief Constructs a shader from code.
-        /// @param shaderStage Shader stage created from GLSL code.
-        Shader(cubos::core::gl::ShaderStage shaderStage)
-            : mShaderStage(std::move(shaderStage)){};
+        /// @param stage Shader stage to create.
+        /// @param renderDevice Render device used to create the shader.
+        /// @param contents Shader source code.
+        Shader(const cubos::core::gl::Stage stage, cubos::core::gl::RenderDevice& renderDevice, std::string contents)
+            : mStage(stage)
+            , mRenderDevice(renderDevice)
+            , mContents(std::move(contents)){};
 
         /// @brief Returns the asset's shader stage.
         /// @return Shader stage.
         cubos::core::gl::ShaderStage shaderStage() const;
 
+        /// @brief Returns a shader builder to configure compile-time shader parameters.
+        /// @return Shader builder.
+        ShaderBuilder builder() const;
+
     private:
-        cubos::core::gl::ShaderStage mShaderStage;
+        const cubos::core::gl::Stage mStage;          ///< Shader stage type to create.
+        cubos::core::gl::RenderDevice& mRenderDevice; ///< Render device used to create the shader.
+        const std::string mContents;                  ///< Shader source code.
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/render/shader/shader_builder.hpp
+++ b/engine/include/cubos/engine/render/shader/shader_builder.hpp
@@ -1,0 +1,61 @@
+/// @file
+/// @brief Class @ref cubos::engine::ShaderBuilder.
+/// @ingroup render-shader-plugin
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <cubos/core/gl/render_device.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    class Shader;
+
+    /// @brief Configures compile-time shader parameters using #define macros.
+    /// @ingroup render-shader-plugin
+    class CUBOS_ENGINE_API ShaderBuilder final
+    {
+    public:
+        /// @brief Creates a shader builder.
+        /// @param renderDevice Render device used to create the shader.
+        /// @param stage Shader stage to create.
+        /// @param contents Shader source code.
+        ShaderBuilder(cubos::core::gl::RenderDevice& renderDevice, const cubos::core::gl::Stage stage,
+                      std::string contents)
+            : mRenderDevice(renderDevice)
+            , mStage(stage)
+            , mContents(std::move(contents)){};
+
+        /// @brief Defines a parameter with no value.
+        /// @param defineName Parameter name to define.
+        /// @return This shader builder (for chaining calls).
+        ShaderBuilder& with(const std::string& defineName);
+
+        /// @brief Defines a parameter with a value.
+        /// @param defineName Parameter name to define.
+        /// @param defineValue Parameter value.
+        /// @return This shader builder (for chaining calls).
+        ShaderBuilder& with(const std::string& defineName, const std::string& defineValue);
+
+        /// @brief Compiles a shader from the source code stored in the builder.
+        /// @return Shader stage.
+        cubos::core::gl::ShaderStage build() const;
+
+    private:
+        struct ShaderParameter
+        {
+            const std::string name;
+            std::optional<const std::string> value;
+        };
+
+        cubos::core::gl::RenderDevice& mRenderDevice; ///< Render device used to create the shader.
+        const cubos::core::gl::Stage mStage;          ///< Shader stage type to create.
+        const std::string mContents;                  ///< Shader source code.
+        std::vector<ShaderParameter> mParameters;
+    };
+} // namespace cubos::engine

--- a/engine/src/render/shader/bridge.cpp
+++ b/engine/src/render/shader/bridge.cpp
@@ -12,15 +12,8 @@ bool ShaderBridge::loadFromFile(Assets& assets, const AnyAsset& handle, Stream& 
     std::string contents;
     stream.readUntil(contents, nullptr);
 
-    cubos::core::gl::ShaderStage shaderStage = mRenderDevice.createShaderStage(mStage, contents.c_str());
-    if (shaderStage == nullptr)
-    {
-        CUBOS_ERROR("Shader asset stage creation failed");
-        return false;
-    }
-
     // Store the asset's data.
-    assets.store(handle, Shader(shaderStage));
+    assets.store(handle, Shader(mStage, mRenderDevice, contents));
     return true;
 }
 

--- a/engine/src/render/shader/shader.cpp
+++ b/engine/src/render/shader/shader.cpp
@@ -17,5 +17,10 @@ CUBOS_REFLECT_IMPL(Shader)
 
 cubos::core::gl::ShaderStage Shader::shaderStage() const
 {
-    return mShaderStage;
+    return builder().build();
+}
+
+ShaderBuilder Shader::builder() const
+{
+    return {mRenderDevice, mStage, mContents};
 }

--- a/engine/src/render/shader/shader_builder.cpp
+++ b/engine/src/render/shader/shader_builder.cpp
@@ -1,0 +1,46 @@
+#include <cubos/core/reflection/external/glm.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+#include <cubos/core/reflection/traits/constructible.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+#include <cubos/engine/render/shader/shader.hpp>
+#include <cubos/engine/render/shader/shader_builder.hpp>
+
+using namespace cubos::engine;
+
+ShaderBuilder& ShaderBuilder::with(const std::string& defineName)
+{
+    mParameters.push_back({defineName, {}});
+    return *this;
+}
+
+ShaderBuilder& ShaderBuilder::with(const std::string& defineName, const std::string& defineValue)
+{
+    mParameters.push_back({defineName, defineValue});
+    return *this;
+}
+
+cubos::core::gl::ShaderStage ShaderBuilder::build() const
+{
+    std::string contents;
+    for (const auto& parameter : mParameters)
+    {
+        if (parameter.value.has_value())
+        {
+            contents += "#define " + parameter.name + " " + parameter.value.value() + "\n";
+        }
+        else
+        {
+            contents += "#define " + parameter.name + "\n";
+        }
+    }
+    contents += mContents;
+
+    cubos::core::gl::ShaderStage shaderStage = mRenderDevice.createShaderStage(mStage, contents.c_str());
+    if (shaderStage == nullptr)
+    {
+        CUBOS_ERROR("Shader asset stage creation failed");
+        return nullptr;
+    }
+    return shaderStage;
+}


### PR DESCRIPTION
# Description

Adds the ability to configure compile-time shader parameters using `#define` macros. This allows changing e.g. the number of CSM splits in deferred shading, textures drawn to in the G-buffer rasterizer (to disable/enable the render picker).

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
