### PR TITLE
1437 change inputpressed axis etc to use stdstring_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make SSAO optional (#1396, **@tomas7770**).
 - Made the fixed step accumulator a public resource of the fixed step plugin (**@RiscadoA**).
+- Change the name parameter type in input methods like ::pressed, ::axis, etc., to use std::string_view and heterogeneous lookup in unordered_map (#1460, **@kuukitenshi**).
 
 ### Fixed
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -80,6 +80,8 @@ set(CUBOS_CORE_SOURCE
 	"src/data/des/deserializer.cpp"
 	"src/data/des/json.cpp"
 	"src/data/des/binary.cpp"
+    "src/data/transparent/string_equal.cpp"
+    "src/data/transparent/string_hash.cpp"
 
 	"src/io/window.cpp"
 	"src/io/cursor.cpp"

--- a/core/include/cubos/core/data/transparent/string_equal.hpp
+++ b/core/include/cubos/core/data/transparent/string_equal.hpp
@@ -1,0 +1,55 @@
+/// @file
+/// @brief Class @ref cubos::core::data::StringTransparentEqual.
+/// @ingroup core-data-transparent
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/api.hpp>
+#include <string>
+
+namespace cubos::core::data
+{
+    /// @brief Redefines equality function for std::string_view and std::string.
+    ///
+    /// This class is used to allow heterogeneous lookup in unordered maps and sets.
+    ///
+    /// @ingroup core-data-transparent
+    class CUBOS_CORE_API StringTransparentEqual final
+    {
+    public:
+        CUBOS_REFLECT;
+        
+        using is_transparent = void; // Tag to allow heterogeneous lookup
+
+        ~StringTransparentEqual() = default;
+        StringTransparentEqual() = default;
+
+        /// @brief Compares two string views for equality.
+        /// @param svhs The first string view.
+        /// @param svvhs The second string view.
+        /// @return True if the string views are equal, false otherwise.
+        bool operator()(std::string_view svhs, std::string_view svvhs) const;
+    
+        /// @brief Compares a string and a string view for equality.
+        /// @param shs The string.
+        /// @param svhs The string view.
+        /// @return True if the string and string view are equal, false otherwise.
+        bool operator()(const std::string& shs, std::string_view svhs) const;
+    
+        /// @brief Compares a string view and a string for equality.
+        /// @param svhs The string view.
+        /// @param shs The string.
+        /// @return True if the string view and string are equal, false otherwise.
+        bool operator()(std::string_view svhs, const std::string& shs) const;
+
+        /// @brief Compares two strings for equality.
+        /// @param shs The first string.
+        /// @param sshs The second string.
+        /// @return True if the strings are equal, false otherwise.
+        bool operator()(const std::string& shs, const std::string& sshs) const;
+
+    };
+} // namespace cubos::core::data
+
+

--- a/core/include/cubos/core/data/transparent/string_hash.hpp
+++ b/core/include/cubos/core/data/transparent/string_hash.hpp
@@ -1,0 +1,46 @@
+/// @file
+/// @brief Class @ref cubos::core::data::StringTransparentHash.
+/// @ingroup core-data-transparent
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/api.hpp>
+#include <string>
+
+namespace cubos::core::data
+{
+    /// @brief Hash function for std::string and std::string_view, implemented as a class.
+    ///
+    /// This allows using std::string_view as a key in unordered_map, while still allowing
+    /// std::string as a key.
+    ///
+    /// @ingroup core-data-transparent
+    class CUBOS_CORE_API StringTransparentHash final
+    {
+    public:
+        CUBOS_REFLECT;
+        
+        using is_transparent = void; // Tag to allow heterogeneous lookup
+
+        ~StringTransparentHash() = default;
+        StringTransparentHash() = default;
+
+        /// @brief Hash function for const char*.
+        /// @param c The string to hash.
+        /// @return The hash value.
+        std::size_t operator()(const char* c) const;
+
+        /// @brief Hash function for std::string_view.
+        /// @param sv The string view to hash.
+        /// @return The hash value.
+        std::size_t operator()(std::string_view sv) const;
+       
+        /// @brief Hash function for std::string.
+        /// @param s The string to hash.
+        /// @return The hash value.
+        std::size_t operator()(const std::string& s) const;
+    };
+} // namespace cubos::core::data
+
+

--- a/core/include/cubos/core/reflection/external/unordered_map.hpp
+++ b/core/include/cubos/core/reflection/external/unordered_map.hpp
@@ -10,9 +10,9 @@
 #include <cubos/core/reflection/traits/dictionary.hpp>
 #include <cubos/core/reflection/type.hpp>
 
-CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename K, typename V), (std::unordered_map<K, V>))
+CUBOS_REFLECT_EXTERNAL_TEMPLATE((typename K, typename V, typename H, typename E), (std::unordered_map<K, V, H, E>))
 {
-    using Map = std::unordered_map<K, V>;
+    using Map = std::unordered_map<K, V, H, E>;
 
     auto dictionaryTrait = DictionaryTrait(
         reflect<K>(), reflect<V>(),

--- a/core/src/data/transparent/string_equal.cpp
+++ b/core/src/data/transparent/string_equal.cpp
@@ -1,0 +1,32 @@
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/unordered_map.hpp>
+#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/data/transparent/string_equal.hpp>
+
+using namespace cubos::core::data;
+
+CUBOS_REFLECT_IMPL(cubos::core::data::StringTransparentEqual)
+{
+    using namespace cubos::core::reflection;
+    return Type::create("cubos::core::data::StringTransparentEqual");
+}
+
+bool StringTransparentEqual::operator()(std::string_view svhs, std::string_view svvhs) const
+{
+    return svhs == svvhs;
+}
+
+bool StringTransparentEqual::operator()(const std::string& shs, std::string_view svhs) const
+{
+    return shs == svhs;
+}
+
+bool StringTransparentEqual::operator()(std::string_view svhs, const std::string& shs) const
+{
+    return svhs == shs;
+}
+
+bool StringTransparentEqual::operator()(const std::string& shs, const std::string& sshs) const
+{
+    return shs == sshs;
+}

--- a/core/src/data/transparent/string_hash.cpp
+++ b/core/src/data/transparent/string_hash.cpp
@@ -1,0 +1,27 @@
+#include <cubos/core/reflection/external/string.hpp>
+#include <cubos/core/reflection/external/unordered_map.hpp>
+#include <cubos/core/reflection/type.hpp>
+#include <cubos/core/data/transparent/string_hash.hpp>
+
+using namespace cubos::core::data;
+
+CUBOS_REFLECT_IMPL(cubos::core::data::StringTransparentHash)
+{
+    using namespace cubos::core::reflection;
+    return Type::create("cubos::core::data::StringTransparentHash");
+}
+
+std::size_t StringTransparentHash::operator()(const char* c) const
+{
+    return std::hash<std::string_view>{}(c);
+}
+
+std::size_t StringTransparentHash::operator()(std::string_view sv) const
+{
+    return std::hash<std::string_view>{}(sv);
+}
+
+std::size_t StringTransparentHash::operator()(const std::string& s) const
+{
+    return std::hash<std::string>{}(s);
+}

--- a/engine/include/cubos/engine/input/bindings.hpp
+++ b/engine/include/cubos/engine/input/bindings.hpp
@@ -7,9 +7,13 @@
 #include <unordered_map>
 
 #include <cubos/core/reflection/reflect.hpp>
+#include <cubos/core/reflection/external/unordered_map.hpp>
+#include <cubos/core/data/transparent/string_hash.hpp>
+#include <cubos/core/data/transparent/string_equal.hpp>
 
 #include <cubos/engine/input/action.hpp>
 #include <cubos/engine/input/axis.hpp>
+
 
 namespace cubos::engine
 {
@@ -28,22 +32,22 @@ namespace cubos::engine
 
         /// @brief Gets the input actions map.
         /// @return Input actions map.
-        const std::unordered_map<std::string, InputAction>& actions() const;
+        const std::unordered_map<std::string, InputAction, core::data::StringTransparentHash, core::data::StringTransparentEqual>& actions() const;
 
         /// @brief Gets the input axes map.
         /// @return Input axes map.
-        const std::unordered_map<std::string, InputAxis>& axes() const;
+        const std::unordered_map<std::string, InputAxis, core::data::StringTransparentHash, core::data::StringTransparentEqual>& axes() const;
 
         /// @brief Gets the input actions map.
         /// @return Input actions map.
-        std::unordered_map<std::string, InputAction>& actions();
+        std::unordered_map<std::string, InputAction, core::data::StringTransparentHash, core::data::StringTransparentEqual>& actions();
 
         /// @brief Gets the input axes map.
         /// @return Input axes map.
-        std::unordered_map<std::string, InputAxis>& axes();
+        std::unordered_map<std::string, InputAxis, core::data::StringTransparentHash, core::data::StringTransparentEqual>& axes();
 
     private:
-        std::unordered_map<std::string, InputAction> mActions;
-        std::unordered_map<std::string, InputAxis> mAxes;
+        std::unordered_map<std::string, InputAction, core::data::StringTransparentHash, core::data::StringTransparentEqual> mActions;
+        std::unordered_map<std::string, InputAxis, core::data::StringTransparentHash, core::data::StringTransparentEqual> mAxes;
     };
 } // namespace cubos::engine

--- a/engine/include/cubos/engine/input/input.hpp
+++ b/engine/include/cubos/engine/input/input.hpp
@@ -68,25 +68,25 @@ namespace cubos::engine
         /// @param actionName Name of the action.
         /// @param player Player whose action state will be retrieved.
         /// @return Whether the action exists and is pressed.
-        bool pressed(const char* actionName, int player = 0) const;
+        bool pressed(std::string_view actionName, int player = 0) const;
 
         /// @brief Gets an action state for a specific player.
         /// @param actionName Name of the action.
         /// @param player Player whose action state will be retrieved.
         /// @return Whether the action exists and was just pressed.
-        bool justPressed(const char* actionName, int player = 0) const;
+        bool justPressed(std::string_view actionName, int player = 0) const;
 
         /// @brief Gets an action state for a specific player.
         /// @param actionName Name of the action.
         /// @param player Player whose action state will be retrieved.
         /// @return Whether the action exists and was just released.
-        bool justReleased(const char* actionName, int player = 0) const;
+        bool justReleased(std::string_view actionName, int player = 0) const;
 
         /// @brief Gets an axis value for a specific player.
         /// @param axisName Name of the axis.
         /// @param player Player whose axis value will be retrieved.
         /// @return Axis value if the axis exists, 0.0 otherwise.
-        float axis(const char* axisName, int player = 0) const;
+        float axis(std::string_view axisName, int player = 0) const;
 
         /// @brief Handle a key event.
         /// @param window Window that received the event.

--- a/engine/src/input/bindings.cpp
+++ b/engine/src/input/bindings.cpp
@@ -2,6 +2,8 @@
 #include <cubos/core/reflection/external/unordered_map.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
 #include <cubos/core/reflection/type.hpp>
+#include <cubos/core/data/transparent/string_hash.hpp>
+#include <cubos/core/data/transparent/string_equal.hpp>
 
 #include <cubos/engine/input/bindings.hpp>
 
@@ -14,22 +16,22 @@ CUBOS_REFLECT_IMPL(cubos::engine::InputBindings)
         .with(FieldsTrait{}.withField("actions", &InputBindings::mActions).withField("axes", &InputBindings::mAxes));
 }
 
-const std::unordered_map<std::string, InputAction>& InputBindings::actions() const
+const std::unordered_map<std::string, InputAction, cubos::core::data::StringTransparentHash, cubos::core::data::StringTransparentEqual>& InputBindings::actions() const
 {
     return mActions;
 }
 
-const std::unordered_map<std::string, InputAxis>& InputBindings::axes() const
+const std::unordered_map<std::string, InputAxis, cubos::core::data::StringTransparentHash, cubos::core::data::StringTransparentEqual>& InputBindings::axes() const
 {
     return mAxes;
 }
 
-std::unordered_map<std::string, InputAction>& InputBindings::actions()
+std::unordered_map<std::string, InputAction, cubos::core::data::StringTransparentHash, cubos::core::data::StringTransparentEqual>& InputBindings::actions()
 {
     return mActions;
 }
 
-std::unordered_map<std::string, InputAxis>& InputBindings::axes()
+std::unordered_map<std::string, InputAxis, cubos::core::data::StringTransparentHash, cubos::core::data::StringTransparentEqual>& InputBindings::axes()
 {
     return mAxes;
 }

--- a/engine/src/input/input.cpp
+++ b/engine/src/input/input.cpp
@@ -216,7 +216,7 @@ int Input::gamepadCount() const
     return static_cast<int>(mGamepadStates.size());
 }
 
