### PR TITLE
Allow gizmos to be drawn for specific cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly match the entity components to the entity in the penetration constraint solving (**@fallenatlas**).
 - Correctly compute the local collision point for voxel shapes (**@fallenatlas**).
 - Creation of CollidingWith relation between box and voxel shapes when only the AABBs intersect (**@fallenatlas**).
+- Missing renderDepthPlugin in Gizmos sample (**@tomas7770**).
 
 ## [v0.7.0] - 2025-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly compute the local collision point for voxel shapes (**@fallenatlas**).
 - Creation of CollidingWith relation between box and voxel shapes when only the AABBs intersect (**@fallenatlas**).
 - Missing renderDepthPlugin in Gizmos sample (**@tomas7770**).
+- Clear picker depth in Gizmos plugin if not already cleared (**@tomas7770**).
 
 ## [v0.7.0] - 2025-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Constant type reflection support with a new Constant trait (#1507, **@RiscadoA**).
 - Constant trait handler to the ImGui inspector (#1507, **@RiscadoA**).
 - Toggle for matrix decomposition to the inspector (#1521, **@RiscadoA**).
+- Allow gizmos to be drawn for specific cameras (#1402, **@tomas7770**).
 
 ### Changed
 
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing renderDepthPlugin in Gizmos sample (**@tomas7770**).
 - Clear picker depth in Gizmos plugin if not already cleared (**@tomas7770**).
 - Only draw gizmos to active cameras (**@tomas7770**).
+- Transform Gizmos rendered in wrong location when splitting the screen (#1148, **@tomas7770**).
 
 ## [v0.7.0] - 2025-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Creation of CollidingWith relation between box and voxel shapes when only the AABBs intersect (**@fallenatlas**).
 - Missing renderDepthPlugin in Gizmos sample (**@tomas7770**).
 - Clear picker depth in Gizmos plugin if not already cleared (**@tomas7770**).
+- Only draw gizmos to active cameras (**@tomas7770**).
 
 ## [v0.7.0] - 2025-05-03
 

--- a/engine/include/cubos/engine/gizmos/gizmos.hpp
+++ b/engine/include/cubos/engine/gizmos/gizmos.hpp
@@ -41,29 +41,35 @@ namespace cubos::engine
         /// @param id Identifier of the gizmo.
         /// @param from One of the ends of the line to be drawn.
         /// @param to The other end of the line to be drawn.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
-        void drawLine(const std::string& id, glm::vec3 from, glm::vec3 to, float lifespan = 0.0F,
+        void drawLine(const std::string& id, glm::vec3 from, glm::vec3 to,
+                      const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
                       Space space = Space::World);
 
         /// @brief Draws a filled box gizmo.
         /// @param id Identifier of the gizmo.
         /// @param corner One of the corners of the box to be drawn.
         /// @param oppositeCorner The opposite corner of the box to be drawn.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
-        void drawBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner, float lifespan = 0.0F,
+        void drawBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner,
+                     const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
                      Space space = Space::World);
 
         /// @brief Draws a filled box gizmo.
         /// @param id Identifier of the gizmo.
         /// @param transform Transformation matrix to apply to a unit-sized box centered at the origin.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
-        void drawBox(const std::string& id, const glm::mat4& transform, float lifespan = 0.0F,
+        void drawBox(const std::string& id, const glm::mat4& transform,
+                     const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
                      Space space = Space::World);
 
         /// @brief Draws a cut cone gizmo.
@@ -72,11 +78,13 @@ namespace cubos::engine
         /// @param firstBaseRadius Radius of one of the bases.
         /// @param secondBaseCenter Center of the second base.
         /// @param secondBaseRadius Radius of the second base.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
         void drawCutCone(const std::string& id, glm::vec3 firstBaseCenter, float firstBaseRadius,
-                         glm::vec3 secondBaseCenter, float secondBaseRadius, float lifespan = 0.0F,
+                         glm::vec3 secondBaseCenter, float secondBaseRadius,
+                         const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
                          Space space = Space::World);
 
         /// @brief Draws a ring gizmo.
@@ -85,11 +93,13 @@ namespace cubos::engine
         /// @param secondBasePosition Center of the second base.
         /// @param outerRadius Radius of one of the ring.
         /// @param innerRadius Radius of the of the hole.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
         void drawRing(const std::string& id, glm::vec3 firstBasePosition, glm::vec3 secondBasePosition,
-                      float outerRadius, float innerRadius, float lifespan = 0.0F, Space space = Space::World);
+                      float outerRadius, float innerRadius, const std::vector<core::ecs::Entity>& drawCameras = {},
+                      float lifespan = 0.0F, Space space = Space::World);
 
         /// @brief Draws an arrow gizmo.
         /// @param id Identifier of the gizmo.
@@ -98,29 +108,35 @@ namespace cubos::engine
         /// @param girth Radius of the cylinder part of the arrow.
         /// @param width Radius of the base of the cone at the tip of the arrow.
         /// @param ratio Point of the arrow at which the cylinder ends and the cone begins.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
         void drawArrow(const std::string& id, glm::vec3 origin, glm::vec3 direction, float girth, float width,
-                       float ratio = 0.F, float lifespan = 0.0F, Space space = Space::World);
+                       float ratio = 0.F, const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
+                       Space space = Space::World);
 
         /// @brief Draws a wireframe box gizmo.
         /// @param id Identifier of the gizmo.
         /// @param corner One of the corners of the box to be drawn.
         /// @param oppositeCorner The opposite corner of the box to be drawn.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
-        void drawWireBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner, float lifespan = 0.0F,
+        void drawWireBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner,
+                         const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
                          Space space = Space::World);
 
         /// @brief Draws a wireframe box gizmo.
         /// @param id Identifier of the gizmo.
         /// @param transform Transformation matrix to apply to a unit-sized box centered at the origin.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         /// @param lifespan How long the line will be on screen for, in seconds. Defaults to 0, which means a single
         /// frame.
         /// @param space Space to draw the gizmo in.
-        void drawWireBox(const std::string& id, const glm::mat4& transform, float lifespan = 0.0F,
+        void drawWireBox(const std::string& id, const glm::mat4& transform,
+                         const std::vector<core::ecs::Entity>& drawCameras = {}, float lifespan = 0.0F,
                          Space space = Space::World);
 
         /// @brief Checks whether the left mouse button was pressed over a gizmo.
@@ -162,7 +178,7 @@ namespace cubos::engine
 
             virtual ~Gizmo() = default;
 
-            Gizmo(uint32_t id, glm::vec3 color, float lifespan);
+            Gizmo(uint32_t id, glm::vec3 color, float lifespan, std::vector<core::ecs::Entity> drawCameras);
 
             /// @brief Draws the gizmo to screen.
             /// @param renderer Renderer.
@@ -175,6 +191,9 @@ namespace cubos::engine
             bool decreaseLifespan(float delta);
 
             const uint32_t id; ///< Gizmo identifier.
+
+            std::vector<core::ecs::Entity>
+                drawCameras; ///< List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
 
         protected:
             glm::vec3 mColor; ///< Color of the gizmo.

--- a/engine/samples/collisions/main.cpp
+++ b/engine/samples/collisions/main.cpp
@@ -236,7 +236,7 @@ int main(int argc, char** argv)
                     {
                         glm::vec3 origin = ent1 == collidingWith.entity ? pos1.vec : pos2.vec;
                         gizmos.color({0.0F, 1.0F, 0.0F});
-                        gizmos.drawArrow("arrow", origin, manifold.normal, 0.01F, 0.05F, 0.7F, 0.05F,
+                        gizmos.drawArrow("arrow", origin, manifold.normal, 0.01F, 0.05F, 0.7F, {}, 0.05F,
                                          Gizmos::Space::World);
                     }
 
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
                         {
                             gizmos.color({1.0F, 1.0F, 0.0F});
                             gizmos.drawArrow("line", start.globalOn1, end.globalOn1 - start.globalOn1, 0.01F, 0.05F,
-                                             1.0F, 0.05F, Gizmos::Space::World);
+                                             1.0F, {}, 0.05F, Gizmos::Space::World);
                             start = end;
                         }
                     }
@@ -260,11 +260,11 @@ int main(int argc, char** argv)
                             bool isEnt1 = ent1 == collidingWith.entity;
                             gizmos.color((isEnt1 ? glm::vec3(0.0F, 0.0F, 1.0F) : glm::vec3(1.0F, 0.0F, 1.0F)));
                             gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F,
-                                             1.0F, 0.05F, Gizmos::Space::World);
+                                             1.0F, {}, 0.05F, Gizmos::Space::World);
 
                             gizmos.color((isEnt1 ? glm::vec3(1.0F, 0.0F, 1.0F) : glm::vec3(0.0F, 0.0F, 1.0F)));
                             gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 0.03F, 0.05F,
