### PR TITLE
feat(ecs): add relation creation and removal detection to observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Infinite terrain profiling sample (#1487, **@tomas7770**).
 - Added inertia for voxel shape (**@fallenatlas**).
 - Added a method to Query to count the number of matches (#1451, **@GalaxyCrush**).
+- Added relation creation and removal detection to observers (#1416, **@kuukitenshi**).
 
 ### Changed
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -623,6 +623,36 @@ namespace cubos::core::ecs
         /// @return Builder.
         ObserverBuilder&& onDestroy(int target = -1) &&;
 
+        /// @brief Triggers the observer whenever the given relation is added between entities.
+        /// @param type Relation type.
+        /// @param fromTarget From target index. By default, the last specified target or 0.
+        /// @param toTarget To target index. By default, @p fromTarget + 1.
+        /// @return Builder.
+        ObserverBuilder&& onRelate(const reflection::Type& type, int fromTarget = -1, int toTarget = -1) &&;
+
+        /// @copydoc onRelate(const reflection::Type&, int, int)
+        /// @tparam T Relation type.
+        template <typename T>
+        ObserverBuilder&& onRelate(int fromTarget = -1, int toTarget = -1) &&
+        {
+            return std::move(*this).onRelate(reflection::reflect<T>(), fromTarget, toTarget);
+        }
+
+        /// @brief Triggers the observer whenever the given relation is removed between entities.
+        /// @param type Relation type.
+        /// @param fromTarget From target index. By default, the last specified target or 0.
+        /// @param toTarget To target index. By default, @p fromTarget + 1.
+        /// @return Builder.
+        ObserverBuilder&& onUnrelate(const reflection::Type& type, int fromTarget = -1, int toTarget = -1) &&;
+
+        /// @copydoc onUnrelate(const reflection::Type&, int, int)
+        /// @tparam T Relation type.
+        template <typename T>
+        ObserverBuilder&& onUnrelate(int fromTarget = -1, int toTarget = -1) &&
+        {
+            return std::move(*this).onUnrelate(reflection::reflect<T>(), fromTarget, toTarget);
+        }
+
         /// @brief Forces the next entity query argument to have the given target.
         /// @param target Target index. By default, the last specified target or 0.
         /// @return Builder.

--- a/core/include/cubos/core/ecs/observer/observers.hpp
+++ b/core/include/cubos/core/ecs/observer/observers.hpp
@@ -42,6 +42,20 @@ namespace cubos::core::ecs
         /// @return Whether an observer was triggered.
         bool notifyDestroy(CommandBuffer& commandBuffer, Entity entity, ColumnId column);
 
+        /// @brief Notifies that the given entity has a new relationship.
+        /// @param commandBuffer Command buffer to record the any commands emitted by the observer.
+        /// @param entity Entity.
+        /// @param column Column.
+        /// @return Whether an observer was triggered.
+        bool notifyRelate(CommandBuffer& commandBuffer, Entity entity, ColumnId column);
+
+        /// @brief Notifies that the given entity has lost a relationship.
+        /// @param commandBuffer Command buffer to record the any commands emitted by the observer.
+        /// @param entity Entity.
+        /// @param column Column.
+        /// @return Whether an observer was triggered.
+        bool notifyUnrelate(CommandBuffer& commandBuffer, Entity entity, ColumnId column);
+
         /// @brief Hooks an observer to the addition of a column.
         /// @param column Column.
         /// @param observer Observer system.
@@ -60,6 +74,18 @@ namespace cubos::core::ecs
         /// @return Observer identifier.
         ObserverId hookOnDestroy(ColumnId column, System<void> observer);
 
+        /// @brief Hooks an observer to add the relationship of a column.
+        /// @param column Column.
+        /// @param observer Observer system.
+        /// @return Observer identifier.
+        ObserverId hookOnRelate(ColumnId column, System<void> observer);
+
+        /// @brief Hooks an observer to the removal of a relationship of a column.
+        /// @param column Column.
+        /// @param observer Observer system.
+        /// @return Observer identifier.
+        ObserverId hookOnUnrelate(ColumnId column, System<void> observer);
+
         /// @brief Unhooks an observer.
         /// @param id Observer identifier.
         void unhook(ObserverId id);
@@ -69,5 +95,7 @@ namespace cubos::core::ecs
         std::unordered_multimap<ColumnId, ObserverId, ColumnIdHash> mOnAdd;
         std::unordered_multimap<ColumnId, ObserverId, ColumnIdHash> mOnRemove;
         std::unordered_multimap<ColumnId, ObserverId, ColumnIdHash> mOnDestroy;
+        std::unordered_multimap<ColumnId, ObserverId, ColumnIdHash> mOnRelate;
+        std::unordered_multimap<ColumnId, ObserverId, ColumnIdHash> mOnUnrelate;
     };
 } // namespace cubos::core::ecs

--- a/core/include/cubos/core/ecs/plugin_queue.hpp
+++ b/core/include/cubos/core/ecs/plugin_queue.hpp
@@ -24,6 +24,8 @@ namespace cubos::core::ecs
         std::vector<Plugin> toAdd;
         std::vector<Plugin> toRemove;
         std::vector<Plugin> toDestroy;
+        std::vector<Plugin> toRelate;
+        std::vector<Plugin> toUnrelate;
         std::mutex mutex;
     };
 } // namespace cubos::core::ecs

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -935,6 +935,63 @@ auto Cubos::ObserverBuilder::onDestroy(int target) && -> ObserverBuilder&&
     return std::move(*this);
 }
 