-bool Input::pressed(const char* actionName, int player) const
+bool Input::pressed(std::string_view actionName, int player) const
 {
     auto pIt = mPlayerBindings.find(player);
     if (pIt == mPlayerBindings.end())
@@ -228,14 +228,14 @@ bool Input::pressed(const char* actionName, int player) const
     auto aIt = pIt->second.actions().find(actionName);
     if (aIt == pIt->second.actions().end())
     {
-        CUBOS_WARN("Action {} is not bound to any input for player {}", actionName, player);
+        CUBOS_WARN("Action {} is not bound to any input for player {}", std::string(actionName), player);
         return false;
     }
 
     return aIt->second.pressed();
 }
 
-bool Input::justPressed(const char* actionName, int player) const
+bool Input::justPressed(std::string_view actionName, int player) const
 {
     auto pIt = mPlayerBindings.find(player);
     if (pIt == mPlayerBindings.end())
@@ -247,14 +247,14 @@ bool Input::justPressed(const char* actionName, int player) const
     auto aIt = pIt->second.actions().find(actionName);
     if (aIt == pIt->second.actions().end())
     {
-        CUBOS_WARN("Action {} is not bound to any input for player {}", actionName, player);
+        CUBOS_WARN("Action {} is not bound to any input for player {}", std::string(actionName), player);
         return false;
     }
 
     return aIt->second.justPressed();
 }
 
