### PR TITLE
Add custom constructors to the ConstructibleTrait and support on the inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reflection support for C arrays (**@RiscadoA**).
 - Reflection for RenderEnvironment (**@RiscadoA**).
 - Configurable directional shadow range for objects outside the frustum (**@tomas7770**).
+- Reflected custom constructors to the ConstructibleTrait (#1528, **@RiscadoA**).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reflection for RenderEnvironment (**@RiscadoA**).
 - Configurable directional shadow range for objects outside the frustum (**@tomas7770**).
 - Reflected custom constructors to the ConstructibleTrait (#1528, **@RiscadoA**).
+- Construct button to the ImGui inspector (**@RiscadoA**).
 
 ### Changed
 

--- a/core/include/cubos/core/reflection/traits/constructible.hpp
+++ b/core/include/cubos/core/reflection/traits/constructible.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <cstddef>
+#include <utility>
+#include <vector>
 
 #include <cubos/core/api.hpp>
 #include <cubos/core/memory/function.hpp>
@@ -21,17 +23,67 @@ namespace cubos::core::reflection
     public:
         CUBOS_REFLECT;
 
-        /// @brief Function pointer to the destructor of a type.
+        /// @brief Destructor of a type.
         using Destructor = memory::Function<void(void* instance) const>;
 
-        /// @brief Function pointer to the default constructor of a type.
+        /// @brief Default constructor of a type.
         using DefaultConstructor = memory::Function<void(void* instance) const>;
 
-        /// @brief Function pointer to the copy constructor of a type.
+        /// @brief Copy constructor of a type.
         using CopyConstructor = memory::Function<void(void* instance, const void* other) const>;
 
-        /// @brief Function pointer to the move constructor of a type.
+        /// @brief Move constructor of a type.
         using MoveConstructor = memory::Function<void(void* instance, void* other) const>;
+
+        /// @brief Custom constructor of a type.
+        class CustomConstructor
+        {
+        public:
+            /// @brief Constructs a custom constructor.
+            /// @param argTypes Types of the arguments of the constructor.
+            /// @param argNames Names of the arguments of the constructor.
+            /// @param functor Functor taking the array of arguments to be passed.
+            CustomConstructor(std::vector<const Type*> argTypes, std::vector<std::string> argNames,
+                              memory::Function<void(void* instance, void** args) const> functor);
+
+            /// @brief Move constructs.
+            CustomConstructor(CustomConstructor&& other) = default;
+
+            /// @brief Copy constructs.
+            CustomConstructor(const CustomConstructor& other) = default;
+
+            /// @brief Copy assignment.
+            CustomConstructor& operator=(CustomConstructor&& other) = default;
+
+            /// @brief Gets the number of arguments to the constructor.
+            /// @return Number of arguments to the constructor.
+            std::size_t argCount() const;
+
+            /// @brief Gets the name of an argument of the constructor.
+            /// @param index Index of the argument.
+            /// @return Name of the argument.
+            const std::string& argName(std::size_t index) const;
+
+            /// @brief Gets the type of an argument of the constructor.
+            /// @param index Index of the argument.
+            /// @return Type of the argument.
+            const Type& argType(std::size_t index) const;
+
+            /// @brief Calls the constructor with the given arguments.
+            /// @param instance Pointer to the instance to construct.
+            /// @param args Array of pointers to the arguments to pass to the constructor.
+            void call(void* instance, void** args) const;
+
+        private:
+            /// @brief Types of the arguments of the constructor.
+            std::vector<const Type*> mArgTypes;
+
+            /// @brief Names of the arguments of the constructor.
+            std::vector<std::string> mArgNames;
+
+            /// @brief Functor taking the array of arguments to be passed.
+            memory::Function<void(void* instance, void** args) const> mFunctor;
+        };
 
         /// @brief Builder for @ref ConstructibleTrait.
         template <typename T>
@@ -73,6 +125,29 @@ namespace cubos::core::reflection
         /// @return Trait.
         ConstructibleTrait&& withMoveConstructor(MoveConstructor moveConstructor) &&;
 
+        /// @brief Adds a custom constructor to the type.
+        /// @param customConstructor Custom constructor to add.
+        /// @return Trait.
+        ConstructibleTrait&& withCustomConstructor(CustomConstructor customConstructor) &&;
+
+        /// @brief Adds a custom constructor to the type.
+        /// @param customConstructor Custom constructor to add.
+        void addCustomConstructor(CustomConstructor customConstructor);
+
+        /// @brief Adds a custom constructor to the type.
+        /// @tparam Args Argument types of the constructor.
+        /// @param argNames Names of the arguments to the constructor.
+        template <typename T, typename... Args>
+        void addCustomConstructor(std::initializer_list<std::string> argNames)
+        {
+            addCustomConstructor(CustomConstructor({&reflect<Args>()...}, argNames, [](void* instance, void** args) {
+                auto callConstructor = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+                    new (instance) T(*static_cast<Args*>(args[Is])...);
+                };
+                callConstructor(std::index_sequence_for<Args...>());
+            }));
+        }
+
         /// @brief Returns the size of the type in bytes.
         /// @return Size of the type in bytes.
         std::size_t size() const;
@@ -92,6 +167,10 @@ namespace cubos::core::reflection
         /// @brief Checks if move construction is supported.
         /// @return Whether the operation is supported.
         bool hasMoveConstruct() const;
+
+        /// @brief Returns the number of custom constructors.
+        /// @return Number of custom constructors.
+        std::size_t customConstructorCount() const;
 
         /// @brief Destructs an instance of the type.
         /// @param instance Pointer to the instance to destruct.
@@ -114,6 +193,13 @@ namespace cubos::core::reflection
         /// @param other Pointer to the instance to move construct from.
         void moveConstruct(void* instance, void* other) const;
 
+        /// @brief Calls a custom constructor.
+        /// @note Aborts if the index is out of bounds.
+        /// @param index Index of the custom constructor to call.
+        /// @param instance Pointer to the location to construct the instance at.
+        /// @param args Array of pointers to the arguments to pass to the constructor.
+        void customConstruct(std::size_t index, void* instance, void** args) const;
+
         /// @brief Gets the destructor of the type.
         /// @return Destructor of the type.
         Destructor destructor() const;
@@ -130,6 +216,11 @@ namespace cubos::core::reflection
         /// @return Move constructor of the type.
         MoveConstructor moveConstructor() const;
 
+        /// @brief Gets the custom constructor of the type.
+        /// @param index Index of the custom constructor.
+        /// @return Custom constructor of the type.
+        const CustomConstructor& customConstructor(std::size_t index) const;
+
     private:
         std::size_t mSize;
         std::size_t mAlignment;
@@ -137,6 +228,7 @@ namespace cubos::core::reflection
         DefaultConstructor mDefaultConstructor{};
         CopyConstructor mCopyConstructor{};
         MoveConstructor mMoveConstructor{};
+        std::vector<CustomConstructor> mCustomConstructors{};
     };
 
     template <typename T>
