### PR TITLE
1438 add auto-scroll toggle to Console tool

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -11,6 +11,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatically add ColliderAABB when adding a Collision Shape to an entity (#1444, **@fallenatlas**).
 - Wrapper trait to distinguish between single-field structs and wrapper structs (**SrGesus**, **@RiscadoA**).
 - Bindings subpropject for future lua bindings (#1496, **@mkuritsu**).
+- Added an auto-scroll toggle to Console tool (#1438, **@R-Camacho**)
 
 ### Changed
 - Move Tesseratos' tools' status to their respective plugins and remove them from the Toolbox (#1234, **@jdbaracho**).

--- a/engine/src/tools/console/plugin.cpp
+++ b/engine/src/tools/console/plugin.cpp
@@ -18,6 +18,7 @@ namespace
         char searchString[256];
         bool clearEnabled = false;
         bool collapseEnabled = false;
+        bool autoScrollEnabled = true;
         bool traceEnabled = true;
         bool debugEnabled = true;
         bool infoEnabled = true;
@@ -103,6 +104,12 @@ void cubos::engine::consolePlugin(Cubos& cubos)
             {cubos::core::tel::Level::Error, 0}, {cubos::core::tel::Level::Critical, 0}};
 
         ImGui::BeginChild("Log", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()));
+
+        // If scrolled up manually, disable auto-scroll
+        if (state.autoScrollEnabled && ImGui::IsWindowHovered() && ImGui::GetIO().MouseWheel > 0)
+        {
+            state.autoScrollEnabled = false;
+        }
 
         while (cubos::core::tel::Logger::read(state.cursor, entry))
         {
@@ -199,6 +206,12 @@ void cubos::engine::consolePlugin(Cubos& cubos)
             }
         }
 
+        // If auto-scroll is enabled and a new entry was added, scroll to bottom
+        if (state.autoScrollEnabled && ImGui::GetScrollY() >= ImGui::GetScrollMaxX())
+        {
+            ImGui::SetScrollHereY(1.0F);
+        }
+
         ImGui::EndChild();
 
         // Input Search Bar
@@ -219,6 +232,9 @@ void cubos::engine::consolePlugin(Cubos& cubos)
         {
             state.collapseEnabled = !state.collapseEnabled;
         }
+
+        // Auto-Scroll Checkbox
+        ImGui::Checkbox("Auto-Scroll", &state.autoScrollEnabled);
 
         std::string traceText = "Trace (" + std::to_string(logCounts[cubos::core::tel::Level::Trace]) + ")";
         if (ImGui::SmallButton(traceText.c_str()))


### PR DESCRIPTION
# Description

Added an auto-scroll toggle to Console tool, so the user does not need to scroll manually.

## Checklist

- [X] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