+auto Cubos::ObserverBuilder::onRelate(const reflection::Type& type, int fromTarget, int toTarget) && -> ObserverBuilder&&
+{
+    CUBOS_ASSERT(mCubos.isRegistered(type), "No such relation type {} was registered", type.name());
+    auto dataTypeId = mCubos.mWorld->types().id(type);
+    CUBOS_ASSERT(mCubos.mWorld->types().isRelation(dataTypeId), "Type {} isn't registered as a relation", type.name());
+    CUBOS_ASSERT(mColumnId == ColumnId::Invalid, "An observer can only have at most one hook");
+
+    if (mOptions.empty())
+    {
+        mOptions.emplace_back();
+    }
+
+    if (fromTarget == -1)
+    {
+        fromTarget = mDefaultTarget;
+    }
+    if (toTarget == -1)
+    {
+        toTarget = fromTarget + 1;
+    }
+
+    mDefaultTarget = toTarget;
+    mOptions.back().observedTarget = fromTarget;
+    mRemove = false;
+    mDestroy = false;
+    mColumnId = ColumnId::make(mCubos.mWorld->types().id(type));
+    return std::move(*this);
+}
+
+auto Cubos::ObserverBuilder::onUnrelate(const reflection::Type& type, int fromTarget, int toTarget) && -> ObserverBuilder&&
+{
+    CUBOS_ASSERT(mCubos.isRegistered(type), "No such relation type {} was registered", type.name());
+    auto dataTypeId = mCubos.mWorld->types().id(type);
+    CUBOS_ASSERT(mCubos.mWorld->types().isRelation(dataTypeId), "Type {} isn't registered as a relation", type.name());
+    CUBOS_ASSERT(mColumnId == ColumnId::Invalid, "An observer can only have at most one hook");
+
+    if (mOptions.empty())
+    {
+        mOptions.emplace_back();
+    }
+
+    if (fromTarget == -1)
+    {
+        fromTarget = mDefaultTarget;
+    }
+    if (toTarget == -1)
+    {
+        toTarget = fromTarget + 1;
+    }
+
+    mDefaultTarget = toTarget;
+    mOptions.back().observedTarget = fromTarget;
+    mRemove = true;
+    mDestroy = false;
+    mColumnId = ColumnId::make(mCubos.mWorld->types().id(type));
+    return std::move(*this);
+}
 
 auto Cubos::ObserverBuilder::entity(int target) && -> ObserverBuilder&&
 {

--- a/core/src/ecs/observer/observers.cpp
+++ b/core/src/ecs/observer/observers.cpp
@@ -65,6 +65,43 @@ bool Observers::notifyDestroy(CommandBuffer& commandBuffer, Entity entity, Colum
     return triggered;
 }
 
+bool Observers::notifyRelate(CommandBuffer& commandBuffer, Entity entity, ColumnId column)
+{
+    bool triggered = false;
+
+    auto range = mOnRelate.equal_range(column);
+    for (auto it = range.first; it != range.second; ++it)
+    {
+        auto* observer = mObservers[it->second.inner];
+        if (observer != nullptr)
+        {
+            observer->run({.cmdBuffer = commandBuffer, .observedEntity = entity});
+            triggered = true;
+        }
+    }
+
+    return triggered;
+}
+
+bool Observers::notifyUnrelate(CommandBuffer& commandBuffer, Entity entity, ColumnId column)
+{
+    bool triggered = false;
+
+    auto range = mOnUnrelate.equal_range(column);
+    for (auto it = range.first; it != range.second; ++it)
+    {
+        auto* observer = mObservers[it->second.inner];
+        if (observer != nullptr)
+        {
+            observer->run({.cmdBuffer = commandBuffer, .observedEntity = entity});
+            triggered = true;
+        }
+    }
+
+    return triggered;
+}
+
+
 ObserverId Observers::hookOnAdd(ColumnId column, System<void> observer)
 {
     ObserverId id{.inner = mObservers.size()};
@@ -86,6 +123,22 @@ ObserverId Observers::hookOnDestroy(ColumnId column, System<void> observer)
     ObserverId id{.inner = mObservers.size()};
     mObservers.push_back(new System<void>(std::move(observer)));
     mOnDestroy.emplace(column, id);
+    return id;
+}
+
+ObserverId Observers::hookOnRelate(ColumnId column, System<void> observer)
+{
+    ObserverId id{.inner = mObservers.size()};
+    mObservers.push_back(new System<void>(std::move(observer)));
+    mOnRelate.emplace(column, id);
+    return id;
+}
+
+ObserverId Observers::hookOnUnrelate(ColumnId column, System<void> observer)
+{
+    ObserverId id{.inner = mObservers.size()};
+    mObservers.push_back(new System<void>(std::move(observer)));
+    mOnUnrelate.emplace(column, id);
     return id;
 }
 

--- a/core/tests/ecs/observer/observers.cpp
+++ b/core/tests/ecs/observer/observers.cpp
@@ -7,7 +7,7 @@
 
 using namespace cubos::core::ecs;
 
-TEST_CASE("ecs::Observers")
+TEST_CASE("ecs::Observers - Add, Remove and Destroy")
 {
     World world{};
     CommandBuffer cmdBuffer{world};
@@ -48,4 +48,36 @@ TEST_CASE("ecs::Observers")
     obs.unhook(hook1);
     obs.notifyAdd(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 1});
     CHECK(acc == 0);
+}
+
+TEST_CASE("ecs::Observers - Relate and Unrelate")
+{
+    World world{};
+    CommandBuffer cmdBuffer{world};
+    Observers obs{};
+
+    static int acc = 0;
+    auto hookRelate = obs.hookOnRelate(ColumnId{.inner = 1}, System<void>::make(world, []() { acc += 10; }, {}));
+    auto hookUnrelate = obs.hookOnUnrelate(ColumnId{.inner = 1}, System<void>::make(world, []() { acc -= 5; }, {}));
+    CHECK(acc == 0);
+
+    obs.notifyRelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 0});
+    CHECK(acc == 0);
+    obs.notifyUnrelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 2});
+    CHECK(acc == 0);
+
+    obs.notifyRelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 1});
+    CHECK(acc == 10);
+    obs.notifyUnrelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 1});
+    CHECK(acc == 5);
+
+    obs.unhook(hookRelate);
+    obs.notifyRelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 1});
+    CHECK(acc == 5);
+
+    obs.notifyUnrelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 1});
+    CHECK(acc == 0);
+    obs.unhook(hookUnrelate);
+    obs.notifyUnrelate(cmdBuffer, Entity{0, 0}, ColumnId{.inner = 1});
+    CHECK(acc == 0); 
 }


### PR DESCRIPTION
# Description

Added relation creation and removal detection to observers to allow  ```.onRelate<ChildOf>``` and ```.onUnrelate<ChildOf>```.

## Checklist

- [x] Self-review changes.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
