### PR TITLE
feat(core): added named plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Constant trait handler to the ImGui inspector (#1507, **@RiscadoA**).
 - Toggle for matrix decomposition to the inspector (#1521, **@RiscadoA**).
 - Allow gizmos to be drawn for specific cameras (#1402, **@tomas7770**).
+- Named method for attributing a name to a plugin (#1556, **@mcanais**).
 
 ### Changed
 

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -116,6 +116,11 @@ namespace cubos::core::ecs
         /// @return Cubos.
         Cubos& depends(Plugin plugin);
 
+        /// @brief Sets the name of the current plugin to the given name.
+        ///
+        /// @param std::string name Plugin name.
+        void named(std::string name);
+
         /// @brief Marks the target plugin so that when it is added, it is replaced by the given plugin.
         ///
         /// Aborts if the target plugin has already been added.
@@ -274,6 +279,9 @@ namespace cubos::core::ecs
 
             /// @brief Observers which were added by this plugin.
             std::vector<ObserverId> observers;
+
+            /// @brief Name of the plugin.
+            std::string name;
         };
 
         /// @brief Stores information regarding a tag.

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -140,6 +140,18 @@ Cubos& Cubos::plugin(Plugin plugin)
     return *this;
 }
 
+void Cubos::named(std::string name)
+{
+    Plugin plugin = mPluginStack.back();
+
+    if (mInjectedPlugins.contains(plugin))
+    {
+        plugin = mInjectedPlugins.at(plugin);
+    }
+
+    mInstalledPlugins.at(plugin).name = std::move(name);
+}
+
 Cubos& Cubos::depends(Plugin plugin)
 {
     if (mInjectedPlugins.contains(plugin))

--- a/engine/src/transform/plugin.cpp
+++ b/engine/src/transform/plugin.cpp
@@ -24,6 +24,8 @@ void addComponent(Commands cmds, Query<Entity> query)
 
 void cubos::engine::transformPlugin(Cubos& cubos)
 {
+    cubos.named("cubos::engine::transformPlugin");
+
     cubos.component<Position>();
     cubos.component<Rotation>();
     cubos.component<Scale>();


### PR DESCRIPTION
# Description

Added a named method that allows to attribute a name to the current plugin. 
This feature is especially useful for scripting, because we can import a plugin by it's name at runtime.

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [ ] Write new samples.
- [x] Add entry to the changelog's unreleased section.