-                                             1.0F, 0.05F, Gizmos::Space::World);
+                                             1.0F, {}, 0.05F, Gizmos::Space::World);
                         }
                     }
                 }

--- a/engine/samples/gizmos/main.cpp
+++ b/engine/samples/gizmos/main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
     /// [Start Up System]
     cubos.startupSystem("draw line at startup").after(gizmosInitTag).call([](Gizmos& gizmos) {
         gizmos.color({1, 0, 1});
-        gizmos.drawArrow("arrow", {0.6F, 0.6F, 0.0F}, {-0.1F, -0.1F, 0.0F}, 0.003F, 0.009F, 0.7F, 10.0F,
+        gizmos.drawArrow("arrow", {0.6F, 0.6F, 0.0F}, {-0.1F, -0.1F, 0.0F}, 0.003F, 0.009F, 0.7F, {}, 10.0F,
                          Gizmos::Space::Screen);
     });
     /// [Start Up System]
@@ -92,18 +92,18 @@ int main(int argc, char** argv)
     cubos.system("draw gizmos").call([](Gizmos& gizmos) {
         /// [Lines]
         gizmos.color({1.0F, 1.0F, 1.0F});
-        gizmos.drawLine("separator line", {1.0F, 0.5F, 0.5F}, {0.0F, 0.5F, 0.5F}, 0, Gizmos::Space::Screen);
-        gizmos.drawLine("separator line", {0.5F, 1.0F, 0.5F}, {0.5F, 0.0F, 0.5F}, 0, Gizmos::Space::Screen);
+        gizmos.drawLine("separator line", {1.0F, 0.5F, 0.5F}, {0.0F, 0.5F, 0.5F}, {}, 0, Gizmos::Space::Screen);
+        gizmos.drawLine("separator line", {0.5F, 1.0F, 0.5F}, {0.5F, 0.0F, 0.5F}, {}, 0, Gizmos::Space::Screen);
         /// [Lines]
 
         /// [WireBox]
         gizmos.color({1.0F, 0.5F, 1.0F});
-        gizmos.drawBox("box", {0.4, 0.4, 0}, {0.55, 0.55, 0}, 0, Gizmos::Space::View);
+        gizmos.drawBox("box", {0.4, 0.4, 0}, {0.55, 0.55, 0}, {}, 0, Gizmos::Space::View);
         /// [WireBox]
 
         /// [Box]
         gizmos.color({0.2F, 0.2F, 1.0F});
-        gizmos.drawWireBox("wire box", {-5, -5, -5}, {-7, -7, -7}, 0, Gizmos::Space::World);
+        gizmos.drawWireBox("wire box", {-5, -5, -5}, {-7, -7, -7}, {}, 0, Gizmos::Space::World);
         /// [Box]
 
         ///[Cut Cone]
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
             gizmos.color({0.1F, 0.05F, 0.25F});
         }
 
-        gizmos.drawCutCone("cut cone", {0.7F, 0.7F, 0.7F}, 5.0F, {-3, -3, -3}, 3.0F, 0, Gizmos::Space::World);
+        gizmos.drawCutCone("cut cone", {0.7F, 0.7F, 0.7F}, 5.0F, {-3, -3, -3}, 3.0F, {}, 0, Gizmos::Space::World);
         ///[Cut Cone]
     });
     /// [System]

