### PR TITLE
Add collision masks and layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Entity destruction detection to observers (#1458, **@kuukitenshi**).
+- Added CollisionGroup component to support internal collision layer overrides (#535, **@fallenatlas**).
+
+### Changed
+- Made collision layer and mask their own components (#535, **@fallenatlas**).
 
 
 ## [v0.6.0] - 2025-02-10

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -95,6 +95,8 @@ set(CUBOS_ENGINE_SOURCE
 	"src/collisions/interface/raycast.cpp"
 	"src/collisions/interface/shapes/capsule.cpp"
 	"src/collisions/interface/shapes/voxel.cpp"
+	"src/collisions/interface/collision_layers.cpp"
+	"src/collisions/interface/collision_mask.cpp"
 	"src/collisions/broad_phase/plugin.cpp"
 	"src/collisions/broad_phase/sweep_and_prune.cpp"
 	"src/collisions/broad_phase/potentially_colliding_with.cpp"

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -100,6 +100,7 @@ set(CUBOS_ENGINE_SOURCE
 	"src/collisions/broad_phase/plugin.cpp"
 	"src/collisions/broad_phase/sweep_and_prune.cpp"
 	"src/collisions/broad_phase/potentially_colliding_with.cpp"
+	"src/collisions/broad_phase/collision_group.cpp"
 	"src/collisions/narrow_phase/plugin.cpp"
 
 	"src/physics/plugin.cpp"

--- a/engine/include/cubos/engine/collisions/collider.hpp
+++ b/engine/include/cubos/engine/collisions/collider.hpp
@@ -24,17 +24,6 @@ namespace cubos::engine
         core::geom::AABB localAABB{}; ///< Local space AABB of the collider.
         core::geom::AABB worldAABB{}; ///< World space AABB of the collider.
 
-        /// @brief Layer of the collider, from 0 to 63.
-        uint64_t layer{0};
-
-        /// @brief Mask of layers which the collider can collide with.
-        ///
-        /// Set to (1 << 0) to collide only with entities of layer 0, to (1 << 0) | (1 << 1) to collide with
-        /// entities of layer 0 and 1, etc.
-        ///
-        /// By default, colliders collide with layer 0.
-        uint64_t mask{1 << 0};
-
         /// @brief Margin of the collider.
         ///
         /// When the collider shape has sharp edges, a margin is needed.

--- a/engine/include/cubos/engine/collisions/collision_layers.hpp
+++ b/engine/include/cubos/engine/collisions/collision_layers.hpp
@@ -1,0 +1,42 @@
+/// @file
+/// @brief Component @ref cubos::engine::CollisionLayers.
+/// @ingroup collisions-plugin
+
+#pragma once
+
+#include <cstdint>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component that contains the collision layers where the collider appears in.
+    /// Check also @ref CollisionMask.
+    /// @ingroup collisions-plugin
+    struct CUBOS_ENGINE_API CollisionLayers
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Layers of the collider.
+        ///
+        /// There are 32 layers, from 0 to 31. A collider can belong to any number of layers.
+        ///
+        /// Internally, the layers go from right to left, meaning, layer 0 is the least significant bit and layer 31 the
+        /// most significant bit. Any type of number can be used to manually set the layers, just make sure the binary
+        /// representation has all the bits corresponding to the wanted layers set to 1.
+        ///
+        /// By default, colliders appear only in layer 0.
+        uint32_t value = 0x00000001;
+
+        /// @brief Based on `newValue`, enables or disables the specified `layerNumber`.
+        /// @param layerNumber Layer number between 0 and 31.
+        /// @param newValue `true` enables the layer. `false` disables the layer.
+        void setLayerValue(unsigned int layerNumber, bool newValue);
+
+        /// @brief Returns whether or not the specified `layerNumber` is enabled.
+        /// @param layerNumber Layer number between 0 and 31.
+        bool getLayerValue(unsigned int layerNumber) const;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/collisions/collision_mask.hpp
+++ b/engine/include/cubos/engine/collisions/collision_mask.hpp
@@ -1,0 +1,42 @@
+/// @file
+/// @brief Component @ref cubos::engine::CollisionMask.
+/// @ingroup collisions-plugin
+
+#pragma once
+
+#include <cstdint>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component that contains the mask of layers which the collider can collide with.
+    /// Check also @ref CollisionLayers.
+    /// @ingroup collisions-plugin
+    struct CUBOS_ENGINE_API CollisionMask
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Mask of layers which the collider can collide with.
+        ///
+        /// There are 32 layers, from 0 to 31. A collider can collide with any number of layers.
+        ///
+        /// Internally, the layers go from right to left, meaning, layer 0 is the least significant bit and layer 31 the
+        /// most significant bit. Any type of number can be used to manually set the layers, just make sure the binary
+        /// representation has all the bits corresponding to the wanted layers set to 1.
+        ///
+        /// By default, colliders collide with layer 0.
+        uint32_t value = 0x00000001;
+
+        /// @brief Based on `newValue`, enables or disables the specified `layerNumber` in the mask.
+        /// @param layerNumber Layer number between 0 and 31.
+        /// @param newValue `true` enables the layer. `false` disables the layer.
+        void setLayerValue(unsigned int layerNumber, bool newValue);
+
+        /// @brief Returns whether or not the specified `layerNumber` is enabled.
+        /// @param layerNumber Layer number between 0 and 31.
+        bool getLayerValue(unsigned int layerNumber) const;
+    };
+} // namespace cubos::engine

--- a/engine/include/cubos/engine/collisions/plugin.hpp
+++ b/engine/include/cubos/engine/collisions/plugin.hpp
@@ -26,7 +26,10 @@ namespace cubos::engine
     /// ## Components
     /// - @ref BoxCollisionShape - holds the box collision shape.
     /// - @ref CapsuleCollisionShape - holds the capsule collision shape.
+    /// - @ref VoxelCollisionShape - holds the voxel collision shape.
     /// - @ref Collider - holds collider data.
+    /// - @ref CollisionLayers - holds the collision layers where the collider appears in.
+    /// - @ref CollisionMask - holds the mask of layers which the collider can collide with.
     ///
     /// ## Events
     /// - @ref CollisionEvent - (TODO) emitted when a collision occurs.

--- a/engine/include/cubos/engine/collisions/raycast.hpp
+++ b/engine/include/cubos/engine/collisions/raycast.hpp
@@ -13,6 +13,7 @@
 #include <cubos/core/geom/box.hpp>
 
 #include <cubos/engine/collisions/collider.hpp>
+#include <cubos/engine/collisions/collision_layers.hpp>
 #include <cubos/engine/collisions/shapes/box.hpp>
 #include <cubos/engine/collisions/shapes/capsule.hpp>
 #include <cubos/engine/prelude.hpp>
@@ -49,17 +50,19 @@ namespace cubos::engine
         /// @brief Describes the ray used in a raycast query.
         struct Ray
         {
-            glm::vec3 origin;                   ///< Origin of the ray.
-            glm::vec3 direction;                ///< Direction of the ray.
-            uint64_t mask = 0xFFFFFFFFFFFFFFFF; ///< Mask of collision layers to consider.
+            glm::vec3 origin;           ///< Origin of the ray.
+            glm::vec3 direction;        ///< Direction of the ray.
+            uint32_t mask = 0xFFFFFFFF; ///< Mask of collision layers to consider. By default, considers all layers.
         };
 
         /// @brief Constructs.
         /// @param boxes Query for entities with box colliders.
         /// @param capsules Query for entities with capsule colliders.
         Raycast(
-            Query<Entity, const LocalToWorld&, const Collider&, const BoxCollisionShape&> boxes,
-            Query<Entity, const LocalToWorld&, const Collider&, const CapsuleCollisionShape&, const Position&> capsules)
+            Query<Entity, const LocalToWorld&, const Collider&, const BoxCollisionShape&, const CollisionLayers&> boxes,
+            Query<Entity, const LocalToWorld&, const Collider&, const CapsuleCollisionShape&, const Position&,
+                  const CollisionLayers&>
+                capsules)
             : mBoxes{std::move(boxes)}
             , mCapsules{std::move(capsules)} {};
 
@@ -69,8 +72,10 @@ namespace cubos::engine
         Opt<Hit> fire(Ray ray);
 
     private:
-        Query<Entity, const LocalToWorld&, const Collider&, const BoxCollisionShape&> mBoxes;
-        Query<Entity, const LocalToWorld&, const Collider&, const CapsuleCollisionShape&, const Position&> mCapsules;
+        Query<Entity, const LocalToWorld&, const Collider&, const BoxCollisionShape&, const CollisionLayers&> mBoxes;
+        Query<Entity, const LocalToWorld&, const Collider&, const CapsuleCollisionShape&, const Position&,
+              const CollisionLayers&>
+            mCapsules;
     };
 } // namespace cubos::engine
 
