### PR TITLE
Show render timers in metrics panel

### DIFF
--- a/engine/include/cubos/engine/render/profiling/plugin.hpp
+++ b/engine/include/cubos/engine/render/profiling/plugin.hpp
@@ -15,6 +15,15 @@ namespace cubos::engine
     /// @defgroup render-profiling-plugin RenderProfiling
     /// @ingroup render-plugins
     /// @brief Adds and manages the @ref RenderProfiler resource.
+    ///
+    /// ## Settings
+    /// - `render.profiling` - whether profiling should be enabled (default: `false`).
+    ///
+    /// ## Resources
+    /// - @ref RenderProfiler - holds settings for render performance profiling.
+    ///
+    /// ## Dependencies
+    /// - @ref settings-plugin
 
     /// @brief Plugin entry function.
     /// @param cubos @b Cubos main class.

--- a/engine/src/render/bloom/plugin.cpp
+++ b/engine/src/render/bloom/plugin.cpp
@@ -287,7 +287,7 @@ void cubos::engine::bloomPlugin(Cubos& cubos)
 
             if (profiler.profilingEnabled)
             {
-                CUBOS_METRIC("Bloom", state.timer->end().result);
+                CUBOS_METRIC("Graphics::Bloom", state.timer->end().result);
             }
         });
 }

--- a/engine/src/render/deferred_shading/plugin.cpp
+++ b/engine/src/render/deferred_shading/plugin.cpp
@@ -507,7 +507,7 @@ void cubos::engine::deferredShadingPlugin(Cubos& cubos)
 
             if (profiler.profilingEnabled)
             {
-                CUBOS_METRIC("Deferred Shading", state.timer->end().result);
+                CUBOS_METRIC("Graphics::Deferred Shading", state.timer->end().result);
             }
         });
 }

--- a/engine/src/render/g_buffer_rasterizer/plugin.cpp
+++ b/engine/src/render/g_buffer_rasterizer/plugin.cpp
@@ -350,7 +350,7 @@ void cubos::engine::gBufferRasterizerPlugin(Cubos& cubos)
 
             if (profiler.profilingEnabled)
             {
-                CUBOS_METRIC("G-Buffer Rasterizer", state.timer->end().result);
+                CUBOS_METRIC("Graphics::G-Buffer Rasterizer", state.timer->end().result);
             }
         });
 }

--- a/engine/src/render/profiling/plugin.cpp
+++ b/engine/src/render/profiling/plugin.cpp
@@ -1,9 +1,18 @@
 #include <cubos/engine/render/profiling/plugin.hpp>
 #include <cubos/engine/render/profiling/profiler.hpp>
+#include <cubos/engine/settings/plugin.hpp>
 
 using namespace cubos::engine;
 
 void cubos::engine::renderProfilingPlugin(Cubos& cubos)
 {
+    cubos.depends(settingsPlugin);
+
     cubos.resource<RenderProfiler>();
+
+    cubos.startupSystem("enable render profiling")
+        .after(settingsTag)
+        .call([](RenderProfiler& profiler, Settings& settings) {
+            profiler.profilingEnabled = settings.getBool("render.profiling", false);
+        });
 }

--- a/engine/src/render/ssao/plugin.cpp
+++ b/engine/src/render/ssao/plugin.cpp
@@ -313,7 +313,7 @@ void cubos::engine::ssaoPlugin(Cubos& cubos)
 
             if (profiler.profilingEnabled)
             {
-                CUBOS_METRIC("SSAO", state.timer->end().result);
+                CUBOS_METRIC("Graphics::SSAO", state.timer->end().result);
             }
         });
 }

--- a/engine/src/render/tone_mapping/plugin.cpp
+++ b/engine/src/render/tone_mapping/plugin.cpp
@@ -146,7 +146,7 @@ void cubos::engine::toneMappingPlugin(Cubos& cubos)
 
             if (profiler.profilingEnabled)
             {
-                CUBOS_METRIC("Tonemapping", state.timer->end().result);
+                CUBOS_METRIC("Graphics::Tonemapping", state.timer->end().result);
             }
         });
 }

--- a/engine/src/tools/metrics_panel/plugin.cpp
+++ b/engine/src/tools/metrics_panel/plugin.cpp
@@ -4,6 +4,8 @@
 #include <imgui.h>
 #include <implot.h>
 
