### PR TITLE
feat(engine): allow multiple contacts between two entities

### DIFF
--- a/engine/include/cubos/engine/collisions/colliding_with.hpp
+++ b/engine/include/cubos/engine/collisions/colliding_with.hpp
@@ -21,7 +21,7 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        cubos::core::ecs::Entity entity; ///< Entity to which the normal is relative to.
+        cubos::core::ecs::Entity entity; ///< Entity to which the normals in the manifolds are relative to..
 
         std::vector<ContactManifold> manifolds; ///< All contact interfaces between the entities
     };

--- a/engine/include/cubos/engine/collisions/colliding_with.hpp
+++ b/engine/include/cubos/engine/collisions/colliding_with.hpp
@@ -7,9 +7,11 @@
 #include <glm/vec3.hpp>
 
 #include <cubos/core/ecs/entity/entity.hpp>
+#include <cubos/core/reflection/external/vector.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
+#include <cubos/engine/collisions/contact_manifold.hpp>
 
 namespace cubos::engine
 {
@@ -20,10 +22,7 @@ namespace cubos::engine
         CUBOS_REFLECT;
 
         cubos::core::ecs::Entity entity; ///< Entity to which the normal is relative to.
-        glm::vec3 entity1OriginalPosition;
-        glm::vec3 entity2OriginalPosition;
-        float penetration;  ///< Penetration depth of the collision.
-        glm::vec3 position; ///< Position of contact on the surface of the entity.
-        glm::vec3 normal;   ///< Normal of contact on the surface of the entity.
+
+        std::vector<ContactManifold> manifolds; ///< All contact interfaces between the entities
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/collisions/contact_manifold.hpp
+++ b/engine/include/cubos/engine/collisions/contact_manifold.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @brief Relation @ref cubos::engine::ContactManifold.
+/// @brief Struct @ref cubos::engine::ContactManifold.
 /// @ingroup collisions-plugin
 
 #pragma once
@@ -127,9 +127,10 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        cubos::core::ecs::Entity entity;      ///< Entity to which the normal is relative to.
         glm::vec3 normal;                     ///< A contact normal shared by all contacts in this manifold,
                                               ///< expressed in the local space of the first entity.
         std::vector<ContactPointData> points; ///< Contact points of this manifold.
+        uint32_t boxId1;                      ///< If the manifold is from a voxelShape we need to know which boxes
+        uint32_t boxId2;                      ///< are colliding
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/collisions/shapes/voxel.hpp
+++ b/engine/include/cubos/engine/collisions/shapes/voxel.hpp
@@ -30,6 +30,7 @@ namespace cubos::engine
         {
             cubos::core::geom::Box box;
             glm::vec3 shift;
+            uint32_t boxId;
         };
 
         /// @brief Entities voxel grid.
@@ -74,11 +75,12 @@ namespace cubos::engine
         /// @brief Inserts a new @ref BoxShiftPair to the list of the class.
         /// @param box Box to insert.
         /// @param shift Shift vector of the box.
-        void insertBox(const cubos::core::geom::Box& box, const glm::vec3& shift)
+        void insertBox(const cubos::core::geom::Box& box, const glm::vec3& shift, uint32_t boxId)
         {
             BoxShiftPair pair;
             pair.box = box;
             pair.shift = shift;
+            pair.boxId = boxId;
             this->mBoxes.push_back(pair);
         }
 

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -223,41 +223,45 @@ int main(int argc, char** argv)
         .after(collisionsTag)
         .after(gizmosDrawTag)
         .call([](Gizmos& gizmos, const DebugDraw& draw,
-                 Query<Entity, const Position&, const ContactManifold&, Entity, const Position&> query) {
-            for (auto [ent1, pos1, manifold, ent2, pos2] : query)
+                 Query<Entity, const Position&, const CollidingWith&, Entity, const Position&> query) {
+            for (auto [ent1, pos1, collidingWith, ent2, pos2] : query)
             {
-                if (draw.normal)
+                for (auto manifold : collidingWith.manifolds)
                 {
-                    glm::vec3 origin = ent1 == manifold.entity ? pos1.vec : pos2.vec;
-                    gizmos.color({0.0F, 1.0F, 0.0F});
-                    gizmos.drawArrow("arrow", origin, manifold.normal, 0.01F, 0.05F, 0.7F, 0.05F, Gizmos::Space::World);
-                }
-
-                if (draw.manifoldPolygon && manifold.points.size() > 1)
-                {
-                    cubos::engine::ContactPointData start = manifold.points.back();
-                    for (const cubos::engine::ContactPointData& end : manifold.points)
+                    if (draw.normal)
                     {
-                        gizmos.color({1.0F, 1.0F, 0.0F});
-                        gizmos.drawArrow("line", start.globalOn1, end.globalOn1 - start.globalOn1, 0.01F, 0.05F, 1.0F,
-                                         0.05F, Gizmos::Space::World);
-                        start = end;
+                        glm::vec3 origin = ent1 == collidingWith.entity ? pos1.vec : pos2.vec;
+                        gizmos.color({0.0F, 1.0F, 0.0F});
+                        gizmos.drawArrow("arrow", origin, manifold.normal, 0.01F, 0.05F, 0.7F, 0.05F,
+                                         Gizmos::Space::World);
                     }
-                }
 
-                if (draw.points)
-                {
-                    for (auto point : manifold.points)
+                    if (draw.manifoldPolygon && manifold.points.size() > 1)
                     {
-                        // Have a set color for each of the entities for an easier distinction
-                        bool isEnt1 = ent1 == manifold.entity;
-                        gizmos.color((isEnt1 ? glm::vec3(0.0F, 0.0F, 1.0F) : glm::vec3(1.0F, 0.0F, 1.0F)));
-                        gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F, 1.0F,
-                                         0.05F, Gizmos::Space::World);
+                        cubos::engine::ContactPointData start = manifold.points.back();
+                        for (const cubos::engine::ContactPointData& end : manifold.points)
+                        {
+                            gizmos.color({1.0F, 1.0F, 0.0F});
+                            gizmos.drawArrow("line", start.globalOn1, end.globalOn1 - start.globalOn1, 0.01F, 0.05F,
+                                             1.0F, 0.05F, Gizmos::Space::World);
+                            start = end;
+                        }
+                    }
 
-                        gizmos.color((isEnt1 ? glm::vec3(1.0F, 0.0F, 1.0F) : glm::vec3(0.0F, 0.0F, 1.0F)));
-                        gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F, 1.0F,
-                                         0.05F, Gizmos::Space::World);
+                    if (draw.points)
+                    {
+                        for (auto point : manifold.points)
+                        {
+                            // Have a set color for each of the entities for an easier distinction
+                            bool isEnt1 = ent1 == collidingWith.entity;
+                            gizmos.color((isEnt1 ? glm::vec3(0.0F, 0.0F, 1.0F) : glm::vec3(1.0F, 0.0F, 1.0F)));
+                            gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F,
+                                             1.0F, 0.05F, Gizmos::Space::World);
+
+                            gizmos.color((isEnt1 ? glm::vec3(1.0F, 0.0F, 1.0F) : glm::vec3(0.0F, 0.0F, 1.0F)));
+                            gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F,
+                                             1.0F, 0.05F, Gizmos::Space::World);
+                        }
                     }
                 }
             }