@@ -83,10 +88,11 @@ namespace cubos::core::ecs
         static inline constexpr bool ConsumesOptions = false;
 
         SystemFetcher<Query<Entity, const cubos::engine::LocalToWorld&, const cubos::engine::Collider&,
-                            const cubos::engine::BoxCollisionShape&>>
+                            const cubos::engine::BoxCollisionShape&, const cubos::engine::CollisionLayers&>>
             boxes;
         SystemFetcher<Query<Entity, const cubos::engine::LocalToWorld&, const cubos::engine::Collider&,
-                            const cubos::engine::CapsuleCollisionShape&, const cubos::engine::Position&>>
+                            const cubos::engine::CapsuleCollisionShape&, const cubos::engine::Position&,
+                            const cubos::engine::CollisionLayers&>>
             capsules;
 
         SystemFetcher(World& world, const SystemOptions& options)

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -6,6 +6,8 @@
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/collisions/collider.hpp>
 #include <cubos/engine/collisions/colliding_with.hpp>
+#include <cubos/engine/collisions/collision_layers.hpp>
+#include <cubos/engine/collisions/collision_mask.hpp>
 #include <cubos/engine/collisions/contact_manifold.hpp>
 #include <cubos/engine/collisions/plugin.hpp>
 #include <cubos/engine/collisions/shapes/box.hpp>
