### PR TITLE
chore: added support for wayland in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,10 @@
             mkdir -p $EM_CACHE
             cp -r $EMSCRIPTEN/cache/* $EM_CACHE
             chmod u+rwx -R $EM_CACHE
+
+            if [ -n "$WAYLAND_DISPLAY" ]; then
+              LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(nix-build '<nixpkgs>' -A wayland --no-out-link)/lib"
+            fi
           '';
         };
 


### PR DESCRIPTION
# Description

Cubos was not able to run on wayland with the nix flake because of mismatching wayland versions being used by the graphics.
The solution was to include the wayland library used by the system in the library path.

## Checklist

- [x] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