--- a/engine/samples/gizmos/main.cpp
+++ b/engine/samples/gizmos/main.cpp
@@ -5,6 +5,8 @@
 #include <cubos/engine/render/camera/draws_to.hpp>
 #include <cubos/engine/render/camera/perspective.hpp>
 #include <cubos/engine/render/camera/plugin.hpp>
+#include <cubos/engine/render/depth/depth.hpp>
+#include <cubos/engine/render/depth/plugin.hpp>
 #include <cubos/engine/render/picker/picker.hpp>
 #include <cubos/engine/render/picker/plugin.hpp>
 #include <cubos/engine/render/split_screen/plugin.hpp>
@@ -26,6 +28,7 @@ int main(int argc, char** argv)
     cubos.plugin(transformPlugin);
     cubos.plugin(renderTargetPlugin);
     cubos.plugin(renderPickerPlugin);
+    cubos.plugin(renderDepthPlugin);
     cubos.plugin(cameraPlugin);
     cubos.plugin(splitScreenPlugin);
 
@@ -34,8 +37,13 @@ int main(int argc, char** argv)
     /// [Adding plugin]
 
     cubos.startupSystem("setup render target and cameras").call([](Commands cmds) {
-        auto target =
-            cmds.create().add(RenderTarget{}).add(RenderPicker{}).add(GizmosTarget{}).add(SplitScreen{}).entity();
+        auto target = cmds.create()
+                          .add(RenderTarget{})
+                          .add(RenderPicker{})
+                          .add(RenderDepth{})
+                          .add(GizmosTarget{})
+                          .add(SplitScreen{})
+                          .entity();
 
         cmds.create()
             .relatedTo(target, DrawsTo{})

--- a/engine/samples/voxel-shape-collisions/main.cpp
+++ b/engine/samples/voxel-shape-collisions/main.cpp
@@ -191,7 +191,7 @@ int main()
                     {
                         glm::vec3 origin = ent1 == collidingWith.entity ? pos1.vec : pos2.vec;
                         gizmos.color({0.0F, 1.0F, 0.0F});
-                        gizmos.drawArrow("arrow", origin, manifold.normal, 0.1F, 0.5F, 0.7F, 0.05F,
+                        gizmos.drawArrow("arrow", origin, manifold.normal, 0.1F, 0.5F, 0.7F, {}, 0.05F,
                                          Gizmos::Space::World);
                     }
 
@@ -202,7 +202,7 @@ int main()
                         {
                             gizmos.color({1.0F, 1.0F, 0.0F});
                             gizmos.drawArrow("line", start.globalOn1, end.globalOn1 - start.globalOn1, 1.0F, 1.2F, 1.0F,
-                                             0.05F, Gizmos::Space::World);
+                                             {}, 0.05F, Gizmos::Space::World);
                             start = end;
                         }
                     }
@@ -213,11 +213,11 @@ int main()
                         {
                             gizmos.color({0.0F, 0.0F, 1.0F});
                             gizmos.drawArrow("point", point.globalOn1, glm::vec3(0.02F, 0.02F, 0.02F), 1.0F, 1.0F, 1.0F,
-                                             0.05F, Gizmos::Space::World);
+                                             {}, 0.05F, Gizmos::Space::World);
 
                             gizmos.color({1.0F, 0.0F, 1.0F});
                             gizmos.drawArrow("point", point.globalOn2, glm::vec3(0.02F, 0.02F, 0.02F), 1.0F, 1.0F, 1.0F,
-                                             0.05F, Gizmos::Space::World);
+                                             {}, 0.05F, Gizmos::Space::World);
                         }
                     }
                 }