--- a/engine/samples/voxel-shape-collisions/main.cpp
+++ b/engine/samples/voxel-shape-collisions/main.cpp
@@ -176,40 +176,43 @@ int main()
         .after(collisionsTag)
         .after(gizmosDrawTag)
         .call([](Gizmos& gizmos, const DebugDraw& draw,
-                 Query<Entity, const Position&, const ContactManifold&, Entity, const Position&> query) {
-            for (auto [ent1, pos1, manifold, ent2, pos2] : query)
+                 Query<Entity, const Position&, const CollidingWith&, Entity, const Position&> query) {
+            for (auto [ent1, pos1, collidingWith, ent2, pos2] : query)
             {
-
-                if (draw.normal)
+                for (auto manifold : collidingWith.manifolds)
                 {
-                    glm::vec3 origin = ent1 == manifold.entity ? pos1.vec : pos2.vec;
-                    gizmos.color({0.0F, 1.0F, 0.0F});
-                    gizmos.drawArrow("arrow", origin, manifold.normal, 0.1F, 0.5F, 0.7F, 0.05F, Gizmos::Space::World);
-                }
-
-                if (draw.manifoldPolygon && manifold.points.size() > 1)
-                {
-                    cubos::engine::ContactPointData start = manifold.points.back();
-                    for (const cubos::engine::ContactPointData& end : manifold.points)
+                    if (draw.normal)
                     {
-                        gizmos.color({1.0F, 1.0F, 0.0F});
-                        gizmos.drawArrow("line", start.globalOn1, end.globalOn1 - start.globalOn1, 1.0F, 1.2F, 1.0F,
-                                         0.05F, Gizmos::Space::World);
-                        start = end;
+                        glm::vec3 origin = ent1 == collidingWith.entity ? pos1.vec : pos2.vec;
+                        gizmos.color({0.0F, 1.0F, 0.0F});
+                        gizmos.drawArrow("arrow", origin, manifold.normal, 0.1F, 0.5F, 0.7F, 0.05F,
+                                         Gizmos::Space::World);
                     }
-                }
 
-                if (draw.points)
-                {
-                    for (auto point : manifold.points)
+                    if (draw.manifoldPolygon && manifold.points.size() > 1)
                     {
-                        gizmos.color({0.0F, 0.0F, 1.0F});
-                        gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 1.0F, 1.0F, 1.0F,
-                                         0.05F, Gizmos::Space::World);
+                        cubos::engine::ContactPointData start = manifold.points.back();
+                        for (const cubos::engine::ContactPointData& end : manifold.points)
+                        {
+                            gizmos.color({1.0F, 1.0F, 0.0F});
+                            gizmos.drawArrow("line", start.globalOn1, end.globalOn1 - start.globalOn1, 1.0F, 1.2F, 1.0F,
+                                             0.05F, Gizmos::Space::World);
+                            start = end;
+                        }
+                    }
 
-                        gizmos.color({1.0F, 0.0F, 1.0F});
-                        gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 1.0F, 1.0F, 1.0F,
-                                         0.05F, Gizmos::Space::World);
+                    if (draw.points)
+                    {
+                        for (auto point : manifold.points)
+                        {
+                            gizmos.color({0.0F, 0.0F, 1.0F});
+                            gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 1.0F, 1.0F, 1.0F,
+                                             0.05F, Gizmos::Space::World);
+
+                            gizmos.color({1.0F, 0.0F, 1.0F});
+                            gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 1.0F, 1.0F, 1.0F,
+                                             0.05F, Gizmos::Space::World);
+                        }
                     }
                 }
             }

--- a/engine/src/collisions/interface/colliding_with.cpp
+++ b/engine/src/collisions/interface/colliding_with.cpp
@@ -9,8 +9,6 @@ CUBOS_REFLECT_IMPL(cubos::engine::CollidingWith)
     return core::ecs::TypeBuilder<CollidingWith>("cubos::engine::CollidingWith")
         .symmetric()
         .withField("entity", &CollidingWith::entity)
-        .withField("penetration", &CollidingWith::penetration)
-        .withField("position", &CollidingWith::position)
-        .withField("normal", &CollidingWith::normal)
+        .withField("manifolds", &CollidingWith::manifolds)
         .build();
 }

--- a/engine/src/collisions/interface/contact_manifold.cpp
+++ b/engine/src/collisions/interface/contact_manifold.cpp
@@ -32,9 +32,9 @@ CUBOS_REFLECT_IMPL(cubos::engine::ContactPointData)
 CUBOS_REFLECT_IMPL(cubos::engine::ContactManifold)
 {
     return core::ecs::TypeBuilder<ContactManifold>("cubos::engine::ContactManifold")
-        .symmetric()
-        .withField("entity", &ContactManifold::entity)
         .withField("normal", &ContactManifold::normal)
         .withField("points", &ContactManifold::points)
+        .withField("boxId1", &ContactManifold::boxId1)
+        .withField("boxId2", &ContactManifold::boxId2)
         .build();
 }

--- a/engine/src/collisions/interface/plugin.cpp
+++ b/engine/src/collisions/interface/plugin.cpp
@@ -15,5 +15,4 @@ void cubos::engine::interfaceCollisionsPlugin(Cubos& cubos)
     cubos.component<VoxelCollisionShape>();
 
     cubos.relation<CollidingWith>();
-    cubos.relation<ContactManifold>();
 }

--- a/engine/src/collisions/plugin.cpp
+++ b/engine/src/collisions/plugin.cpp
@@ -229,6 +229,7 @@ void cubos::engine::collisionsPlugin(Cubos& cubos)
             glm::uvec3 size = grid.size();
             glm::vec3 center = glm::vec3(size) / 2.0F;
             auto boxCoords = greedy3dMeshing(grid);
+            uint32_t boxId = 1;
 
             for (auto corners : boxCoords)
             {
@@ -236,7 +237,8 @@ void cubos::engine::collisionsPlugin(Cubos& cubos)
                 auto boxCenter = glm::vec3(glm::ivec3(corners.first + corners.second) + glm::ivec3(1, 1, 1)) / 2.0F;
                 glm::vec3 shift = center - boxCenter;
                 box.halfSize = glm::vec3(glm::ivec3(corners.second - corners.first) + glm::ivec3(1, 1, 1)) / 2.0F;
-                shape.insertBox(box, shift);
+                shape.insertBox(box, shift, boxId);
+                boxId++;
             }
         }
     };

