### PR TITLE
feat(rendering): add frustum culling for voxel meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Entity destruction detection to observers (#1458, **@kuukitenshi**).
 - Added CollisionGroup component to support internal collision layer overrides (#535, **@fallenatlas**).
+- Perform frustum culling for voxel meshes (#1183, **@mkuritsu**).
 
 ### Changed
 

--- a/core/include/cubos/core/geom/frustum.hpp
+++ b/core/include/cubos/core/geom/frustum.hpp
@@ -2,6 +2,8 @@
 /// @brief Class @ref cubos::core::geom::Frustum.
 /// @ingroup core-geom
 
+#pragma once
+
 #include <cubos/core/api.hpp>
 #include <cubos/core/geom/plane.hpp>
 #include <cubos/core/reflection/reflect.hpp>

--- a/core/include/cubos/core/geom/intersections.hpp
+++ b/core/include/cubos/core/geom/intersections.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include <glm/glm.hpp>
 
 #include <cubos/core/ecs/entity/entity.hpp>

--- a/core/src/geom/intersections.cpp
+++ b/core/src/geom/intersections.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <array>
 #include <limits>
 
 #include <glm/glm.hpp>
@@ -154,14 +153,12 @@ bool cubos::core::geom::intersects(const Box& box1, const glm::mat4& localToWorl
 
 bool cubos::core::geom::intersects(const Frustum& frustum, const Box& box, const glm::mat4& localToWorld)
 {
-    std::array<glm::vec3, 8> corners;
-    box.corners(corners.data());
-    std::ranges::transform(corners, corners.begin(),
-                           [localToWorld](glm::vec3& corner) { return localToWorld * glm::vec4{corner, 1.0F}; });
     auto planes = {&frustum.top, &frustum.right, &frustum.bottom, &frustum.left, &frustum.near, &frustum.far};
-    return std::ranges::any_of(corners, [planes](const glm::vec3 corner) {
-        return std::ranges::all_of(
-            planes, [corner](const Plane* plane) { return pointDistanceToPlane(corner, *plane) > 0.0F; });
+    glm::vec3 center = localToWorld * glm::vec4{0.0F, 0.0F, 0.0F, 1.0F};
+    return std::ranges::all_of(planes, [box, center](const Plane* plane) {
+        glm::vec3 norm = glm::vec3{std::abs(plane->normal.x), std::abs(plane->normal.y), std::abs(plane->normal.z)};
+        float r = glm::dot(box.halfSize, norm);
+        return -r <= pointDistanceToPlane(center, *plane);
     });
 }
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -273,7 +273,7 @@ target_link_libraries(cubos-engine PRIVATE $<BUILD_INTERFACE:stb_image>)
 
 # Fetch Freetype, which msdfgen depends on
 FetchContent_Declare(Freetype
-	GIT_REPOSITORY "https://gitlab.freedesktop.org/freetype/freetype.git"
+	GIT_REPOSITORY "https://github.com/freetype/freetype.git"
 	GIT_TAG "VER-2-13-3"
 	SYSTEM
 )

--- a/engine/include/cubos/engine/render/camera/camera.hpp
+++ b/engine/include/cubos/engine/render/camera/camera.hpp
@@ -6,6 +6,7 @@
 
 #include <glm/mat4x4.hpp>
 
+#include <cubos/core/geom/frustum.hpp>
 #include <cubos/core/reflection/reflect.hpp>
 
 #include <cubos/engine/api.hpp>
@@ -30,5 +31,11 @@ namespace cubos::engine
 
         /// @brief Far clipping plane.
         float zFar = 1000.0F;
+
+        /// @brief Frustum of the projection.
+        core::geom::Frustum frustum{};
+
+        /// @brief If the frustum should stop being updated.
+        bool freezeFrustum{false};
     };
 } // namespace cubos::engine

--- a/engine/src/render/camera/camera.cpp
+++ b/engine/src/render/camera/camera.cpp
@@ -11,5 +11,7 @@ CUBOS_REFLECT_IMPL(cubos::engine::Camera)
         .withField("projection", &Camera::projection)
         .withField("zNear", &Camera::zNear)
         .withField("zFar", &Camera::zFar)
+        .withField("frustum", &Camera::frustum)
+        .withField("freezeFrustum", &Camera::freezeFrustum)
         .build();
 }

--- a/engine/src/render/camera/plugin.cpp
+++ b/engine/src/render/camera/plugin.cpp
@@ -1,5 +1,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <cubos/core/memory/opt.hpp>
+
 #include <cubos/engine/render/camera/camera.hpp>
 #include <cubos/engine/render/camera/draws_to.hpp>
 #include <cubos/engine/render/camera/orthographic.hpp>
@@ -7,12 +9,15 @@
 #include <cubos/engine/render/camera/plugin.hpp>
 #include <cubos/engine/render/target/plugin.hpp>
 #include <cubos/engine/render/target/target.hpp>
+#include <cubos/engine/transform/local_to_world.hpp>
+#include <cubos/engine/transform/plugin.hpp>
 
 using namespace cubos::engine;
 
 void cubos::engine::cameraPlugin(Cubos& cubos)
 {
     cubos.depends(renderTargetPlugin);
+    cubos.depends(transformPlugin);
 
     cubos.component<Camera>();
     cubos.component<PerspectiveCamera>();
@@ -69,6 +74,84 @@ void cubos::engine::cameraPlugin(Cubos& cubos)
                 {
                     camera.projection = glm::ortho(-ortho.size, ortho.size, -ortho.size / aspect, ortho.size / aspect,
                                                    camera.zNear, camera.zFar);
+                }
+            }
+        });
+
+    cubos.system("update Camera frustum by PerspectiveCamera")
+        .call([](Query<Camera&, const PerspectiveCamera&, const LocalToWorld&> query) {
+            for (auto [camera, perspective, localToWorld] : query)
+            {
+                if (camera.active && !camera.freezeFrustum)
+                {
+                    glm::vec up = localToWorld.up();
+                    glm::vec3 front = -localToWorld.forward();
+                    glm::vec3 right = glm::cross(up, front);
+                    glm::vec3 position = localToWorld.worldPosition();
+
+                    float aspect = camera.projection[1][1] / camera.projection[0][0];
+                    float halfVSide = camera.zFar * tanf(glm::radians(perspective.fovY) * 0.5F);
+                    float halfHSide = halfVSide * aspect;
+
+                    glm::vec3 nearPoint = position + camera.zNear * front;
+                    glm::vec3 farPoint = position + camera.zFar * front;
+                    glm::vec3 rightNorm = glm::normalize(glm::cross(front + right * halfHSide, up));
+                    glm::vec3 leftNorm = glm::normalize(glm::cross(up, front - right * halfHSide));
+                    glm::vec3 topNorm = glm::normalize(glm::cross(right, front + up * halfVSide));
+                    glm::vec3 botNorm = glm::normalize(glm::cross(front - up * halfVSide, right));
+
+                    camera.frustum.near = {.normal = front, .d = glm::dot(front, nearPoint)};
+                    camera.frustum.far = {.normal = -front, .d = glm::dot(-front, farPoint)};
+                    camera.frustum.top = {.normal = topNorm, .d = glm::dot(topNorm, position)};
+                    camera.frustum.bottom = {.normal = botNorm, .d = glm::dot(botNorm, position)};
+                    camera.frustum.left = {.normal = leftNorm, .d = glm::dot(leftNorm, position)};
+                    camera.frustum.right = {.normal = rightNorm, .d = glm::dot(rightNorm, position)};
+                }
+            }
+        });
+
+    cubos.system("update Camera frustum by OrthographicCamera")
+        .call([](Query<Camera&, const OrthographicCamera&, const LocalToWorld&, const DrawsTo&, const RenderTarget&>
+                     query) {
+            for (auto [camera, ortho, localToWorld, drawsTo, target] : query)
+            {
+                if (camera.active && !camera.freezeFrustum)
+                {
+                    glm::vec up = localToWorld.up();
+                    glm::vec3 front = -localToWorld.forward();
+                    glm::vec3 right = glm::cross(up, front);
+                    glm::vec3 position = localToWorld.worldPosition();
+
+                    float aspect = (static_cast<float>(target.size.x) * drawsTo.viewportSize.x) /
+                                   (static_cast<float>(target.size.y) * drawsTo.viewportSize.y);
+                    float leftSize = -ortho.size;
+                    float rightSize = ortho.size;
+                    float bottomSize = -ortho.size;
+                    float topSize = ortho.size;
+                    if (ortho.axis == OrthographicCamera::Axis::Vertical)
+                    {
+                        leftSize *= aspect;
+                        rightSize *= aspect;
+                    }
+                    else
+                    {
+                        bottomSize /= aspect;
+                        topSize /= aspect;
+                    }
+
+                    glm::vec3 nearPoint = position + camera.zNear * front;
+                    glm::vec3 farPoint = position + camera.zFar * front;
+                    glm::vec3 rightPoint = rightSize * right;
+                    glm::vec3 leftPoint = leftSize * right;
+                    glm::vec3 topPoint = topSize * up;
+                    glm::vec3 bottomPoint = bottomSize * up;
+
+                    camera.frustum.near = {.normal = front, .d = glm::dot(front, nearPoint)};
+                    camera.frustum.far = {.normal = -front, .d = glm::dot(-front, farPoint)};
+                    camera.frustum.right = {.normal = -right, .d = glm::dot(-right, rightPoint)};
+                    camera.frustum.left = {.normal = right, .d = glm::dot(right, leftPoint)};
+                    camera.frustum.top = {.normal = -up, .d = glm::dot(-up, topPoint)};
+                    camera.frustum.bottom = {.normal = up, .d = glm::dot(up, bottomPoint)};
                 }
             }
         });


### PR DESCRIPTION
# Description

Added frustum culling for Perspective and Orthographic camera, avoiding submitting draw calls for meshes outside the camera vision.

## Checklist

- [x] Self-review changes.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