@@ -117,6 +119,8 @@ int main(int argc, char** argv)
         state.a = commands.create()
                       .add(Collider{})
                       .add(BoxCollisionShape{})
+                      .add(CollisionLayers{})
+                      .add(CollisionMask{})
                       .add(LocalToWorld{})
                       .add(Position{glm::vec3{0.0F, 0.0F, -2.0F}})
                       .add(Rotation{})
@@ -127,6 +131,8 @@ int main(int argc, char** argv)
         state.b = commands.create()
                       .add(Collider{})
                       .add(BoxCollisionShape{})
+                      .add(CollisionLayers{})
+                      .add(CollisionMask{})
                       .add(LocalToWorld{})
                       .add(Position{glm::vec3{0.0F, 0.0F, 2.0F}})
                       .add(Rotation{})

--- a/engine/samples/complex_physics/assets/scenes/red_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/red_cube.cubos
@@ -37,6 +37,8 @@
           "z": 0.0
         }
       },
+      "cubos::engine::CollisionLayers": 1,
+      "cubos::engine::CollisionMask": 1,
       "cubos::engine::Force": {
       },
       "cubos::engine::Torque": {

--- a/engine/samples/complex_physics/assets/scenes/white_cube.cubos
+++ b/engine/samples/complex_physics/assets/scenes/white_cube.cubos
@@ -37,6 +37,8 @@
           "z": 0.0
         }
       },
+      "cubos::engine::CollisionLayers": 1,
+      "cubos::engine::CollisionMask": 1,
       "cubos::engine::Force": {
       },
       "cubos::engine::Torque": {

--- a/engine/samples/complex_physics/main.cpp
+++ b/engine/samples/complex_physics/main.cpp
@@ -3,6 +3,8 @@
 
 #include <cubos/engine/assets/plugin.hpp>
 #include <cubos/engine/collisions/collider.hpp>
+#include <cubos/engine/collisions/collision_layers.hpp>
+#include <cubos/engine/collisions/collision_mask.hpp>
 #include <cubos/engine/collisions/plugin.hpp>
 #include <cubos/engine/collisions/shapes/box.hpp>
 #include <cubos/engine/fixed_step/plugin.hpp>
@@ -115,6 +117,8 @@ int main(int argc, char** argv)
         cmds.create()
             .add(Collider{})
             .add(BoxCollisionShape{cubos::core::geom::Box{.halfSize = glm::vec3{20.0F, 0.5F, 20.0F}}})
+            .add(CollisionLayers{})
+            .add(CollisionMask{})
             .add(LocalToWorld{})
             .add(Position{{0.0F, 0.0F, 0.0F}})
             .add(Rotation{})

--- a/engine/src/collisions/broad_phase/collision_group.cpp
+++ b/engine/src/collisions/broad_phase/collision_group.cpp
@@ -1,0 +1,12 @@
+#include "collision_group.hpp"
+
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::CollisionGroup)
+{
+    return core::ecs::TypeBuilder<CollisionGroup>("cubos::engine::CollisionGroup")
+        .withField("groupId", &CollisionGroup::groupId)
+        .withField("isStatic", &CollisionGroup::isStatic)
+        .build();
+}

