### PR TITLE
feat: Allow generating metas with random UUIDs through Quadrados

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added possibility of creating basic systems in lua scripts (#1518, **@mkuritsu**)
 - Sane default placement for tools in tesseratos (#1387, **@jdbaracho**).
 - Layout structure with loading and ImGui application (#1387, **@jdbaracho**).
+- Allow generating metas with random UUIDs through Quadrados (#1441, **@Fkatar**)
 
 ### Changed
 

--- a/tools/quadrados/CMakeLists.txt
+++ b/tools/quadrados/CMakeLists.txt
@@ -14,6 +14,7 @@ set(QUADRADOS_SOURCE
     "src/convert.cpp"
     "src/init.cpp"
     "src/create.cpp"
+    "src/import.cpp"
 )
 
 # ------------------------ Configure quadrados target -------------------------

--- a/tools/quadrados/src/import.cpp
+++ b/tools/quadrados/src/import.cpp
@@ -1,0 +1,66 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+
+#include <uuid.h>
+
+#include "tools.hpp"
+
+namespace fs = std::filesystem;
+
+/// `import` command for `quadrados`:
+/// - Verifies the asset exists.
+/// - If `<asset>.meta` already exists, just reports.
+/// - Otherwise, generates a UUID, creates `<asset>.meta` with JSON:
+///   {
+///     "id": "<UUID>"
+///   }
+///
+/// @param argc Number of arguments passed after `import`.
+/// @param argv Array of argument strings.
+/// @param ga   Global arguments (not used here).
+/// @returns 0 on success, <0 on error.
+int runImport(int argc, char** argv, GlobalArgs& /*ga*/)
+{
+    if (argc != 1)
+    {
+        std::cerr << "Usage: quadrados import <file>\n";
+        return -1;
+    }
+
+    fs::path assetPath = argv[0];
+    if (!fs::exists(assetPath))
+    {
+        std::cerr << "Error: file does not exist: " << assetPath << "\n";
+        return -1;
+    }
+
+    fs::path metaPath = assetPath;
+    metaPath += ".meta";
+
+    if (fs::exists(metaPath))
+    {
+        std::cerr << "Meta file already exists: " << metaPath << "\n";
+        return 0;
+    }
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    auto uuid = uuids::uuid_random_generator(gen)();
+
+    std::ofstream metaFile(metaPath);
+    if (!metaFile)
+    {
+        std::cerr << "Error: could not create .meta file at " << metaPath << "\n";
+        return -1;
+    }
+
+    metaFile << "{\n";
+    metaFile << R"(    "id": ")" << uuid << "\"\n";
+    metaFile << "}\n";
+    metaFile.close();
+
+    std::cerr << "Created " << metaPath << " with UUID: " << uuid << "\n";
+    return 0;
+}

--- a/tools/quadrados/src/tools.hpp
+++ b/tools/quadrados/src/tools.hpp
@@ -2,7 +2,8 @@
 
 #include <string>
 
-struct GlobalArgs {
+struct GlobalArgs
+{
     std::string installDir = QUADRADOS_INSTALL_PATH;
 };
 /// Stores info about a tool.
@@ -12,17 +13,14 @@ struct Tool
     int (*run)(int, char**, GlobalArgs&);
 };
 
-
 int runHelp(int argc, char** argv, GlobalArgs& ga);
 int runEmbed(int argc, char** argv, GlobalArgs& ga);
 int runConvert(int argc, char** argv, GlobalArgs& ga);
 int runInit(int argc, char** argv, GlobalArgs& ga);
-int runCreate(int argc, char **argv, GlobalArgs& ga);
+int runImport(int argc, char** argv, GlobalArgs& ga);
+int runCreate(int argc, char** argv, GlobalArgs& ga);
 
 static const Tool Tools[] = {
-    {"help", runHelp},
-    {"embed", runEmbed},
-    {"convert", runConvert},
-    {"init", runInit},
-    {"create", runCreate},
+    {"help", runHelp}, {"embed", runEmbed},   {"convert", runConvert},
+    {"init", runInit}, {"import", runImport}, {"create", runCreate},
 };


### PR DESCRIPTION
Adds a simple tool to the quadrados project to generate .meta files with random UUIDs automatically. This solves the current problem where users have to manually generate UUIDs through external programs or websites and write .meta files by hand. With this tool, running quadrados import dir/asset.qb will create asset.qb.meta with a proper UUID, streamlining the asset import process.

Output:
{
    "id": "1fiekvrd-v360-d5p5-xssz-0i3al2f2zl6k"
}

- [ x] Self-review changes.
- [ ] Add entry to the changelog's unreleased section.