@@ -149,6 +241,12 @@ namespace cubos::core::reflection
         {
         }
 
+        /// @brief Constructs.
+        Builder(ConstructibleTrait trait)
+            : mTrait(memory::move(trait))
+        {
+        }
+
         /// @brief Returns the constructed trait.
         /// @return Constructed trait.
         ConstructibleTrait build() &&
@@ -158,35 +256,43 @@ namespace cubos::core::reflection
 
         /// @brief Sets the default constructor of the type.
         /// @return Builder.
-        Builder&& withDefaultConstructor() &&
+        Builder withDefaultConstructor() &&
         {
-            mTrait = memory::move(mTrait).withDefaultConstructor([](void* instance) { new (instance) T(); });
-            return memory::move(*this);
+            return {memory::move(mTrait).withDefaultConstructor([](void* instance) { new (instance) T(); })};
         }
 
         /// @brief Sets the copy constructor of the type.
         /// @return Builder.
-        Builder&& withCopyConstructor() &&
+        Builder withCopyConstructor() &&
         {
-            mTrait = memory::move(mTrait).withCopyConstructor(
-                [](void* instance, const void* other) { new (instance) T(*static_cast<const T*>(other)); });
-            return memory::move(*this);
+            return {memory::move(mTrait).withCopyConstructor(
+                [](void* instance, const void* other) { new (instance) T(*static_cast<const T*>(other)); })};
         }
 
         /// @brief Sets the move constructor of the type.
         /// @return Builder.
-        Builder&& withMoveConstructor() &&
+        Builder withMoveConstructor() &&
         {
-            mTrait = memory::move(mTrait).withMoveConstructor(
-                [](void* instance, void* other) { new (instance) T(memory::move(*static_cast<T*>(other))); });
-            return memory::move(*this);
+            return {memory::move(mTrait).withMoveConstructor(
+                [](void* instance, void* other) { new (instance) T(memory::move(*static_cast<T*>(other))); })};
         }
 
         /// @brief Sets the default, copy and move constructors of the type.
         /// @return Builder.
-        Builder&& withBasicConstructors() &&
+        Builder withBasicConstructors() &&
         {
             return memory::move(*this).withDefaultConstructor().withCopyConstructor().withMoveConstructor();
+        }
+
+        /// @brief Adds a custom constructor to the type.
+        /// @tparam Argument types of the arguments to the constructor.
+        /// @param argNames Names of the arguments to the constructor.
+        /// @return Builder.
+        template <typename... Args>
+        Builder withCustomConstructor(std::initializer_list<std::string> argNames) &&
+        {
+            mTrait.addCustomConstructor<T, Args...>(argNames);
+            return memory::move(*this);
         }
 
     private:

--- a/core/samples/reflection/traits/constructible/main.cpp
+++ b/core/samples/reflection/traits/constructible/main.cpp
@@ -7,10 +7,17 @@ struct Scale
 {
     CUBOS_REFLECT;
     float value = 1.0F;
+
+    Scale() = default;
+    Scale(float value)
+        : value(value)
+    {
+    }
 };
 /// [Scale declaration]
 
 /// [Scale definition]
+#include <cubos/core/reflection/external/primitives.hpp>
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/type.hpp>
 
@@ -19,15 +26,16 @@ using cubos::core::reflection::Type;
 
 CUBOS_REFLECT_IMPL(Scale)
 {
-    return Type::create("Scale").with(ConstructibleTrait::typed<Scale>().withDefaultConstructor().build());
+    return Type::create("Scale").with(
+        ConstructibleTrait::typed<Scale>().withDefaultConstructor().withCustomConstructor<float>({"value"}).build());
 }
 /// [Scale definition]
 
-/// [Accessing the trait]
 int main()
 {
     using cubos::core::reflection::reflect;
 
+    /// [Accessing the trait]
     const auto& scaleType = reflect<Scale>();
     CUBOS_ASSERT(scaleType.has<ConstructibleTrait>());
     const auto& constructible = scaleType.get<ConstructibleTrait>();
@@ -43,6 +51,20 @@ int main()
     /// [Destroying the instance]
     // Destroy the instance and deallocate its memory.
     constructible.destruct(instance);
+    /// [Destroying the instance]
+
+    /// [Creating a custom instance]
+    CUBOS_ASSERT(constructible.customConstructorCount() == 1);
+    CUBOS_ASSERT(constructible.customConstructor(0).argCount() == 1);
+    CUBOS_ASSERT(constructible.customConstructor(0).argName(0) == "value");
+    CUBOS_ASSERT(constructible.customConstructor(0).argType(0).is<float>());
+
+    float value = 2.0F;
+    void* args[] = {&value};
+    constructible.customConstruct(0, instance, args);
+    CUBOS_ASSERT(static_cast<Scale*>(instance)->value == 2.0F);
+    /// [Creating a custom instance]
+
+    constructible.destruct(instance);
     operator delete(instance);
 }
-/// [Destroying the instance]

--- a/core/samples/reflection/traits/constructible/page.md
+++ b/core/samples/reflection/traits/constructible/page.md
@@ -35,4 +35,10 @@ Don't forget to destroy the instance manually when you're done with it:
 
 @snippet reflection/traits/constructible/main.cpp Destroying the instance
 
+The constructible trait always stores the destructor of a type, and may
+optionally contain any of the basic constructors (default, copy and move), or
+even arbitrary custom constructors, which receive arguments of reflectable
+types. For example, below, we're calling the custom constructor we previously
+reflected.
 
+@snippet reflection/traits/constructible/main.cpp Creating a custom instance

--- a/engine/samples/imgui/main.cpp
+++ b/engine/samples/imgui/main.cpp
@@ -50,15 +50,32 @@ CUBOS_REFLECT_IMPL(MyUnsupported)
 struct MyStruct
 {
     CUBOS_REFLECT;
-    int foo{3};
-    float bar{0.14F};
+
+    int integer{};
+    float fract{};
+
+    MyStruct(int integer = 3, float fract = 0.14F)
+        : integer(integer)
+        , fract(fract)
+    {
+    }
+
+    MyStruct(float number)
+    {
+        integer = static_cast<int>(number);
+        fract = number - static_cast<float>(integer);
+    }
 };
 
 CUBOS_REFLECT_IMPL(MyStruct)
 {
     return Type::create("MyStruct")
-        .with(FieldsTrait{}.withField("foo", &MyStruct::foo).withField("bar", &MyStruct::bar))
-        .with(ConstructibleTrait::typed<MyStruct>().withBasicConstructors().build());
+        .with(FieldsTrait{}.withField("integer", &MyStruct::integer).withField("fract", &MyStruct::fract))
+        .with(ConstructibleTrait::typed<MyStruct>()
+                  .withBasicConstructors()
+                  .withCustomConstructor<int, float>({"integer", "fract"})
+                  .withCustomConstructor<float>({"number"})
+                  .build());
 }
 
 enum class MyEnum


### PR DESCRIPTION
# Description

This PR adds custom constructors to the ConstructibleTrait, which means we can now reflect constructors other than the default, copy and move constructors.
This will be useful for components like `Mass`, which are meant to be modified through their constructors.
I've also added a hook to the ImGui inspector which catches these types and adds a button, which when clicked, opens a popup that allows calling that type's constructors.

![image](https://github.com/user-attachments/assets/191059cc-5b28-4af4-856b-3f7ac91c5d2e)



![image](https://github.com/user-attachments/assets/c50b7124-45ca-42a2-ace5-d0e88ae70d09)



![image](https://github.com/user-attachments/assets/a3da05fe-e720-4904-8d72-c47c565c3152)



![image](https://github.com/user-attachments/assets/ad7eb81d-389e-4f69-a320-f805fe0033fd)


## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