--- a/engine/src/collisions/broad_phase/collision_group.hpp
+++ b/engine/src/collisions/broad_phase/collision_group.hpp
@@ -1,0 +1,41 @@
+/// @file
+/// @brief Component @ref cubos::engine::CollisionMask.
+/// @ingroup collisions-plugin
+
+#pragma once
+
+#include <cstdint>
+
+#include <cubos/core/reflection/reflect.hpp>
+
+#include <cubos/engine/api.hpp>
+
+namespace cubos::engine
+{
+    /// @brief Component that contains the group of the collider and if it is static.
+    /// @ingroup collisions-plugin
+    struct CollisionGroup
+    {
+        CUBOS_REFLECT;
+
+        /// @brief Group to which the collider belongs.
+        ///
+        /// The groupId is the index of the owner entity of the shape.
+        ///
+        /// Internally, it is used to identity whether the shapes should collide or if they constitute a bigger shape,
+        /// as is the case when being a sub-shape of a MultiCollisionShape. In case they are unique, they will be
+        /// attributed their entity index, otherwise, they will be attributed the index of the entity containing the
+        /// MultiCollisionShape component (their parent).
+        ///
+        /// By default, this is set automatically.
+        uint32_t groupId;
+
+        /// @brief Identities if a collider is static.
+        ///
+        /// Internally, it works as a special groupId. It is used to check whether two bodies should collide. For
+        /// optimization, two static bodies do not collide even when they are intersecting.
+        ///
+        /// By default, this is set automatically.
+        bool isStatic;
+    };
+} // namespace cubos::engine

--- a/engine/src/collisions/interface/collider.cpp
+++ b/engine/src/collisions/interface/collider.cpp
@@ -8,7 +8,5 @@ CUBOS_REFLECT_IMPL(cubos::engine::Collider)
 {
     return core::ecs::TypeBuilder<Collider>("cubos::engine::Collider")
         .withField("transform", &Collider::transform)
-        .withField("layer", &Collider::layer)
-        .withField("mask", &Collider::mask)
         .build();
 }

--- a/engine/src/collisions/interface/collision_layers.cpp
+++ b/engine/src/collisions/interface/collision_layers.cpp
@@ -1,0 +1,23 @@
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/collisions/collision_layers.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::CollisionLayers)
+{
+    return core::ecs::TypeBuilder<CollisionLayers>("cubos::engine::CollisionLayers")
+        .withField("value", &CollisionLayers::value)
+        .build();
+}
+
+void cubos::engine::CollisionLayers::setLayerValue(unsigned int layerNumber, bool newValue)
+{
+    CUBOS_ASSERT(layerNumber < 32, "Collision layer number must be between 0 and 31");
+    value = (value & ~(1 << layerNumber)) | (static_cast<uint32_t>(newValue) << layerNumber);
+}
+
+bool cubos::engine::CollisionLayers::getLayerValue(unsigned int layerNumber) const
+{
+    CUBOS_ASSERT(layerNumber < 32, "Collision layer number must be between 0 and 31");
+    return static_cast<bool>((value >> layerNumber) & 1);
+}

--- a/engine/src/collisions/interface/collision_mask.cpp
+++ b/engine/src/collisions/interface/collision_mask.cpp
@@ -1,0 +1,23 @@
+#include <cubos/core/ecs/reflection.hpp>
+#include <cubos/core/reflection/external/primitives.hpp>
+
+#include <cubos/engine/collisions/collision_mask.hpp>
+
+CUBOS_REFLECT_IMPL(cubos::engine::CollisionMask)
+{
+    return core::ecs::TypeBuilder<CollisionMask>("cubos::engine::CollisionMask")
+        .withField("value", &CollisionMask::value)
+        .build();
+}
+
+void cubos::engine::CollisionMask::setLayerValue(unsigned int layerNumber, bool newValue)
+{
+    CUBOS_ASSERT(layerNumber < 32, "Collision mask layer number must be between 0 and 31");
+    value = (value & ~(1 << layerNumber)) | (static_cast<uint32_t>(newValue) << layerNumber);
+}
+
+bool cubos::engine::CollisionMask::getLayerValue(unsigned int layerNumber) const
+{
+    CUBOS_ASSERT(layerNumber < 32, "Collision mask layer number must be between 0 and 31");
+    return static_cast<bool>((value >> layerNumber) & 1);
+}

--- a/engine/src/collisions/interface/plugin.cpp
+++ b/engine/src/collisions/interface/plugin.cpp
@@ -2,6 +2,8 @@
 
 #include <cubos/engine/collisions/collider.hpp>
 #include <cubos/engine/collisions/colliding_with.hpp>
