### PR TITLE
Make RenderPicker optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Entity destruction detection to observers (#1458, **@kuukitenshi**).
 - Added CollisionGroup component to support internal collision layer overrides (#535, **@fallenatlas**).
 
 ### Changed
-- Made collision layer and mask their own components (#535, **@fallenatlas**).
 
+- Made collision layer and mask their own components (#535, **@fallenatlas**).
+- Make RenderPicker optional (#1407, **@tomas7770**).
 
 ## [v0.6.0] - 2025-02-10
 

--- a/engine/assets/render/g_buffer_rasterizer.fs
+++ b/engine/assets/render/g_buffer_rasterizer.fs
@@ -1,17 +1,23 @@
 in vec3 fragPosition;
 in vec3 fragNormal;
 in vec3 fragAlbedo;
+#ifdef RENDER_PICKER
 flat in uvec2 fragPicker;
+#endif
 
 layout(location = 0) out vec3 position;
 layout(location = 1) out vec3 normal;
 layout(location = 2) out vec3 albedo;
+#ifdef RENDER_PICKER
 layout(location = 3) out uvec2 picker;
+#endif
 
 void main()
 {
     position = fragPosition;
     normal = fragNormal;
     albedo = fragAlbedo;
+    #ifdef RENDER_PICKER
     picker = fragPicker;
+    #endif
 }

--- a/engine/assets/render/g_buffer_rasterizer.vs
+++ b/engine/assets/render/g_buffer_rasterizer.vs
@@ -5,7 +5,9 @@ in uint material;
 out vec3 fragPosition;
 out vec3 fragNormal;
 out vec3 fragAlbedo;
+#ifdef RENDER_PICKER
 flat out uvec2 fragPicker;
+#endif
 
 uniform PerScene
 {
@@ -38,6 +40,8 @@ void main(void)
 
     fragAlbedo = texelFetch(palette, ivec2(mod(float(material), 256.0), material / 256u), 0).rgb;
 
+    #ifdef RENDER_PICKER
     fragPicker.r = (picker >> 16U);
     fragPicker.g = (picker & 65535U);
+    #endif
 }

--- a/engine/include/cubos/engine/render/defaults/target.hpp
+++ b/engine/include/cubos/engine/render/defaults/target.hpp
@@ -30,6 +30,7 @@ namespace cubos::core::memory
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::SplitScreen>;
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::Bloom>;
     CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::SSAO>;
+    CUBOS_ENGINE_EXTERN template class CUBOS_ENGINE_API Opt<cubos::engine::RenderPicker>;
 } // namespace cubos::core::memory
 
 namespace cubos::engine
@@ -50,7 +51,7 @@ namespace cubos::engine
         GBuffer gBuffer{};
 
         /// @brief Picker component.
-        RenderPicker picker{};
+        core::memory::Opt<RenderPicker> picker{RenderPicker{}};
 
         /// @brief Depth component.
         RenderDepth depth{};

--- a/engine/src/render/defaults/plugin.cpp
+++ b/engine/src/render/defaults/plugin.cpp
@@ -71,7 +71,6 @@ void cubos::engine::renderDefaultsPlugin(Cubos& cubos)
                     .add(entity, defaults.target)
                     .add(entity, defaults.hdr)
                     .add(entity, defaults.gBuffer)
-                    .add(entity, defaults.picker)
                     .add(entity, defaults.depth)
                     .add(entity, defaults.gBufferRasterizer)
                     .add(entity, defaults.toneMapping)
@@ -91,6 +90,11 @@ void cubos::engine::renderDefaultsPlugin(Cubos& cubos)
                 if (defaults.ssao)
                 {
                     cmds.add(entity, defaults.ssao.value());
+                }
+
+                if (defaults.picker)
+                {
+                    cmds.add(entity, defaults.picker.value());
                 }
             }
         });

--- a/engine/src/render/defaults/target.cpp
+++ b/engine/src/render/defaults/target.cpp
@@ -6,6 +6,7 @@
 template class cubos::core::memory::Opt<cubos::engine::SplitScreen>;
 template class cubos::core::memory::Opt<cubos::engine::Bloom>;
 template class cubos::core::memory::Opt<cubos::engine::SSAO>;
+template class cubos::core::memory::Opt<cubos::engine::RenderPicker>;
 
 CUBOS_REFLECT_IMPL(cubos::engine::RenderTargetDefaults)
 {


### PR DESCRIPTION
# Description

Allows the renderer to work without RenderPicker, for a performance boost. If the RenderPicker component isn't present in the render target, the feature is disabled.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