--- a/engine/src/gizmos/gizmos.cpp
+++ b/engine/src/gizmos/gizmos.cpp
@@ -24,8 +24,9 @@ CUBOS_REFLECT_IMPL(Gizmos)
     return core::ecs::TypeBuilder<Gizmos>("cubos::engine::Gizmos").build();
 }
 
-Gizmos::Gizmo::Gizmo(uint32_t id, glm::vec3 color, float lifespan)
+Gizmos::Gizmo::Gizmo(uint32_t id, glm::vec3 color, float lifespan, std::vector<core::ecs::Entity> drawCameras)
     : id(id)
+    , drawCameras(std::move(drawCameras))
     , mColor(color)
     , mLifespan(lifespan)
 {
@@ -98,34 +99,39 @@ uint32_t Gizmos::mHasher(const std::string& id)
     return hash;
 }
 
-void Gizmos::drawLine(const std::string& id, glm::vec3 from, glm::vec3 to, float lifespan, Space space)
+void Gizmos::drawLine(const std::string& id, glm::vec3 from, glm::vec3 to,
+                      const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
-    push(std::make_shared<LineGizmo>((uint32_t)mHasher(id), from, to, mColor, lifespan), space);
+    push(std::make_shared<LineGizmo>((uint32_t)mHasher(id), from, to, mColor, lifespan, drawCameras), space);
 }
 
