### PR TITLE
feat(data): handle MaskTrait in JSON (de)serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reflection support for C arrays (**@RiscadoA**).
 - Reflection for RenderEnvironment (**@RiscadoA**).
 - Configurable directional shadow range for objects outside the frustum (**@tomas7770**).
+- Support for MaskTrait types in JSON (de)serializer (#1507, **@RiscadoA**).
 
 ### Changed
 

--- a/core/src/data/ser/json.cpp
+++ b/core/src/data/ser/json.cpp
@@ -5,6 +5,7 @@
 #include <cubos/core/reflection/traits/dictionary.hpp>
 #include <cubos/core/reflection/traits/enum.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/traits/mask.hpp>
 #include <cubos/core/reflection/traits/nullable.hpp>
 #include <cubos/core/reflection/traits/string_conversion.hpp>
 #include <cubos/core/reflection/traits/wrapper.hpp>
@@ -16,6 +17,7 @@ using cubos::core::reflection::ArrayTrait;
 using cubos::core::reflection::DictionaryTrait;
 using cubos::core::reflection::EnumTrait;
 using cubos::core::reflection::FieldsTrait;
+using cubos::core::reflection::MaskTrait;
 using cubos::core::reflection::NullableTrait;
 using cubos::core::reflection::reflect;
 using cubos::core::reflection::StringConversionTrait;
@@ -115,6 +117,17 @@ bool JSONSerializer::decompose(const Type& type, const void* value)
     {
         const auto& trait = type.get<EnumTrait>();
         mJSON = trait.variant(value).name();
+        return true;
+    }
+
+    if (type.has<MaskTrait>())
+    {
+        const auto& trait = type.get<MaskTrait>();
+        mJSON = nlohmann::json::array();
+        for (const auto& bit : trait.view(value))
+        {
+            mJSON.push_back(bit.name());
+        }
         return true;
     }
 


### PR DESCRIPTION
# Description

Simply adds handlers for the MaskTrait to the JSON serializer and deserializer.
Mask types are now serialized as lists of flags. E.g., with a mask trait with three flags, 'A', 'B' and 'C', it would be serialized as `[]` or `["A", "B"]` etc.

## Checklist

- [ ] Self-review changes.
- [x] Ensure test coverage.
- [x] Add entry to the changelog's unreleased section.