--- a/engine/src/physics/constraints/penetration_constraint.cpp
+++ b/engine/src/physics/constraints/penetration_constraint.cpp
@@ -27,8 +27,6 @@ CUBOS_REFLECT_IMPL(cubos::engine::PenetrationConstraintPointData)
 CUBOS_REFLECT_IMPL(cubos::engine::PenetrationConstraint)
 {
     return cubos::core::ecs::TypeBuilder<PenetrationConstraint>("cubos::engine::PenetrationConstraint")
-        .symmetric()
-        .withField("entity", &PenetrationConstraint::entity)
         .withField("normal", &PenetrationConstraint::normal)
         .withField("friction", &PenetrationConstraint::friction)
         .withField("restitution", &PenetrationConstraint::restitution)
@@ -36,5 +34,14 @@ CUBOS_REFLECT_IMPL(cubos::engine::PenetrationConstraint)
         .withField("biasCoefficient", &PenetrationConstraint::biasCoefficient)
         .withField("impulseCoefficient", &PenetrationConstraint::impulseCoefficient)
         .withField("massCoefficient", &PenetrationConstraint::massCoefficient)
+        .build();
+}
+
+CUBOS_REFLECT_IMPL(cubos::engine::PenetrationConstraints)
+{
+    return cubos::core::ecs::TypeBuilder<PenetrationConstraints>("cubos::engine::PenetrationConstraints")
+        .symmetric()
+        .withField("entity", &PenetrationConstraints::entity)
+        .withField("penConstraints", &PenetrationConstraints::penConstraints)
         .build();
 }

--- a/engine/src/physics/constraints/penetration_constraint.hpp
+++ b/engine/src/physics/constraints/penetration_constraint.hpp
@@ -50,9 +50,9 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        glm::vec3 normal;                ///< Normal of contact on the surface of the entity.
-        float friction;                  ///< Friction of the constraint.
-        float restitution;               ///< Restitution coefficient of the constraint.
+        glm::vec3 normal;  ///< Normal of contact on the surface of the entity.
+        float friction;    ///< Friction of the constraint.
+        float restitution; ///< Restitution coefficient of the constraint.
 
         std::vector<PenetrationConstraintPointData> points; ///< Contact points in the contact manifold.
 
@@ -62,13 +62,16 @@ namespace cubos::engine
         float massCoefficient;
     };
 
-    /// @brief Holds multiple PenetrationConstraints
+    /// @brief Holds multiple PenetrationConstraints.
+    ///
+    /// Necessary due to the possibility of two entities having more than once collision contact.
+    ///
     /// @ingroup physics-solver-plugin
     struct PenetrationConstraints
     {
         CUBOS_REFLECT;
 
-        cubos::core::ecs::Entity entity; ///< Entity to which the normal is relative to.
+        cubos::core::ecs::Entity entity; ///< Entity to which the normals are relative to.
 
         std::vector<PenetrationConstraint> penConstraints; ///< Penetration contraints for each manifold.
     };

--- a/engine/src/physics/constraints/penetration_constraint.hpp
+++ b/engine/src/physics/constraints/penetration_constraint.hpp
@@ -50,7 +50,6 @@ namespace cubos::engine
     {
         CUBOS_REFLECT;
 
-        cubos::core::ecs::Entity entity; ///< Entity to which the normal is relative to.
         glm::vec3 normal;                ///< Normal of contact on the surface of the entity.
         float friction;                  ///< Friction of the constraint.
         float restitution;               ///< Restitution coefficient of the constraint.
@@ -61,5 +60,16 @@ namespace cubos::engine
         float biasCoefficient;
         float impulseCoefficient;
         float massCoefficient;
+    };
+
+    /// @brief Holds multiple PenetrationConstraints
+    /// @ingroup physics-solver-plugin
+    struct PenetrationConstraints
+    {
+        CUBOS_REFLECT;
+
+        cubos::core::ecs::Entity entity; ///< Entity to which the normal is relative to.
+
+        std::vector<PenetrationConstraint> penConstraints; ///< Penetration contraints for each manifold.
     };
 } // namespace cubos::engine

--- a/engine/src/physics/solver/penetration_constraint/plugin.cpp
+++ b/engine/src/physics/solver/penetration_constraint/plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <glm/glm.hpp>
 
+#include <cubos/engine/collisions/colliding_with.hpp>
 #include <cubos/engine/collisions/contact_manifold.hpp>
 #include <cubos/engine/collisions/plugin.hpp>
 #include <cubos/engine/fixed_step/plugin.hpp>
