### PR TITLE
feat(imgui): toggle for matrix decomposition on inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Barebones lua bindings plugin that can execute standard lua code (#1497, **@mkuritsu**).
 - Constant type reflection support with a new Constant trait (#1507, **@RiscadoA**).
 - Constant trait handler to the ImGui inspector (#1507, **@RiscadoA**).
+- Toggle for matrix decomposition to the inspector (#1521, **@RiscadoA**).
 
 ### Changed
 


### PR DESCRIPTION
# Description

Adds a toggle to the ImGui inspector for 4x4 matrices which allows enabling and disabling decomposition into the translation, rotation, etc, components.

 To test this functionality you can run the engine-sample.imgui sample, open 'State (Edit)' (or show), scroll down, and open the glm header.

![image](https://github.com/user-attachments/assets/e5cfc449-a871-41f9-a528-2c4746413ea3)
![image](https://github.com/user-attachments/assets/f7059e2b-7dfb-433c-86b6-3ba559072d39)
![image](https://github.com/user-attachments/assets/5a0312f3-495c-4dee-820b-df9d19b1157c)

## Checklist

- [ ] Self-review changes.
- [x] ~~Write new samples.~~ present in the imgui sample
- [x] Add entry to the changelog's unreleased section.