-void Gizmos::drawBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner, float lifespan, Space space)
+void Gizmos::drawBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner,
+                     const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
     push(std::make_shared<BoxGizmo>((uint32_t)mHasher(id), corner, oppositeCorner, glm::identity<glm::mat4>(), mColor,
-                                    lifespan),
+                                    lifespan, drawCameras),
          space);
 }
 
-void Gizmos::drawBox(const std::string& id, const glm::mat4& transform, float lifespan, Space space)
+void Gizmos::drawBox(const std::string& id, const glm::mat4& transform,
+                     const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
     push(std::make_shared<BoxGizmo>((uint32_t)mHasher(id), glm::vec3{-0.5F, -0.5F, -0.5F}, glm::vec3{0.5F, 0.5F, 0.5F},
-                                    transform, mColor, lifespan),
+                                    transform, mColor, lifespan, drawCameras),
          space);
 }
 
-void Gizmos::drawWireBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner, float lifespan, Space space)
+void Gizmos::drawWireBox(const std::string& id, glm::vec3 corner, glm::vec3 oppositeCorner,
+                         const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
     auto size = oppositeCorner - corner;
     auto center = corner + size * 0.5F;
     auto transform = glm::scale(glm::translate(glm::mat4{1.0F}, center), size);
-    this->drawWireBox(id, transform, lifespan, space);
+    this->drawWireBox(id, transform, drawCameras, lifespan, space);
 }
 