@@ -80,144 +81,145 @@ static float mixValues(float value1, float value2, PhysicsMaterial::MixProperty 
 
 static void solvePenetrationConstraint(
     Query<Entity, const Mass&, const Inertia&, const Rotation&, AccumulatedCorrection&, Velocity&, AngularVelocity&,
-          PenetrationConstraint&, Entity, const Mass&, const Inertia&, const Rotation&, AccumulatedCorrection&,
+          PenetrationConstraints&, Entity, const Mass&, const Inertia&, const Rotation&, AccumulatedCorrection&,
           Velocity&, AngularVelocity&>
         query,
     const FixedDeltaTime& fixedDeltaTime, const Substeps& substeps, const SolverConstants& solverConstants,
     const bool useBias)
 {
-    for (auto [ent1, mass1, inertia1, rotation1, correction1, velocity1, angVelocity1, constraint, ent2, mass2,
+    for (auto [ent1, mass1, inertia1, rotation1, correction1, velocity1, angVelocity1, constraints, ent2, mass2,
                inertia2, rotation2, correction2, velocity2, angVelocity2] : query)
     {
-
-        float subDeltaTime = fixedDeltaTime.value / (float)substeps.value;
-
-        glm::vec3 v1 = velocity1.vec;
-        glm::vec3 v2 = velocity2.vec;
-
-        glm::vec3 w1 = angVelocity1.vec;
-        glm::vec3 w2 = angVelocity2.vec;
-
-        // Separate bodies
-        for (PenetrationConstraintPointData& contactPoint : constraint.points)
+        for (auto constraint : constraints.penConstraints)
         {
-            glm::vec3 r1 = rotation1.quat * contactPoint.localAnchor1;
-            glm::vec3 r2 = rotation2.quat * contactPoint.localAnchor2;
+            float subDeltaTime = fixedDeltaTime.value / (float)substeps.value;
 
-            glm::vec3 deltaSeparation = correction2.position + r2 - correction1.position - r1;
-            if (ent1 != constraint.entity)
+            glm::vec3 v1 = velocity1.vec;
+            glm::vec3 v2 = velocity2.vec;
+
+            glm::vec3 w1 = angVelocity1.vec;
+            glm::vec3 w2 = angVelocity2.vec;
+
+            // Separate bodies
+            for (PenetrationConstraintPointData& contactPoint : constraint.points)
             {
-                deltaSeparation *= -1.0F;
+                glm::vec3 r1 = rotation1.quat * contactPoint.localAnchor1;
+                glm::vec3 r2 = rotation2.quat * contactPoint.localAnchor2;
+
+                glm::vec3 deltaSeparation = correction2.position + r2 - correction1.position - r1;
+                if (ent1 != constraints.entity)
+                {
+                    deltaSeparation *= -1.0F;
+                }
+
+                float separation = glm::dot(deltaSeparation, constraint.normal) + contactPoint.initialSeparation;
+
+                /// TODO: check correctness of bias
+                float bias = 0.0F;
+                float massScale = 1.0F;
+                float impulseScale = 0.0F;
+                if (separation > 0.0F)
+                {
+                    bias = separation * (1.0F / subDeltaTime);
+                }
+                else if (useBias)
+                {
+                    bias = glm::max(constraint.biasCoefficient * separation, solverConstants.maxBias);
+                    massScale = constraint.massCoefficient;
+                    impulseScale = constraint.impulseCoefficient;
+                }
+
+                // Relative velocity at contact
+                glm::vec3 vr1 = v1 + glm::cross(w1, r1);
+                glm::vec3 vr2 = v2 + glm::cross(w2, r2);
+                glm::vec3 vr = vr2 - vr1;
+                if (ent1 != constraints.entity)
+                {
+                    vr *= -1.0F;
+                }
+
+                float vn = glm::dot(vr, constraint.normal);
+
+                // Compute normal impulse
+                float impulse =
+                    -contactPoint.normalMass * massScale * (vn + bias) - impulseScale * contactPoint.normalImpulse;
+
+                // Clamp the accumulated impulse
+                float newImpulse = glm::max(contactPoint.normalImpulse + impulse, 0.0F);
+                impulse = newImpulse - contactPoint.normalImpulse;
+                contactPoint.normalImpulse = newImpulse;
+
+                glm::vec3 p = impulse * constraint.normal;
+                if (ent1 != constraints.entity)
+                {
+                    p *= -1.0F;
+                }
+
+                v1 -= p * mass1.inverseMass;
+                w1 -= inertia1.inverseInertia * glm::cross(r1, p);
+                v2 += p * mass2.inverseMass;
+                w2 += inertia2.inverseInertia * glm::cross(r2, p);
             }
 
-            float separation = glm::dot(deltaSeparation, constraint.normal) + contactPoint.initialSeparation;
-
-            /// TODO: check correctness of bias
-            float bias = 0.0F;
-            float massScale = 1.0F;
-            float impulseScale = 0.0F;
-            if (separation > 0.0F)
+            glm::vec3 tangent1;
+            glm::vec3 tangent2;
+            if (ent1 != constraints.entity)
             {
-                bias = separation * (1.0F / subDeltaTime);
+                getTangents(v2, v1, constraint.normal, tangent1, tangent2, solverConstants);
             }
-            else if (useBias)
+            else
             {
-                bias = glm::max(constraint.biasCoefficient * separation, solverConstants.maxBias);
-                massScale = constraint.massCoefficient;
-                impulseScale = constraint.impulseCoefficient;
+                getTangents(v1, v2, constraint.normal, tangent1, tangent2, solverConstants);
             }
 
-            // Relative velocity at contact
-            glm::vec3 vr1 = v1 + glm::cross(w1, r1);
-            glm::vec3 vr2 = v2 + glm::cross(w2, r2);
-            glm::vec3 vr = vr2 - vr1;
-            if (ent1 != constraint.entity)
+            // Friction
+            for (PenetrationConstraintPointData& contactPoint : constraint.points)
             {
-                vr *= -1.0F;
+                glm::vec3 r1 = contactPoint.fixedAnchor1;
+                glm::vec3 r2 = contactPoint.fixedAnchor2;
+
+                // Relative velocity at contact
+                glm::vec3 vr1 = v1 + glm::cross(w1, r1);
+                glm::vec3 vr2 = v2 + glm::cross(w2, r2);
+                glm::vec3 vr = vr2 - vr1;
+                if (ent1 != constraints.entity)
+                {
+                    vr *= -1.0F;
+                }
+
+                float vn1 = glm::dot(vr, tangent1);
+                float vn2 = glm::dot(vr, tangent2);
+
+                // Compute friction force
+                float impulse1 = -contactPoint.frictionMass1 * vn1;
+                float impulse2 = -contactPoint.frictionMass2 * vn2;
+
+                // Clamp the accumulated force
+                float maxFriction = constraint.friction * contactPoint.normalImpulse;
+                float newImpulse1 = glm::clamp(contactPoint.frictionImpulse1 + impulse1, -maxFriction, maxFriction);
+                float newImpulse2 = glm::clamp(contactPoint.frictionImpulse2 + impulse2, -maxFriction, maxFriction);
+                impulse1 = newImpulse1 - contactPoint.frictionImpulse1;
+                impulse2 = newImpulse2 - contactPoint.frictionImpulse2;
+                contactPoint.frictionImpulse1 = newImpulse1;
+                contactPoint.frictionImpulse2 = newImpulse2;
+
+                // Apply contact impulse
+                glm::vec3 p = impulse1 * tangent1 + impulse2 * tangent2;
+                if (ent1 != constraints.entity)
+                {
+                    p *= -1.0F;
+                }
+
+                v1 -= p * mass1.inverseMass;
+                w1 -= inertia1.inverseInertia * glm::cross(r1, p);
+                v2 += p * mass2.inverseMass;
+                w2 += inertia2.inverseInertia * glm::cross(r2, p);
             }
-
-            float vn = glm::dot(vr, constraint.normal);
-
-            // Compute normal impulse
-            float impulse =
-                -contactPoint.normalMass * massScale * (vn + bias) - impulseScale * contactPoint.normalImpulse;
-
-            // Clamp the accumulated impulse
-            float newImpulse = glm::max(contactPoint.normalImpulse + impulse, 0.0F);
-            impulse = newImpulse - contactPoint.normalImpulse;
-            contactPoint.normalImpulse = newImpulse;
-
-            glm::vec3 p = impulse * constraint.normal;
-            if (ent1 != constraint.entity)
-            {
-                p *= -1.0F;
-            }
-
-            v1 -= p * mass1.inverseMass;
-            w1 -= inertia1.inverseInertia * glm::cross(r1, p);
-            v2 += p * mass2.inverseMass;
-            w2 += inertia2.inverseInertia * glm::cross(r2, p);
+            velocity1.vec = v1;
+            angVelocity1.vec = w1;
+            velocity2.vec = v2;
+            angVelocity2.vec = w2;
         }
-
-        glm::vec3 tangent1;
-        glm::vec3 tangent2;
-        if (ent1 != constraint.entity)
-        {
-            getTangents(v2, v1, constraint.normal, tangent1, tangent2, solverConstants);
-        }
-        else
-        {
-            getTangents(v1, v2, constraint.normal, tangent1, tangent2, solverConstants);
-        }
-
-        // Friction
-        for (PenetrationConstraintPointData& contactPoint : constraint.points)
-        {
-            glm::vec3 r1 = contactPoint.fixedAnchor1;
-            glm::vec3 r2 = contactPoint.fixedAnchor2;
-
-            // Relative velocity at contact
-            glm::vec3 vr1 = v1 + glm::cross(w1, r1);
-            glm::vec3 vr2 = v2 + glm::cross(w2, r2);
-            glm::vec3 vr = vr2 - vr1;
-            if (ent1 != constraint.entity)
-            {
-                vr *= -1.0F;
-            }
-
-            float vn1 = glm::dot(vr, tangent1);
-            float vn2 = glm::dot(vr, tangent2);
-
-            // Compute friction force
-            float impulse1 = -contactPoint.frictionMass1 * vn1;
-            float impulse2 = -contactPoint.frictionMass2 * vn2;
-
-            // Clamp the accumulated force
-            float maxFriction = constraint.friction * contactPoint.normalImpulse;
-            float newImpulse1 = glm::clamp(contactPoint.frictionImpulse1 + impulse1, -maxFriction, maxFriction);
-            float newImpulse2 = glm::clamp(contactPoint.frictionImpulse2 + impulse2, -maxFriction, maxFriction);
-            impulse1 = newImpulse1 - contactPoint.frictionImpulse1;
-            impulse2 = newImpulse2 - contactPoint.frictionImpulse2;
-            contactPoint.frictionImpulse1 = newImpulse1;
-            contactPoint.frictionImpulse2 = newImpulse2;
-
-            // Apply contact impulse
-            glm::vec3 p = impulse1 * tangent1 + impulse2 * tangent2;
-            if (ent1 != constraint.entity)
-            {
-                p *= -1.0F;
-            }
-
-            v1 -= p * mass1.inverseMass;
-            w1 -= inertia1.inverseInertia * glm::cross(r1, p);
-            v2 += p * mass2.inverseMass;
-            w2 += inertia2.inverseInertia * glm::cross(r2, p);
-        }
-
-        velocity1.vec = v1;
-        angVelocity1.vec = w1;
-        velocity2.vec = v2;
-        angVelocity2.vec = w2;
     }
 }
 
@@ -229,7 +231,7 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
     cubos.depends(physicsPlugin);
     cubos.depends(physicsSolverPlugin);
 
-    cubos.relation<PenetrationConstraint>();
+    cubos.relation<PenetrationConstraints>();
 
     cubos.tag(addPenetrationConstraintTag);
     cubos.tag(penetrationConstraintWarmStartTag);
@@ -244,11 +246,11 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
         .before(penetrationConstraintSolveTag)
         .tagged(fixedSubstepTag)
         .call([](Query<Entity, const Mass&, const Inertia&, const Rotation&, AccumulatedCorrection&, Velocity&,
-                       AngularVelocity&, PenetrationConstraint&, Entity, const Mass&, const Inertia&, const Rotation&,
+                       AngularVelocity&, PenetrationConstraints&, Entity, const Mass&, const Inertia&, const Rotation&,
                        AccumulatedCorrection&, Velocity&, AngularVelocity&>
                      query,
                  const SolverConstants& solverConstants) {
-            for (auto [ent1, mass1, inertia1, rotation1, correction1, velocity1, angVelocity1, constraint, ent2, mass2,
+            for (auto [ent1, mass1, inertia1, rotation1, correction1, velocity1, angVelocity1, constraints, ent2, mass2,
                        inertia2, rotation2, correction2, velocity2, angVelocity2] : query)
             {
                 glm::vec3 v1 = velocity1.vec;
@@ -259,38 +261,42 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
 
                 glm::vec3 tangent1;
                 glm::vec3 tangent2;
-                if (ent1 != constraint.entity)
-                {
-                    getTangents(v2, v1, constraint.normal, tangent1, tangent2, solverConstants);
-                }
-                else
-                {
-                    getTangents(v1, v2, constraint.normal, tangent1, tangent2, solverConstants);
-                }
 
-                for (PenetrationConstraintPointData& contactPoint : constraint.points)
+                for (auto& constraint : constraints.penConstraints)
                 {
-                    glm::vec3 r1 = contactPoint.fixedAnchor1;
-                    glm::vec3 r2 = contactPoint.fixedAnchor2;
-
-                    glm::vec3 p =
-                        solverConstants.warmStartCoefficient * (contactPoint.normalImpulse * constraint.normal) +
-                        (contactPoint.frictionImpulse1 * tangent1) + (contactPoint.frictionImpulse2 * tangent2);
-                    if (ent1 != constraint.entity)
+                    if (ent1 != constraints.entity)
                     {
-                        p *= -1.0F;
+                        getTangents(v2, v1, constraint.normal, tangent1, tangent2, solverConstants);
+                    }
+                    else
+                    {
+                        getTangents(v1, v2, constraint.normal, tangent1, tangent2, solverConstants);
                     }
 
-                    v1 -= p * mass1.inverseMass;
-                    w1 -= inertia1.inverseInertia * glm::cross(r1, p);
-                    v2 += p * mass2.inverseMass;
-                    w2 += inertia2.inverseInertia * glm::cross(r2, p);
-                }
+                    for (PenetrationConstraintPointData& contactPoint : constraint.points)
+                    {
+                        glm::vec3 r1 = contactPoint.fixedAnchor1;
+                        glm::vec3 r2 = contactPoint.fixedAnchor2;
 
-                velocity1.vec = v1;
-                angVelocity1.vec = w1;
-                velocity2.vec = v2;
-                angVelocity2.vec = w2;
+                        glm::vec3 p =
+                            solverConstants.warmStartCoefficient * (contactPoint.normalImpulse * constraint.normal) +
+                            (contactPoint.frictionImpulse1 * tangent1) + (contactPoint.frictionImpulse2 * tangent2);
+                        if (ent1 != constraints.entity)
+                        {
+                            p *= -1.0F;
+                        }
+
+                        v1 -= p * mass1.inverseMass;
+                        w1 -= inertia1.inverseInertia * glm::cross(r1, p);
+                        v2 += p * mass2.inverseMass;
+                        w2 += inertia2.inverseInertia * glm::cross(r2, p);
+                    }
+
+                    velocity1.vec = v1;
+                    angVelocity1.vec = w1;
+                    velocity2.vec = v2;
+                    angVelocity2.vec = w2;
+                }
             }
         });
 
@@ -298,7 +304,7 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
         .tagged(penetrationConstraintSolveTag)
         .tagged(physicsSolveContactTag)
         .call([](Query<Entity, const Mass&, const Inertia&, const Rotation&, AccumulatedCorrection&, Velocity&,
-                       AngularVelocity&, PenetrationConstraint&, Entity, const Mass&, const Inertia&, const Rotation&,
+                       AngularVelocity&, PenetrationConstraints&, Entity, const Mass&, const Inertia&, const Rotation&,
                        AccumulatedCorrection&, Velocity&, AngularVelocity&>
                      query,
                  const FixedDeltaTime& fixedDeltaTime, const Substeps& substeps,
@@ -310,7 +316,7 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
         .tagged(penetrationConstraintSolveRelaxTag)
         .tagged(physicsSolveRelaxContactTag)
         .call([](Query<Entity, const Mass&, const Inertia&, const Rotation&, AccumulatedCorrection&, Velocity&,
-                       AngularVelocity&, PenetrationConstraint&, Entity, const Mass&, const Inertia&, const Rotation&,
+                       AngularVelocity&, PenetrationConstraints&, Entity, const Mass&, const Inertia&, const Rotation&,
                        AccumulatedCorrection&, Velocity&, AngularVelocity&>
                      query,
                  const FixedDeltaTime& fixedDeltaTime, const Substeps& substeps,
@@ -324,65 +330,68 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
         .before(physicsFinalizePositionTag)
         .tagged(fixedStepTag)
         .call([](Query<Entity, const Mass&, const Inertia&, AccumulatedCorrection&, Velocity&, AngularVelocity&,
-                       PenetrationConstraint&, Entity, const Mass&, const Inertia&, AccumulatedCorrection&, Velocity&,
+                       PenetrationConstraints&, Entity, const Mass&, const Inertia&, AccumulatedCorrection&, Velocity&,
                        AngularVelocity&>
                      query,
                  const SolverConstants& solverConstants) {
-            for (auto [ent1, mass1, inertia1, correction1, velocity1, angVelocity1, constraint, ent2, mass2, inertia2,
+            for (auto [ent1, mass1, inertia1, correction1, velocity1, angVelocity1, constraints, ent2, mass2, inertia2,
                        correction2, velocity2, angVelocity2] : query)
             {
-                if (constraint.restitution == solverConstants.minRestitution)
+                for (auto& constraint : constraints.penConstraints)
                 {
-                    continue;
-                }
-
-                glm::vec3 v1 = velocity1.vec;
-                glm::vec3 v2 = velocity2.vec;
-                glm::vec3 w1 = angVelocity1.vec;
-                glm::vec3 w2 = angVelocity2.vec;
-
-                for (auto point : constraint.points)
-                {
-                    if (point.normalSpeed > solverConstants.minNormalSpeed ||
-                        point.normalImpulse == solverConstants.minNormalImpulse)
+                    if (constraint.restitution == solverConstants.minRestitution)
                     {
                         continue;
                     }
 
-                    glm::vec3 r1 = point.fixedAnchor1;
-                    glm::vec3 r2 = point.fixedAnchor2;
+                    glm::vec3 v1 = velocity1.vec;
+                    glm::vec3 v2 = velocity2.vec;
+                    glm::vec3 w1 = angVelocity1.vec;
+                    glm::vec3 w2 = angVelocity2.vec;
 
-                    // Relative velocity at contact
-                    glm::vec3 vr1 = v1 + glm::cross(w1, r1);
-                    glm::vec3 vr2 = v2 + glm::cross(w2, r2);
-                    glm::vec3 vr = vr2 - vr1;
-                    if (ent1 != constraint.entity)
+                    for (auto point : constraint.points)
                     {
-                        vr *= -1.0F;
+                        if (point.normalSpeed > solverConstants.minNormalSpeed ||
+                            point.normalImpulse == solverConstants.minNormalImpulse)
+                        {
+                            continue;
+                        }
+
+                        glm::vec3 r1 = point.fixedAnchor1;
+                        glm::vec3 r2 = point.fixedAnchor2;
+
+                        // Relative velocity at contact
+                        glm::vec3 vr1 = v1 + glm::cross(w1, r1);
+                        glm::vec3 vr2 = v2 + glm::cross(w2, r2);
+                        glm::vec3 vr = vr2 - vr1;
+                        if (ent1 != constraints.entity)
+                        {
+                            vr *= -1.0F;
+                        }
+
+                        float vn = glm::dot(vr, constraint.normal);
+
+                        // compute normal impulse
+                        float impulse = -point.normalMass * (vn + constraint.restitution * point.normalSpeed);
+
+                        // Clamp the accumulated impulse
+                        float newImpulse = glm::max(point.normalImpulse + impulse, 0.0F);
+                        impulse = newImpulse - point.normalImpulse;
+                        point.normalImpulse = newImpulse;
+
+                        // Apply impulse
+                        glm::vec3 p = constraint.normal * impulse;
+                        v1 -= p * mass1.inverseMass;
+                        w1 -= inertia1.inverseInertia * glm::cross(r1, p);
+                        v2 += p * mass2.inverseMass;
+                        w2 += inertia2.inverseInertia * glm::cross(r2, p);
                     }
 
-                    float vn = glm::dot(vr, constraint.normal);
-
-                    // compute normal impulse
-                    float impulse = -point.normalMass * (vn + constraint.restitution * point.normalSpeed);
-
-                    // Clamp the accumulated impulse
-                    float newImpulse = glm::max(point.normalImpulse + impulse, 0.0F);
-                    impulse = newImpulse - point.normalImpulse;
-                    point.normalImpulse = newImpulse;
-
-                    // Apply impulse
-                    glm::vec3 p = constraint.normal * impulse;
-                    v1 -= p * mass1.inverseMass;
-                    w1 -= inertia1.inverseInertia * glm::cross(r1, p);
-                    v2 += p * mass2.inverseMass;
-                    w2 += inertia2.inverseInertia * glm::cross(r2, p);
+                    velocity1.vec = v1;
+                    angVelocity1.vec = w1;
+                    velocity2.vec = v2;
+                    angVelocity2.vec = w2;
                 }
-
-                velocity1.vec = v1;
-                angVelocity1.vec = w1;
-                velocity2.vec = v2;
-                angVelocity2.vec = w2;
             }
         });
 
@@ -391,7 +400,7 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
         .tagged(physicsPrepareSolveTag)
         .call([](Commands cmds,
                  Query<Entity, const Mass&, const Inertia&, const CenterOfMass&, const Rotation&, const Velocity&,
-                       const AngularVelocity&, const PhysicsMaterial&, const ContactManifold&, Entity, const Mass&,
+                       const AngularVelocity&, const PhysicsMaterial&, const CollidingWith&, Entity, const Mass&,
                        const Inertia&, const CenterOfMass&, const Rotation&, const Velocity&, const AngularVelocity&,
                        const PhysicsMaterial&>
                      query,
@@ -400,129 +409,142 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
             float subDeltaTime = fixedDeltaTime.value / (float)substeps.value;
             float contactHertz = glm::min(solverConstants.minContactHertz, 0.25F * (1.0F / subDeltaTime));
 
-            for (auto [ent1, mass1, inertia1, centerOfMass1, rotation1, velocity1, angVelocity1, material1, manifold,
-                       ent2, mass2, inertia2, centerOfMass2, rotation2, velocity2, angVelocity2, material2] : query)
+            for (auto [ent1, mass1, inertia1, centerOfMass1, rotation1, velocity1, angVelocity1, material1,
+                       collidingWith, ent2, mass2, inertia2, centerOfMass2, rotation2, velocity2, angVelocity2,
+                       material2] : query)
             {
-                glm::vec3 tangent1;
-                glm::vec3 tangent2;
-                if (ent1 != manifold.entity)
+                std::vector<PenetrationConstraint> penConstraints;
+                for (auto manifold : collidingWith.manifolds)
                 {
-                    getTangents(velocity2.vec, velocity1.vec, manifold.normal, tangent1, tangent2, solverConstants);
-                }
-                else
-                {
-                    getTangents(velocity1.vec, velocity2.vec, manifold.normal, tangent1, tangent2, solverConstants);
-                }
-
-                std::vector<PenetrationConstraintPointData> points;
-                for (auto point : manifold.points)
-                {
-                    auto pointData = PenetrationConstraintPointData{};
-
-                    pointData.normalImpulse = point.normalImpulse;
-                    pointData.frictionImpulse1 = point.frictionImpulse1;
-                    pointData.frictionImpulse2 = point.frictionImpulse2;
-
-                    pointData.localAnchor1 = point.localOn1 - centerOfMass1.vec;
-                    pointData.localAnchor2 = point.localOn2 - centerOfMass2.vec;
-
-                    glm::vec3 r1 = rotation1.quat * pointData.localAnchor1;
-                    glm::vec3 r2 = rotation2.quat * pointData.localAnchor2;
-
-                    pointData.fixedAnchor1 = r1;
-                    pointData.fixedAnchor2 = r2;
-
-                    pointData.initialSeparation = -point.penetration - glm::dot(r2 - r1, manifold.normal);
-
-                    // Relative velocity at contact
-                    glm::vec3 vr1 = velocity1.vec + glm::cross(angVelocity1.vec, r1);
-                    glm::vec3 vr2 = velocity2.vec + glm::cross(angVelocity2.vec, r2);
-                    glm::vec3 vr = vr2 - vr1;
-                    if (ent1 != manifold.entity)
+                    glm::vec3 tangent1;
+                    glm::vec3 tangent2;
+                    if (ent1 != collidingWith.entity)
                     {
-                        vr *= -1.0F;
+                        getTangents(velocity2.vec, velocity1.vec, manifold.normal, tangent1, tangent2, solverConstants);
+                    }
+                    else
+                    {
+                        getTangents(velocity1.vec, velocity2.vec, manifold.normal, tangent1, tangent2, solverConstants);
                     }
 
-                    pointData.normalSpeed = glm::dot(vr, manifold.normal);
+                    std::vector<PenetrationConstraintPointData> points;
+                    for (auto point : manifold.points)
+                    {
+                        auto pointData = PenetrationConstraintPointData{};
 
-                    // normal mass
-                    glm::vec3 rn1 = glm::cross(r1, manifold.normal);
-                    glm::vec3 rn2 = glm::cross(r2, manifold.normal);
-                    float kNormal = mass1.inverseMass + mass2.inverseMass +
-                                    glm::dot(inertia1.inverseInertia * rn1, rn1) +
-                                    glm::dot(inertia2.inverseInertia * rn2, rn2);
-                    pointData.normalMass = kNormal > solverConstants.minKNormal ? 1.0F / kNormal : 0.0F;
+                        /// TODO: when we have warm-start change this
+                        pointData.normalImpulse = 0.0F;
+                        pointData.frictionImpulse1 = 0.0F;
+                        pointData.frictionImpulse2 = 0.0F;
 
-                    // friction mass
-                    glm::vec3 rt11 = glm::cross(r1, tangent1);
-                    glm::vec3 rt12 = glm::cross(r2, tangent1);
-                    glm::vec3 rt21 = glm::cross(r1, tangent2);
-                    glm::vec3 rt22 = glm::cross(r2, tangent2);
+                        pointData.localAnchor1 = point.localOn1 - centerOfMass1.vec;
+                        pointData.localAnchor2 = point.localOn2 - centerOfMass2.vec;
 
-                    // Multiply by the inverse inertia early to reuse the values
-                    glm::vec3 i1Rt11 = inertia1.inverseInertia * rt11;
-                    glm::vec3 i2Rt12 = inertia2.inverseInertia * rt12;
-                    glm::vec3 i1Rt21 = inertia1.inverseInertia * rt21;
-                    glm::vec3 i2Rt22 = inertia2.inverseInertia * rt22;
+                        glm::vec3 r1 = rotation1.quat * pointData.localAnchor1;
+                        glm::vec3 r2 = rotation2.quat * pointData.localAnchor2;
 
-                    float kFriction1 =
-                        mass1.inverseMass + mass2.inverseMass + glm::dot(i1Rt11, rt11) + glm::dot(i2Rt12, rt12);
-                    float kFriction2 =
-                        mass1.inverseMass + mass2.inverseMass + glm::dot(i1Rt21, rt21) + glm::dot(i2Rt22, rt22);
+                        pointData.fixedAnchor1 = r1;
+                        pointData.fixedAnchor2 = r2;
 
-                    /// TODO: these could be an array in the point
-                    pointData.frictionMass1 = kFriction1 > solverConstants.minKFriction ? 1.0F / kFriction1 : 0.0F;
-                    pointData.frictionMass2 = kFriction2 > solverConstants.minKFriction ? 1.0F / kFriction2 : 0.0F;
+                        pointData.initialSeparation = -point.penetration - glm::dot(r2 - r1, manifold.normal);
 
-                    points.push_back(pointData);
+                        // Relative velocity at contact
+                        glm::vec3 vr1 = velocity1.vec + glm::cross(angVelocity1.vec, r1);
+                        glm::vec3 vr2 = velocity2.vec + glm::cross(angVelocity2.vec, r2);
+                        glm::vec3 vr = vr2 - vr1;
+                        if (ent1 != collidingWith.entity)
+                        {
+                            vr *= -1.0F;
+                        }
+
+                        pointData.normalSpeed = glm::dot(vr, manifold.normal);
+
+                        // normal mass
+                        glm::vec3 rn1 = glm::cross(r1, manifold.normal);
+                        glm::vec3 rn2 = glm::cross(r2, manifold.normal);
+                        float kNormal = mass1.inverseMass + mass2.inverseMass +
+                                        glm::dot(inertia1.inverseInertia * rn1, rn1) +
+                                        glm::dot(inertia2.inverseInertia * rn2, rn2);
+                        pointData.normalMass = kNormal > solverConstants.minKNormal ? 1.0F / kNormal : 0.0F;
+
+                        // friction mass
+                        glm::vec3 rt11 = glm::cross(r1, tangent1);
+                        glm::vec3 rt12 = glm::cross(r2, tangent1);
+                        glm::vec3 rt21 = glm::cross(r1, tangent2);
+                        glm::vec3 rt22 = glm::cross(r2, tangent2);
+
+                        // Multiply by the inverse inertia early to reuse the values
+                        glm::vec3 i1Rt11 = inertia1.inverseInertia * rt11;
+                        glm::vec3 i2Rt12 = inertia2.inverseInertia * rt12;
+                        glm::vec3 i1Rt21 = inertia1.inverseInertia * rt21;
+                        glm::vec3 i2Rt22 = inertia2.inverseInertia * rt22;
+
+                        float kFriction1 =
+                            mass1.inverseMass + mass2.inverseMass + glm::dot(i1Rt11, rt11) + glm::dot(i2Rt12, rt12);
+                        float kFriction2 =
+                            mass1.inverseMass + mass2.inverseMass + glm::dot(i1Rt21, rt21) + glm::dot(i2Rt22, rt22);
+
+                        /// TODO: these could be an array in the point
+                        pointData.frictionMass1 = kFriction1 > solverConstants.minKFriction ? 1.0F / kFriction1 : 0.0F;
+                        pointData.frictionMass2 = kFriction2 > solverConstants.minKFriction ? 1.0F / kFriction2 : 0.0F;
+
+                        points.push_back(pointData);
+                    }
+
+                    // determine friction
+                    float friction = mixValues(material1.friction, material2.friction,
+                                               getMixProperty(material1.frictionMix, material2.frictionMix));
+
+                    // determine restitution
+                    float restitution = mixValues(material1.bounciness, material2.bounciness,
+                                                  getMixProperty(material1.bouncinessMix, material2.bouncinessMix));
+
+                    // Soft contact
+                    const float zeta = 10.0F;
+                    float omega = 2.0F * glm::pi<float>() * contactHertz;
+                    float c = subDeltaTime * omega * (2.0F * zeta + subDeltaTime * omega);
+
+                    float biasCoefficient = omega / (2.0F * zeta + subDeltaTime * omega);
+                    float impulseCoefficient = 1.0F / (1.0F + c);
+                    float massCoefficient = c * impulseCoefficient;
+
+                    penConstraints.push_back(PenetrationConstraint{.normal = manifold.normal,
+                                                                   .friction = friction,
+                                                                   .restitution = restitution,
+                                                                   .points = points,
+                                                                   .biasCoefficient = biasCoefficient,
+                                                                   .impulseCoefficient = impulseCoefficient,
+                                                                   .massCoefficient = massCoefficient});
                 }
-
-                // determine friction
-                float friction = mixValues(material1.friction, material2.friction,
-                                           getMixProperty(material1.frictionMix, material2.frictionMix));
-
-                // determine restitution
-                float restitution = mixValues(material1.bounciness, material2.bounciness,
-                                              getMixProperty(material1.bouncinessMix, material2.bouncinessMix));
-
-                // Soft contact
-                const float zeta = 10.0F;
-                float omega = 2.0F * glm::pi<float>() * contactHertz;
-                float c = subDeltaTime * omega * (2.0F * zeta + subDeltaTime * omega);
-
-                float biasCoefficient = omega / (2.0F * zeta + subDeltaTime * omega);
-                float impulseCoefficient = 1.0F / (1.0F + c);
-                float massCoefficient = c * impulseCoefficient;
-
                 cmds.relate(ent1, ent2,
-                            PenetrationConstraint{.entity = manifold.entity,
-                                                  .normal = manifold.normal,
-                                                  .friction = friction,
-                                                  .restitution = restitution,
-                                                  .points = points,
-                                                  .biasCoefficient = biasCoefficient,
-                                                  .impulseCoefficient = impulseCoefficient,
-                                                  .massCoefficient = massCoefficient});
+                            PenetrationConstraints{.entity = collidingWith.entity, .penConstraints = penConstraints});
             }
         });
-
+    
     cubos.system("store impulses and clean penetration constraint pairs")
         .tagged(physicsFinalizePositionTag)
-        .call([](Commands cmds, Query<Entity, ContactManifold&, Entity> cQuery,
-                 Query<Entity, PenetrationConstraint&, Entity> pQuery) {
-            for (auto [entity, constraint, other] : cQuery)
+        .call([](Commands cmds, Query<Entity, CollidingWith&, Entity> cQuery,
+                 Query<Entity, PenetrationConstraints&, Entity> pQuery) {
+            for (auto [entity, collidingWith, other] : cQuery)
             {
                 if (auto match = pQuery.pin(0, entity).pin(1, other).first())
                 {
-                    auto [entity, manifold, other] = *match;
-                    for (size_t i = 0; i < manifold.points.size(); i++)
+                    auto [entity, constraints, other] = *match;
+
+                    for (size_t i = 0; i < collidingWith.manifolds.size(); i++)
                     {
-                        manifold.points[i].normalImpulse = constraint.points[i].normalImpulse;
-                        manifold.points[i].frictionImpulse1 = constraint.points[i].frictionImpulse1;
-                        manifold.points[i].frictionImpulse2 = constraint.points[i].frictionImpulse2;
+                        for (size_t j = 0; j < collidingWith.manifolds[i].points.size(); j++)
+                        {
+                            collidingWith.manifolds[i].points[j].normalImpulse =
+                                constraints.penConstraints[i].points[j].normalImpulse;
+                            collidingWith.manifolds[i].points[j].frictionImpulse1 =
+                                constraints.penConstraints[i].points[j].frictionImpulse1;
+                            collidingWith.manifolds[i].points[j].frictionImpulse2 =
+                                constraints.penConstraints[i].points[j].frictionImpulse2;
+                        }
                     }
                 }
-                cmds.unrelate<PenetrationConstraint>(entity, other);
+                cmds.unrelate<PenetrationConstraints>(entity, other);
             }
         });
 }

--- a/engine/src/physics/solver/penetration_constraint/plugin.cpp
+++ b/engine/src/physics/solver/penetration_constraint/plugin.cpp
@@ -87,19 +87,19 @@ static void solvePenetrationConstraint(
     const FixedDeltaTime& fixedDeltaTime, const Substeps& substeps, const SolverConstants& solverConstants,
     const bool useBias)
 {
+    float subDeltaTime = fixedDeltaTime.value / (float)substeps.value;
+
     for (auto [ent1, mass1, inertia1, rotation1, correction1, velocity1, angVelocity1, constraints, ent2, mass2,
                inertia2, rotation2, correction2, velocity2, angVelocity2] : query)
     {
-        for (auto constraint : constraints.penConstraints)
+        glm::vec3 v1 = velocity1.vec;
+        glm::vec3 v2 = velocity2.vec;
+
+        glm::vec3 w1 = angVelocity1.vec;
+        glm::vec3 w2 = angVelocity2.vec;
+
+        for (auto& constraint : constraints.penConstraints)
         {
-            float subDeltaTime = fixedDeltaTime.value / (float)substeps.value;
-
-            glm::vec3 v1 = velocity1.vec;
-            glm::vec3 v2 = velocity2.vec;
-
-            glm::vec3 w1 = angVelocity1.vec;
-            glm::vec3 w2 = angVelocity2.vec;
-
             // Separate bodies
             for (PenetrationConstraintPointData& contactPoint : constraint.points)
             {
@@ -215,11 +215,11 @@ static void solvePenetrationConstraint(
                 v2 += p * mass2.inverseMass;
                 w2 += inertia2.inverseInertia * glm::cross(r2, p);
             }
-            velocity1.vec = v1;
-            angVelocity1.vec = w1;
-            velocity2.vec = v2;
-            angVelocity2.vec = w2;
         }
+        velocity1.vec = v1;
+        angVelocity1.vec = w1;
+        velocity2.vec = v2;
+        angVelocity2.vec = w2;
     }
 }
 
@@ -337,7 +337,7 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
             for (auto [ent1, mass1, inertia1, correction1, velocity1, angVelocity1, constraints, ent2, mass2, inertia2,
                        correction2, velocity2, angVelocity2] : query)
             {
-                for (auto& constraint : constraints.penConstraints)
+                for (const auto& constraint : constraints.penConstraints)
                 {
                     if (constraint.restitution == solverConstants.minRestitution)
                     {
@@ -414,7 +414,7 @@ void cubos::engine::penetrationConstraintPlugin(Cubos& cubos)
                        material2] : query)
             {
                 std::vector<PenetrationConstraint> penConstraints;
-                for (auto manifold : collidingWith.manifolds)
+                for (const auto& manifold : collidingWith.manifolds)
                 {
                     glm::vec3 tangent1;
                     glm::vec3 tangent2;


### PR DESCRIPTION
# Description

Remove everything from CollidingWith except entity, add a vector of manifolds.
ContactManifold is no longer a relation.
Same thing for PenetrationConstraint, add a PenetrationtConstraints relation that holds a vector of PenetrationConstraint.

Change narrow phase systems to buildup the vector of manifolds in a collidingWith relation.
Change peneration constraint plugin to create the vector of PenetrationConstraint for each manifold.
Change penetraton constraint solver to buildup the effects of all constraints in PenetrationConstraints

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
