### PR TITLE
fix(build): compile error in inertia.cpp when using gcc 15

### DIFF
--- a/engine/include/cubos/engine/collisions/shapes/voxel.hpp
+++ b/engine/include/cubos/engine/collisions/shapes/voxel.hpp
@@ -89,7 +89,7 @@ namespace cubos::engine
         }
 
         /// @brief Getter for the list of @ref BoxShiftPair of the class.
-        std::vector<BoxShiftPair> getBoxes() const
+        const std::vector<BoxShiftPair>& getBoxes() const
         {
             return this->mBoxes;
         }

--- a/engine/src/physics/components/inertia.cpp
+++ b/engine/src/physics/components/inertia.cpp
@@ -81,11 +81,10 @@ inline static float cylinderShapeVolume(float height, float radius)
 static float voxelShapeVolume(const VoxelCollisionShape& shape)
 {
     float volume = 0.0F;
-    for (auto& box : shape.getBoxes())
+    for (auto box : shape.getBoxes())
     {
         volume += boxShapeVolume(box.box.halfSize * 2.0F);
     }
-
     return volume;
 }
 


### PR DESCRIPTION
# Description

GCC 15 seems to have broken something in the inertia.cpp code. This change seems to fix the compile error just want to be sure it doesn't modify the expected behaviour.

# Additional Information
[compile error.txt](https://github.com/user-attachments/files/20002752/out.txt)


## Checklist

- [ ] Self-review changes.
- [ ] Ensure test coverage.
- [ ] Add entry to the changelog's unreleased section.
