### PR TITLE
Use custom ImGui style and font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow mouse state to be changed through the input plugin (#1401, **@mcanais**).
 - Move the reflection implementation of each physics component into its own file (**@fallenatlas**).
 - Move Tesseratos' tools' status to their respective plugins and remove them from the Toolbox (#1234, **@jdbaracho**).
+- Use Roboto font in ImGui, following the Brand Guidelines (#817, **@RiscadoA**).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the reflection implementation of each physics component into its own file (**@fallenatlas**).
 - Move Tesseratos' tools' status to their respective plugins and remove them from the Toolbox (#1234, **@jdbaracho**).
 - Use Roboto font in ImGui, following the Brand Guidelines (#817, **@RiscadoA**).
+- ImGui style colors to match the Brand Guidelines (#817, **@RiscadoA**).
 
 ### Changed
 

--- a/engine/include/cubos/engine/font/font.hpp
+++ b/engine/include/cubos/engine/font/font.hpp
@@ -34,6 +34,10 @@ namespace cubos::engine
         /// @brief Returns the handle to this loaded font.
         void* handle() const;
 
+        /// @brief Returns the data bytes of the font.
+        /// @return The data bytes of the font.
+        const std::vector<uint8_t>& data() const;
+
     private:
         void* mHandle{nullptr};
 

--- a/engine/samples/CMakeLists.txt
+++ b/engine/samples/CMakeLists.txt
@@ -61,7 +61,7 @@ make_sample(DIR "assets/saving" ASSETS NO_WEB) # Can't save assets on Emscripten
 make_sample(DIR "render/main" ASSETS)
 make_sample(DIR "render/shadows" ASSETS)
 make_sample(DIR "render/profiling" ASSETS)
-make_sample(DIR "imgui")
+make_sample(DIR "imgui" ASSETS)
 make_sample(DIR "collisions" ASSETS)
 make_sample(DIR "voxel-shape-collisions" ASSETS)
 make_sample(DIR "scene" ASSETS)

--- a/engine/samples/imgui/main.cpp
+++ b/engine/samples/imgui/main.cpp
@@ -19,6 +19,8 @@
 #include <cubos/core/reflection/traits/nullable.hpp>
 
 /// [Including plugin headers]
+#include <cubos/engine/assets/plugin.hpp>
+#include <cubos/engine/font/plugin.hpp>
 #include <cubos/engine/imgui/inspector.hpp>
 #include <cubos/engine/imgui/plugin.hpp>
 /// [Including plugin headers]
@@ -271,9 +273,16 @@ int main(int argc, char** argv)
     cubos.plugin(settingsPlugin);
     cubos.plugin(windowPlugin);
     cubos.plugin(renderTargetPlugin);
+    cubos.plugin(assetsPlugin);
+    cubos.plugin(fontPlugin);
     /// [Adding the plugin]
     cubos.plugin(imguiPlugin);
     /// [Adding the plugin]
+
+    cubos.startupSystem("configure settings").before(settingsTag).call([](Settings& settings) {
+        settings.setString("assets.app.osPath", APP_ASSETS_PATH);
+        settings.setString("assets.builtin.osPath", BUILTIN_ASSETS_PATH);
+    });
 
     /// [ImGui initialization]
     cubos.startupSystem("set ImGui context").after(imguiInitTag).call([](ImGuiContextHolder& holder) {

--- a/engine/src/font/font.cpp
+++ b/engine/src/font/font.cpp
@@ -59,4 +59,8 @@ namespace cubos::engine
         return mHandle;
     }
 
+    const std::vector<uint8_t>& Font::data() const
+    {
+        return mData;
+    }
 } // namespace cubos::engine

--- a/engine/src/imgui/imgui.cpp
+++ b/engine/src/imgui/imgui.cpp
@@ -2,6 +2,7 @@
 #include <utility>
 
 #include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtx/color_space.hpp>
 #include <imgui.h>
 #include <implot.h>
 
@@ -270,6 +271,18 @@ void main()
     bd->ibSize = 0;
 }
 
+static ImVec4 hsvToImVec4(float h, float s, float v, float a = 1.0F)
+{
+    auto rgb = glm::rgbColor(glm::vec3(h, s, v));
+    return {rgb.r, rgb.g, rgb.b, a};
+}
+
+static ImVec4 hsvToImVec4(int h, int s, int v, int a = 100)
+{
+    return hsvToImVec4(static_cast<float>(h), static_cast<float>(s) / 100.0F, static_cast<float>(v) / 100.0F,
+                       static_cast<float>(a) / 100.0F);
+}
+
 void cubos::engine::imguiInitialize(const io::Window& window, float dpiScale, const Font& font)
 {
     // Initialize ImGui
@@ -277,6 +290,73 @@ void cubos::engine::imguiInitialize(const io::Window& window, float dpiScale, co
     ImGui::CreateContext();
     ImPlot::CreateContext();
     ImGui::StyleColorsDark();
+
+    int hue = 208;
+    auto text = hsvToImVec4(hue, 2, 87);
+    auto primary = hsvToImVec4(hue, 45, 36);
+    auto secondary = hsvToImVec4(hue, 38, 24);
+    auto tertiary = hsvToImVec4(hue, 14, 15);
+    auto background = hsvToImVec4(hue, 10, 13);
+    auto hovered = hsvToImVec4(hue, 45, 45);
+    auto active = hsvToImVec4(hue, 45, 54);
+
+    // Apply our own style, according to the brand guidelines
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.Colors[ImGuiCol_Text] = text;
+    // style.Colors[ImGuiCol_TextDisabled] = ???;
+    style.Colors[ImGuiCol_WindowBg] = tertiary;
+    style.Colors[ImGuiCol_ChildBg] = tertiary;
+    style.Colors[ImGuiCol_PopupBg] = tertiary;
+    // style.Colors[ImGuiCol_Border] = ???;
+    // style.Colors[ImGuiCol_BorderShadow] = ???;
+    style.Colors[ImGuiCol_FrameBg] = hsvToImVec4(hue, 10, 7);
+    style.Colors[ImGuiCol_FrameBgHovered] = hsvToImVec4(hue, 10, 9);
+    style.Colors[ImGuiCol_FrameBgActive] = secondary;
+    style.Colors[ImGuiCol_TitleBg] = secondary;
+    style.Colors[ImGuiCol_TitleBgActive] = primary;
+    style.Colors[ImGuiCol_MenuBarBg] = background;
+    style.Colors[ImGuiCol_ScrollbarBg] = hsvToImVec4(hue, 10, 7);
+    style.Colors[ImGuiCol_ScrollbarGrab] = primary;
+    style.Colors[ImGuiCol_ScrollbarGrabHovered] = hovered;
+    style.Colors[ImGuiCol_ScrollbarGrabActive] = active;
+    style.Colors[ImGuiCol_CheckMark] = active;
+    style.Colors[ImGuiCol_SliderGrab] = primary;
+    style.Colors[ImGuiCol_SliderGrabActive] = active;
+    style.Colors[ImGuiCol_Button] = primary;
+    style.Colors[ImGuiCol_ButtonHovered] = hovered;
+    style.Colors[ImGuiCol_ButtonActive] = active;
+    style.Colors[ImGuiCol_Header] = primary;
+    style.Colors[ImGuiCol_HeaderHovered] = hovered;
+    style.Colors[ImGuiCol_HeaderActive] = active;
+    style.Colors[ImGuiCol_Separator] = background;
+    style.Colors[ImGuiCol_SeparatorHovered] = hovered;
+    style.Colors[ImGuiCol_SeparatorActive] = active;
+    style.Colors[ImGuiCol_ResizeGrip] = primary;
+    style.Colors[ImGuiCol_ResizeGripHovered] = hovered;
+    style.Colors[ImGuiCol_ResizeGripActive] = active;
+    style.Colors[ImGuiCol_Tab] = primary;
+    style.Colors[ImGuiCol_TabHovered] = hovered;
+    style.Colors[ImGuiCol_TabActive] = active;
+    style.Colors[ImGuiCol_TabUnfocused] = primary;
+    style.Colors[ImGuiCol_TabUnfocusedActive] = active;
+    style.Colors[ImGuiCol_DockingPreview] = primary;
+    style.Colors[ImGuiCol_DockingEmptyBg] = background;
+    // style.Colors[ImGuiCol_PlotLines] = ???;
+    // style.Colors[ImGuiCol_PlotLinesHovered] = ???;
+    // style.Colors[ImGuiCol_PlotHistogram] = ???;
+    // style.Colors[ImGuiCol_PlotHistogramHovered] = ???;
+    // style.Colors[ImGuiCol_TableHeaderBg] = ???;
+    // style.Colors[ImGuiCol_TableBorderStrong] = ???;
+    // style.Colors[ImGuiCol_TableBorderLight] = ???;
+    // style.Colors[ImGuiCol_TableRowBg] = ???;
+    // style.Colors[ImGuiCol_TableRowBgAlt] = ???;
+    style.Colors[ImGuiCol_TextSelectedBg] = primary;
+    // style.Colors[ImGuiCol_DragDropTarget] = ???;
+    style.Colors[ImGuiCol_NavHighlight] = active;
+    // style.Colors[ImGuiCol_NavWindowingHighlight] = ???;
+    // style.Colors[ImGuiCol_NavWindowingDimBg] = ???;
+    // style.Colors[ImGuiCol_ModalWindowDimBg] = ???;
+    // style.Colors[ImGuiCol_ModalWindowDimBg] = ???;
 
     ImGuiIO& io = ImGui::GetIO();
     if (io.BackendPlatformUserData != nullptr)
@@ -308,7 +388,6 @@ void cubos::engine::imguiInitialize(const io::Window& window, float dpiScale, co
         if (cursor == nullptr)
         {
             cursor = bd->cursors[ImGuiMouseCursor_Arrow];
-            ;
         }
     }
 

--- a/engine/src/imgui/imgui.cpp
+++ b/engine/src/imgui/imgui.cpp
@@ -270,7 +270,7 @@ void main()
     bd->ibSize = 0;
 }
 
-void cubos::engine::imguiInitialize(const io::Window& window, float dpiScale)
+void cubos::engine::imguiInitialize(const io::Window& window, float dpiScale, const Font& font)
 {
     // Initialize ImGui
     IMGUI_CHECKVERSION();
@@ -326,10 +326,12 @@ void cubos::engine::imguiInitialize(const io::Window& window, float dpiScale)
         dpiScale = 1.0F;
     }
     ImGui::GetStyle().ScaleAllSizes(dpiScale);
-    ImFontConfig fontCfg;
+    ImFontConfig fontCfg{};
     // Default font size is 13; scale that
     fontCfg.SizePixels = 13.0F * dpiScale;
-    io.Fonts->AddFontDefault(&fontCfg);
+    fontCfg.FontDataOwnedByAtlas = false;
+    io.Fonts->AddFontFromMemoryTTF(const_cast<void*>(static_cast<const void*>(font.data().data())),
+                                   static_cast<int>(font.data().size()), 0.0F, &fontCfg);
 
     createDeviceObjects();
 

--- a/engine/src/imgui/imgui.hpp
+++ b/engine/src/imgui/imgui.hpp
@@ -7,14 +7,17 @@
 #include <cubos/core/gl/render_device.hpp>
 #include <cubos/core/io/window.hpp>
 
+#include <cubos/engine/font/font.hpp>
+
 namespace cubos::engine
 {
     /// @brief Initializes ImGui for use with the given window.
     /// @note Should only be called once and no ImGui calls should be made before this is called.
     /// @param window The window to use.
     /// @param dpiScale Size factor by which to scale ImGui elements.
+    /// @param font Font to use.
     /// @ingroup imgui-plugin
-    void imguiInitialize(const core::io::Window& window, float dpiScale);
+    void imguiInitialize(const core::io::Window& window, float dpiScale, const Font& font);
 
     /// @brief Shuts down ImGui.
     /// @note Should only be called once, after @ref initialize(), and no ImGui calls should be

--- a/engine/src/imgui/plugin.cpp
+++ b/engine/src/imgui/plugin.cpp
@@ -1,5 +1,7 @@
 #include <imgui.h>
 
+#include <cubos/engine/assets/plugin.hpp>
+#include <cubos/engine/font/plugin.hpp>
 #include <cubos/engine/imgui/context.hpp>
 #include <cubos/engine/imgui/inspector.hpp>
 #include <cubos/engine/imgui/plugin.hpp>
@@ -15,6 +17,9 @@ CUBOS_DEFINE_TAG(cubos::engine::imguiBeginTag);
 CUBOS_DEFINE_TAG(cubos::engine::imguiEndTag);
 CUBOS_DEFINE_TAG(cubos::engine::imguiTag);
 
+static const cubos::engine::Asset<cubos::engine::Font> RobotoRegularFontAsset =
+    cubos::engine::AnyAsset{"93cbe82e-9c9b-4c25-aa55-5105c1afd0cc"};
+
 using cubos::core::io::Window;
 using cubos::core::io::WindowEvent;
 
@@ -23,6 +28,8 @@ void cubos::engine::imguiPlugin(Cubos& cubos)
     cubos.depends(settingsPlugin);
     cubos.depends(windowPlugin);
     cubos.depends(renderTargetPlugin);
+    cubos.depends(assetsPlugin);
+    cubos.depends(fontPlugin);
 
     cubos.resource<ImGuiInspector::State>();
     cubos.uninitResource<ImGuiContextHolder>();
@@ -35,9 +42,11 @@ void cubos::engine::imguiPlugin(Cubos& cubos)
 
     cubos.startupSystem("initialize ImGui")
         .tagged(imguiInitTag)
-        .call([](Commands cmds, const Window& window, Settings& settings) {
+        .tagged(assetsTag)
+        .call([](Commands cmds, const Window& window, Settings& settings, Assets& assets) {
+            auto font = assets.read(RobotoRegularFontAsset);
             float dpiScale = static_cast<float>(settings.getDouble("imgui.scale", window->contentScale()));
-            imguiInitialize(window, dpiScale);
+            imguiInitialize(window, dpiScale, *font);
 
             cmds.insertResource<ImGuiContextHolder>(ImGuiContextHolder{ImGui::GetCurrentContext()});
         });

--- a/tools/tesseratos/src/tesseratos/main.cpp
+++ b/tools/tesseratos/src/tesseratos/main.cpp
@@ -35,13 +35,14 @@ int main(int argc, char** argv)
             input.bind(*bindings);
         });
 
-    cubos.startupSystem("set ImGui context and enable docking").after(imguiInitTag).call([](ImGuiContextHolder& holder) {
-        ImGui::SetCurrentContext(holder.context);
-        ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-    });
+    cubos.startupSystem("set ImGui context and enable docking")
+        .after(imguiInitTag)
+        .call([](ImGuiContextHolder& holder) {
+            ImGui::SetCurrentContext(holder.context);
+            ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+        });
 
     cubos.system("setup ImGui dockspace").tagged(imguiTag).call([]() {
-
         // make DockSpace fullscreen
         const ImGuiViewport* viewport = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(viewport->WorkPos);
@@ -50,14 +51,15 @@ int main(int argc, char** argv)
 
         // ImGui window flags, check imgui.h for definition
         ImGuiWindowFlags windowFlags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
-        windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
+        windowFlags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+                       ImGuiWindowFlags_NoMove;
         windowFlags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
-    
+
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0F, 0.0F));
         ImGui::Begin("Tesseratos", nullptr, windowFlags);
-        
+        ImGui::PopStyleVar();
         ImGuiID dockspaceId = ImGui::GetID("TesseratosRoot");
         ImGui::DockSpace(dockspaceId, ImVec2(0.0F, 0.0F));
-
         ImGui::End();
     });
 


### PR DESCRIPTION
# Description

This PR changes the ImGui style to use Roboto as a font and also the colors of the menus to match the brand guidelines.

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