-void Gizmos::drawWireBox(const std::string& id, const glm::mat4& transform, float lifespan, Space space)
+void Gizmos::drawWireBox(const std::string& id, const glm::mat4& transform,
+                         const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
     glm::vec3 corners[8] = {
         {-0.5F, -0.5F, -0.5F}, {0.5F, -0.5F, -0.5F}, {0.5F, 0.5F, -0.5F}, {-0.5F, 0.5F, -0.5F},
@@ -139,42 +145,44 @@ void Gizmos::drawWireBox(const std::string& id, const glm::mat4& transform, floa
     }
 
     // Draw edges.
-    drawLine(id, corners[0], corners[1], lifespan, space);
-    drawLine(id, corners[1], corners[2], lifespan, space);
-    drawLine(id, corners[2], corners[3], lifespan, space);
-    drawLine(id, corners[3], corners[0], lifespan, space);
+    drawLine(id, corners[0], corners[1], drawCameras, lifespan, space);
+    drawLine(id, corners[1], corners[2], drawCameras, lifespan, space);
+    drawLine(id, corners[2], corners[3], drawCameras, lifespan, space);
+    drawLine(id, corners[3], corners[0], drawCameras, lifespan, space);
 
-    drawLine(id, corners[4], corners[5], lifespan, space);
-    drawLine(id, corners[5], corners[6], lifespan, space);
-    drawLine(id, corners[6], corners[7], lifespan, space);
-    drawLine(id, corners[7], corners[4], lifespan, space);
+    drawLine(id, corners[4], corners[5], drawCameras, lifespan, space);
+    drawLine(id, corners[5], corners[6], drawCameras, lifespan, space);
+    drawLine(id, corners[6], corners[7], drawCameras, lifespan, space);
+    drawLine(id, corners[7], corners[4], drawCameras, lifespan, space);
 
-    drawLine(id, corners[0], corners[4], lifespan, space);
-    drawLine(id, corners[1], corners[5], lifespan, space);
-    drawLine(id, corners[2], corners[6], lifespan, space);
-    drawLine(id, corners[3], corners[7], lifespan, space);
+    drawLine(id, corners[0], corners[4], drawCameras, lifespan, space);
+    drawLine(id, corners[1], corners[5], drawCameras, lifespan, space);
+    drawLine(id, corners[2], corners[6], drawCameras, lifespan, space);
+    drawLine(id, corners[3], corners[7], drawCameras, lifespan, space);
 }
 
 void Gizmos::drawCutCone(const std::string& id, glm::vec3 firstBaseCenter, float firstBaseRadius,
-                         glm::vec3 secondBaseCenter, float secondBaseRadius, float lifespan, Space space)
+                         glm::vec3 secondBaseCenter, float secondBaseRadius,
+                         const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
     push(std::make_shared<CutConeGizmo>((uint32_t)mHasher(id), firstBaseCenter, firstBaseRadius, secondBaseCenter,
-                                        secondBaseRadius, mColor, lifespan),
+                                        secondBaseRadius, mColor, lifespan, drawCameras),
          space);
 }
 
 void Gizmos::drawRing(const std::string& id, glm::vec3 firstBasePosition, glm::vec3 secondBasePosition,
-                      float outerRadius, float innerRadius, float lifespan, Space space)
+                      float outerRadius, float innerRadius, const std::vector<core::ecs::Entity>& drawCameras,
+                      float lifespan, Space space)
 {
     push(std::make_shared<RingGizmo>((uint32_t)mHasher(id), firstBasePosition, secondBasePosition, outerRadius,
-                                     innerRadius, mColor, lifespan),
+                                     innerRadius, mColor, lifespan, drawCameras),
          space);
 }
 
 void Gizmos::drawArrow(const std::string& id, glm::vec3 origin, glm::vec3 direction, float girth, float width,
-                       float ratio, float lifespan, Space space)
+                       float ratio, const std::vector<core::ecs::Entity>& drawCameras, float lifespan, Space space)
 {
     auto p = direction * ratio;
-    drawCutCone(id, origin, girth, origin + p, girth, lifespan, space);
-    drawCutCone(id, origin + p, width, origin + direction, 0.0F, lifespan, space);
+    drawCutCone(id, origin, girth, origin + p, girth, drawCameras, lifespan, space);
+    drawCutCone(id, origin + p, width, origin + direction, 0.0F, drawCameras, lifespan, space);
 }

--- a/engine/src/gizmos/plugin.cpp
+++ b/engine/src/gizmos/plugin.cpp
@@ -109,7 +109,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
         .tagged(drawToRenderPickerTag)
         .call([](Gizmos& gizmos, GizmosRenderer& gizmosRenderer, const DeltaTime& deltaTime,
                  Query<Entity, RenderTarget&, Opt<RenderPicker&>, RenderDepth&, GizmosTarget&> targets,
-                 Query<const LocalToWorld&, const Camera&, const DrawsTo&> cameras) {
+                 Query<Entity, const LocalToWorld&, const Camera&, const DrawsTo&> cameras) {
             auto& rd = *gizmosRenderer.renderDevice;
             auto orthoVP =
                 glm::translate(glm::mat4(1.0F), glm::vec3(-1.0F, -1.0F, 0.0F)) * glm::ortho(-0.5F, 0.5F, -0.5F, 0.5F);
@@ -152,7 +152,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                 rd.setShaderPipeline(gizmosRenderer.drawPipeline);
 
                 // Draw world and view-space gizmos.
-                for (auto [localToWorld, camera, drawsTo] : cameras.pin(1, targetEnt))
+                for (auto [cameraEntity, localToWorld, camera, drawsTo] : cameras.pin(1, targetEnt))
                 {
                     if (!camera.active)
                     {
@@ -176,14 +176,24 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                     rd.setDepthStencilState(gizmosRenderer.doDepthCheckStencilState);
                     for (auto& gizmo : gizmos.worldGizmos)
                     {
-                        gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Color, worldVP);
+                        if (gizmo->drawCameras.empty() ||
+                            std::find(gizmo->drawCameras.begin(), gizmo->drawCameras.end(), cameraEntity) !=
+                                gizmo->drawCameras.end())
+                        {
+                            gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Color, worldVP);
+                        }
                     }
 
                     // Draw view-space gizmos.
                     rd.setDepthStencilState(gizmosRenderer.noDepthCheckStencilState);
                     for (auto& gizmo : gizmos.viewGizmos)
                     {
-                        gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Color, orthoVP);
+                        if (gizmo->drawCameras.empty() ||
+                            std::find(gizmo->drawCameras.begin(), gizmo->drawCameras.end(), cameraEntity) !=
+                                gizmo->drawCameras.end())
+                        {
+                            gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Color, orthoVP);
+                        }
                     }
                 }
 