+#include <cubos/engine/collisions/collision_layers.hpp>
+#include <cubos/engine/collisions/collision_mask.hpp>
 #include <cubos/engine/collisions/contact_manifold.hpp>
 #include <cubos/engine/collisions/shapes/box.hpp>
 #include <cubos/engine/collisions/shapes/capsule.hpp>
@@ -13,6 +15,8 @@ void cubos::engine::interfaceCollisionsPlugin(Cubos& cubos)
     cubos.component<BoxCollisionShape>();
     cubos.component<CapsuleCollisionShape>();
     cubos.component<VoxelCollisionShape>();
+    cubos.component<CollisionLayers>();
+    cubos.component<CollisionMask>();
 
     cubos.relation<CollidingWith>();
 }

--- a/engine/src/collisions/interface/raycast.cpp
+++ b/engine/src/collisions/interface/raycast.cpp
@@ -140,9 +140,9 @@ cubos::engine::Opt<cubos::engine::Raycast::Hit> cubos::engine::Raycast::fire(Ray
     // normalize the ray
     ray.direction = glm::normalize(ray.direction);
 
-    for (auto [entity, localToWorld, collider, shape] : mBoxes)
+    for (auto [entity, localToWorld, collider, shape, layers] : mBoxes)
     {
-        if ((ray.mask & (static_cast<uint64_t>(1) << collider.layer)) == 0u)
+        if ((ray.mask & layers.value) == 0U)
         {
             continue;
         }
@@ -162,9 +162,9 @@ cubos::engine::Opt<cubos::engine::Raycast::Hit> cubos::engine::Raycast::fire(Ray
         }
     }
 
-    for (auto [entity, localToWorld, collider, shape, position] : mCapsules)
+    for (auto [entity, localToWorld, collider, shape, position, layers] : mCapsules)
     {
-        if (!(ray.mask & (static_cast<uint64_t>(1) << collider.layer)))
+        if ((ray.mask & layers.value) == 0U)
         {
             continue;
         }

--- a/engine/tests/raycast.cpp
+++ b/engine/tests/raycast.cpp
@@ -35,35 +35,40 @@ TEST_CASE("cubos::engine::Raycast")
                 .add(Position{{0.0F, 0.0F, 0.0F}})
                 .add(LocalToWorld{})
                 .add(BoxCollisionShape{})
-                .add(Collider{});
+                .add(Collider{})
+                .add(CollisionLayers{});
 
             cmds.create()
                 .add(Name{"box2"})
                 .add(Position{{1.0F, 0.0F, 0.0F}})
                 .add(LocalToWorld{})
                 .add(BoxCollisionShape{})
-                .add(Collider{});
+                .add(Collider{})
+                .add(CollisionLayers{});
 
             cmds.create()
                 .add(Name{"box3"})
                 .add(Position{{0.0F, 0.0F, 1.0F}})
                 .add(LocalToWorld{})
                 .add(BoxCollisionShape{})
-                .add(Collider{});
+                .add(Collider{})
+                .add(CollisionLayers{});
 
             cmds.create()
                 .add(Name{"box4"})
                 .add(Position{{-1.0F, 0.0F, 0.0F}})
                 .add(LocalToWorld{})
                 .add(BoxCollisionShape{})
-                .add(Collider{});
+                .add(Collider{})
+                .add(CollisionLayers{});
 
             cmds.create()
                 .add(Name{"box5"})
                 .add(Position{{0.0F, 0.0F, -1.0F}})
                 .add(LocalToWorld{})
                 .add(BoxCollisionShape{})
-                .add(Collider{});
+                .add(Collider{})
+                .add(CollisionLayers{});
         });
 
         cubos.system("raycast").after(transformUpdateTag).call([](const World& world, Raycast raycast) {
@@ -99,7 +104,8 @@ TEST_CASE("cubos::engine::Raycast")
                 .add(Position{{0.0F, 0.0F, 0.0F}})
                 .add(LocalToWorld{})
                 .add(CapsuleCollisionShape{{1, 1}})
-                .add(Collider{});
+                .add(Collider{})
+                .add(CollisionLayers{});
         });
 
         cubos.system("raycast").after(transformUpdateTag).call([](Raycast raycast) {


### PR DESCRIPTION
# Description

Move collision layers and masks to their own components and create `CollisionGroup` component. Check out the issue for more info.
Currently collisions are detected if either of the bodies detects the other (this functionality will be extended in future PRs).

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Add entry to the changelog's unreleased section.
