### PR TITLE
feat(imgui): allow changing quaternion mode on inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Named method for attributing a name to a plugin (#1556, **@mcanais**).
 - New quadrados create command to create assets based on templates (#1479, **@R-Camacho**). 
 - Profiling timers in render plugins (#1560, **@tomas7770**).
+- Quaternion representation mode switch on the inspector (#1520, **@RiscadoA**).
 
 ### Changed
 


### PR DESCRIPTION
# Description

Adds a popup to quaternions on the inspector which allows the user to select between three representation modes:
- raw (e.g., just show the 4 quaternion fields as is);
- euler angles XYZ (yaw, pitch, row)
- axis (vec3) + angle

Additionally, the user can toggle between degrees and radians.
To test this functionality you can run the `engine-sample.imgui` sample, open 'State (Edit)' (or show), scroll down, and open the glm header.

![image](https://github.com/user-attachments/assets/f04b7f12-2af2-4315-b328-a5d4c6961c97)
![image](https://github.com/user-attachments/assets/0593b626-c206-484a-a8d5-e0ebc1869bd9)


## Checklist

- [x] Self-review changes.
- [x] ~~Write new samples.~~ not needed
- [x] Add entry to the changelog's unreleased section.