@@ -212,7 +222,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                 auto* idBP = gizmosRenderer.idPipeline->getBindingPoint("gizmo");
 
                 // Draw world and view-space gizmos.
-                for (auto [localToWorld, camera, drawsTo] : cameras.pin(1, targetEnt))
+                for (auto [cameraEntity, localToWorld, camera, drawsTo] : cameras.pin(1, targetEnt))
                 {
                     if (!camera.active)
                     {
@@ -236,16 +246,26 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                     rd.setDepthStencilState(gizmosRenderer.doDepthCheckStencilState);
                     for (auto& gizmo : gizmos.worldGizmos)
                     {
-                        idBP->setConstant(gizmo->id);
-                        gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Id, worldVP);
+                        if (gizmo->drawCameras.empty() ||
+                            std::find(gizmo->drawCameras.begin(), gizmo->drawCameras.end(), cameraEntity) !=
+                                gizmo->drawCameras.end())
+                        {
+                            idBP->setConstant(gizmo->id);
+                            gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Id, worldVP);
+                        }
                     }
 
                     // Draw view-space gizmos.
                     rd.setDepthStencilState(gizmosRenderer.noDepthCheckStencilState);
                     for (auto& gizmo : gizmos.viewGizmos)
                     {
-                        idBP->setConstant(gizmo->id);
-                        gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Id, orthoVP);
+                        if (gizmo->drawCameras.empty() ||
+                            std::find(gizmo->drawCameras.begin(), gizmo->drawCameras.end(), cameraEntity) !=
+                                gizmo->drawCameras.end())
+                        {
+                            idBP->setConstant(gizmo->id);
+                            gizmo->draw(gizmosRenderer, Gizmos::Gizmo::DrawPhase::Id, orthoVP);
+                        }
                     }
                 }
 

