### PR TITLE
Make selection gizmos clickable again and properly handle their depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred shading missing padding leading to black screen on web builds (#1476, **@RiscadoA**).
 - Crashes when adding shadow casters (#1471, **@GalaxyCrush**).
 - Open settings file in correct mode when saving (**@RiscadoA**).
+- Entity and gizmo selection (#1475, **@RiscadoA**).
 
 ## [v0.6.0] - 2025-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crashes when adding shadow casters (#1471, **@GalaxyCrush**).
 - Open settings file in correct mode when saving (**@RiscadoA**).
 - Entity and gizmo selection (#1475, **@RiscadoA**).
+- Use depth texture when rendering gizmos to RenderPicker textures to ensure depth ordered selections (**@RiscadoA**).
 
 ## [v0.6.0] - 2025-02-10
 

--- a/engine/include/cubos/engine/gizmos/target.hpp
+++ b/engine/include/cubos/engine/gizmos/target.hpp
@@ -28,5 +28,11 @@ namespace cubos::engine
 
         /// @brief Picker texture present in the @ref backFramebuffer.
         core::gl::Texture2D backPicker;
+
+        /// @brief Depth texture present in the @ref frontFramebuffer.
+        core::gl::Texture2D frontDepth;
+
+        /// @brief Depth texture present in the @ref backFramebuffer.
+        core::gl::Texture2D backDepth;
     };
 } // namespace cubos::engine

--- a/engine/src/gizmos/renderer.cpp
+++ b/engine/src/gizmos/renderer.cpp
@@ -80,6 +80,7 @@ void GizmosRenderer::init(RenderDevice* currentRenderDevice)
     cubos::core::gl::DepthStencilStateDesc dss;
     dss.depth.enabled = true;
     dss.depth.writeEnabled = true;
+    dss.depth.compare = Compare::LEqual;
     doDepthCheckStencilState = renderDevice->createDepthStencilState(dss);
     dss.depth.enabled = false;
     dss.depth.writeEnabled = false;

--- a/engine/src/tools/selection/plugin.cpp
+++ b/engine/src/tools/selection/plugin.cpp
@@ -34,9 +34,9 @@ void cubos::engine::selectionPlugin(Cubos& cubos)
                     if (target.framebuffer == nullptr)
                     {
                         uint32_t entityId =
-                            picker.read(static_cast<unsigned int>((ImGui::GetMousePos().x / ImGui::GetWindowWidth()) *
+                            picker.read(static_cast<unsigned int>((ImGui::GetMousePos().x / ImGui::GetIO().DisplaySize.x) *
                                                                   static_cast<float>(target.size.x)),
-                                        static_cast<unsigned int>((ImGui::GetMousePos().y / ImGui::GetWindowHeight()) *
+                                        static_cast<unsigned int>((ImGui::GetMousePos().y / ImGui::GetIO().DisplaySize.y) *
                                                                   static_cast<float>(target.size.y)));
 
                         if (entityId == UINT32_MAX)


### PR DESCRIPTION
# Description

- The bug in the issue came from considering `ImGui::GetWindowSize()` to return the window size - it doesn't, it returns the current ImGui window's size. I simply replaced it by the correct call.
- I also noticed that when I clicked, depth wasn't properly taken into account, i.e., occluded gizmos were sometimes selected instead of the ones in front. Turns out we forgot to bind the depth texture on the gizmos framebuffer.

## Checklist

- [x] Self-review changes.
- [x] Add entry to the changelog's unreleased section.