+#include <cubos/core/tel/metrics.hpp>
+
 #include <cubos/engine/imgui/plugin.hpp>
 #include <cubos/engine/tools/metrics_panel/plugin.hpp>
 #include <cubos/engine/tools/toolbox/plugin.hpp>
@@ -23,6 +25,12 @@ namespace
         std::vector<float> fpsHistory;
         const float timeSample = -5.0F;
         const float fpsSample = 1000.0F;
+    };
+
+    enum MetricType
+    {
+        Graphics,
+        Unspecified
     };
 } // namespace
 
@@ -81,6 +89,85 @@ void cubos::engine::metricsPanelPlugin(Cubos& cubos)
                                    (std::accumulate(metrics.fpsHistory.begin(), metrics.fpsHistory.end(), 0.0F) /
                                     static_cast<float>(metrics.fpsHistory.size())));
                 ImPlot::EndPlot();
+            }
+
+            // Show telemetry metrics
+            ImGui::NewLine();
+            ImGui::Separator();
+            ImGui::NewLine();
+            ImGui::Text("Metrics");
+
+            std::string name;
+            std::size_t seenCount = 0;
+            while (cubos::core::tel::Metrics::readName(name, seenCount))
+            {
+                if (ImPlot::BeginPlot(name.c_str()))
+                {
+                    MetricType metricType = Unspecified;
+                    std::size_t subStrStart;
+                    if ((subStrStart = name.find("Graphics::")) != std::string::npos)
+                    {
+                        metricType = Graphics;
+                    }
+
+                    std::vector<float> values;
+                    double value;
+                    std::size_t offset = 0;
+                    while (cubos::core::tel::Metrics::readValue(name, value, offset))
+                    {
+                        switch (metricType)
+                        {
+                        case Graphics:
+                            values.push_back(static_cast<float>(value) / 1000000.0F);
+                            break;
+
+                        default:
+                            values.push_back(static_cast<float>(value));
+                            break;
+                        }
+                    }
+
+                    std::vector<float> frameHistory;
+                    for (int i = -static_cast<int>(values.size()) + 1; i <= 0; i++)
+                    {
+                        frameHistory.push_back(static_cast<float>(i));
+                    }
+
+                    std::string displayName;
+                    double yMin;
+                    switch (metricType)
+                    {
+                    case Graphics:
+                        displayName = (name + " (ms)").substr(subStrStart);
+                        yMin = 0;
+                        break;
+
+                    default:
+                        displayName = name;
+                        yMin = *std::min_element(values.begin(), values.end());
+                        break;
+                    }
+
+                    ImGui::Text("%s: %.2f", displayName.c_str(), values.at(values.size() - 1));
+                    ImPlot::SetupAxes(
+                        "Frame", "Value",
+                        ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Lock | ImPlotAxisFlags_NoDecorations,
+                        ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Lock | ImPlotAxisFlags_NoDecorations);
+                    ImPlot::SetupAxesLimits(-static_cast<float>(frameHistory.size()), 0.0F, yMin,
+                                            *std::max_element(values.begin(), values.end()), ImPlotCond_Always);
+                    ImPlot::SetNextFillStyle(ImVec4(0, 0, 0, -1), 0.0F);
+                    ImPlot::PlotLine(name.c_str(), frameHistory.data(), values.data(),
+                                     static_cast<int>(frameHistory.size()),
+                                     ImPlotFlags_CanvasOnly | ImPlotFlags_NoInputs);
+                    ImGui::TextColored(ImVec4(0.5F, 1.0F, 0.5F, 1.0F), "Min: %.2f",
+                                       *std::min_element(values.begin(), values.end()));
+                    ImGui::TextColored(ImVec4(1.0F, 0.0F, 0.0F, 1.0F), "Max: %.2f",
+                                       *std::max_element(values.begin(), values.end()));
+                    ImGui::TextColored(
+                        ImVec4(1.0F, 1.0F, 0.0F, 1.0F), "Avg: %.2f",
+                        (std::accumulate(values.begin(), values.end(), 0.0F) / static_cast<float>(values.size())));
+                    ImPlot::EndPlot();
+                }
             }
             ImGui::End();
         });


### PR DESCRIPTION
# Description

Adds an option to enable render profiling, and shows values on the metrics panel.

## Checklist

- [ ] Self-review changes.
- [ ] Evaluate impact on the documentation.
- [ ] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