-bool Input::justReleased(const char* actionName, int player) const
+bool Input::justReleased(std::string_view actionName, int player) const
 {
     auto pIt = mPlayerBindings.find(player);
     if (pIt == mPlayerBindings.end())
@@ -266,14 +266,14 @@ bool Input::justReleased(const char* actionName, int player) const
     auto aIt = pIt->second.actions().find(actionName);
     if (aIt == pIt->second.actions().end())
     {
-        CUBOS_WARN("Action {} is not bound to any input for player {}", actionName, player);
+        CUBOS_WARN("Action {} is not bound to any input for player {}", std::string(actionName), player);
         return false;
     }
 
     return aIt->second.justReleased();
 }
 
-float Input::axis(const char* axisName, int player) const
+float Input::axis(std::string_view axisName, int player) const
 {
     auto pIt = mPlayerBindings.find(player);
     if (pIt == mPlayerBindings.end())
@@ -285,7 +285,7 @@ float Input::axis(const char* axisName, int player) const
     auto aIt = pIt->second.axes().find(axisName);
     if (aIt == pIt->second.axes().end())
     {
-        CUBOS_WARN("Axis {} is not bound to any input for player {}", axisName, player);
+        CUBOS_WARN("Axis {} is not bound to any input for player {}", std::string(axisName), player);
         return 0.0F;
     }
 


### PR DESCRIPTION
# Description

Change the name parameter type in input methods like ::pressed, ::axis, etc., to use std::string_view for more readable usage

## Checklist

- [x] Self-review changes.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