--- a/engine/src/gizmos/plugin.cpp
+++ b/engine/src/gizmos/plugin.cpp
@@ -154,6 +154,11 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                 // Draw world and view-space gizmos.
                 for (auto [localToWorld, camera, drawsTo] : cameras.pin(1, targetEnt))
                 {
+                    if (!camera.active)
+                    {
+                        continue;
+                    }
+
                     // Prepare the viewport and scissor rectangles.
                     rd.setViewport(static_cast<int>(drawsTo.viewportOffset.x * static_cast<float>(target.size.x)),
                                    static_cast<int>(drawsTo.viewportOffset.y * static_cast<float>(target.size.y)),
@@ -209,6 +214,11 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                 // Draw world and view-space gizmos.
                 for (auto [localToWorld, camera, drawsTo] : cameras.pin(1, targetEnt))
                 {
+                    if (!camera.active)
+                    {
+                        continue;
+                    }
+
                     // Prepare the viewport and scissor rectangles.
                     rd.setViewport(static_cast<int>(drawsTo.viewportOffset.x * static_cast<float>(target.size.x)),
                                    static_cast<int>(drawsTo.viewportOffset.y * static_cast<float>(target.size.y)),

--- a/engine/src/gizmos/plugin.cpp
+++ b/engine/src/gizmos/plugin.cpp
@@ -200,6 +200,7 @@ void cubos::engine::gizmosPlugin(Cubos& cubos)
                 if (!picker.value().cleared)
                 {
                     rd.clearTargetColor(0, UINT16_MAX, UINT16_MAX, 0, 0);
+                    rd.clearDepth(1.0F);
                     picker.value().cleared = true;
                 }
                 rd.setShaderPipeline(gizmosRenderer.idPipeline);

--- a/engine/src/gizmos/types/box.hpp
+++ b/engine/src/gizmos/types/box.hpp
@@ -22,9 +22,10 @@ namespace cubos::engine
         /// @param oppositeCorner Point at the opposite corner of the box.
         /// @param color Color for the gizmo to be drawn in.
         /// @param lifespan Time the gizmo will remain on screen, in seconds.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         BoxGizmo(uint32_t id, glm::vec3 corner, glm::vec3 oppositeCorner, glm::mat4 transform, const glm::vec3& color,
-                 float lifespan)
-            : cubos::engine::Gizmos::Gizmo(id, color, lifespan)
+                 float lifespan, std::vector<core::ecs::Entity> drawCameras)
+            : cubos::engine::Gizmos::Gizmo(id, color, lifespan, std::move(drawCameras))
             , mPointA(corner)
             , mPointB(oppositeCorner)
             , mTransform(transform)

--- a/engine/src/gizmos/types/cut_cone.hpp
+++ b/engine/src/gizmos/types/cut_cone.hpp
@@ -26,9 +26,11 @@ namespace cubos::engine
         /// @param secondBaseRadius Radius of the second base.
         /// @param color Color for the gizmo to be drawn in.
         /// @param lifespan Time the gizmo will remain on screen, in seconds.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         CutConeGizmo(uint32_t id, glm::vec3 firstBaseCenter, float firstBaseRadius, glm::vec3 secondBaseCenter,
-                     float secondBaseRadius, const glm::vec3& color, float lifespan)
-            : Gizmos::Gizmo(id, color, lifespan)
+                     float secondBaseRadius, const glm::vec3& color, float lifespan,
+                     std::vector<core::ecs::Entity> drawCameras)
+            : Gizmos::Gizmo(id, color, lifespan, std::move(drawCameras))
             , mPointA(firstBaseCenter)
             , mRadiusA(firstBaseRadius)
             , mPointB(secondBaseCenter)

--- a/engine/src/gizmos/types/line.hpp
+++ b/engine/src/gizmos/types/line.hpp
@@ -21,8 +21,10 @@ namespace cubos::engine
         /// @param to Point at the other end of the line.
         /// @param color Color for the gizmo to be drawn in.
         /// @param lifespan Time the gizmo will remain on screen, in seconds.
-        LineGizmo(uint32_t id, glm::vec3 from, glm::vec3 to, const glm::vec3& color, float lifespan)
-            : cubos::engine::Gizmos::Gizmo(id, color, lifespan)
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
+        LineGizmo(uint32_t id, glm::vec3 from, glm::vec3 to, const glm::vec3& color, float lifespan,
+                  std::vector<core::ecs::Entity> drawCameras)
+            : cubos::engine::Gizmos::Gizmo(id, color, lifespan, std::move(drawCameras))
             , mPointA(from)
             , mPointB(to)
         {

--- a/engine/src/gizmos/types/ring.hpp
+++ b/engine/src/gizmos/types/ring.hpp
@@ -26,9 +26,10 @@ namespace cubos::engine
         /// @param innerRadius Radius of the of the hole.
         /// @param color Color for the gizmo to be drawn in.
         /// @param lifespan Time the gizmo will remain on screen, in seconds.
+        /// @param drawCameras List of camera entities the gizmo will be drawn for. If empty, draws to all cameras.
         RingGizmo(uint32_t id, glm::vec3 firstBasePosition, glm::vec3 secondBasePosition, float outerRadius,
-                  float innerRadius, const glm::vec3& color, float lifespan)
-            : Gizmos::Gizmo(id, color, lifespan)
+                  float innerRadius, const glm::vec3& color, float lifespan, std::vector<core::ecs::Entity> drawCameras)
+            : Gizmos::Gizmo(id, color, lifespan, std::move(drawCameras))
             , mPointA(firstBasePosition)
             , mPointB(secondBasePosition)
             , mRadiusOuter(outerRadius)


### PR DESCRIPTION
# Description

Adds an option to specify which cameras to draw a gizmo for.
Also fixes other gizmos-related bugs.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
