### PR TITLE
feat(scripting): add system and startupsystem to lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for MaskTrait types in JSON (de)serializer (#1507, **@RiscadoA**).
 - Render timers in metrics panel (#1565, **@tomas7770**).
 - Custom module loader for lua scripts (#1517, **@mkuritsu**).
+- Added possibility of creating basic systems in lua scripts (#1518, **@mkuritsu**)
 
 ### Changed
 

--- a/bindings/lua/CMakeLists.txt
+++ b/bindings/lua/CMakeLists.txt
@@ -10,7 +10,9 @@ message("# Building cubos::bindings::lua samples " ${CUBOS_LUA_SAMPLES})
 # ----------------------- Define lua bindings source files -----------------------
 
 set(LUA_BINDINGS_SOURCE
+    "src/cubos.cpp"
     "src/plugin.cpp"
+    "src/systems.cpp"
 )
 
 # ------------------------ Configure lua bindings target -------------------------

--- a/bindings/lua/samples/CMakeLists.txt
+++ b/bindings/lua/samples/CMakeLists.txt
@@ -53,3 +53,4 @@ endfunction()
 # Add samples
 make_sample(DIR "hello_world" ASSETS)
 make_sample(DIR "modules" ASSETS)
+make_sample(DIR "systems" ASSETS)

--- a/bindings/lua/samples/systems/main.cpp
+++ b/bindings/lua/samples/systems/main.cpp
@@ -1,0 +1,24 @@
+#include <cubos/bindings/lua/plugin.hpp>
+
+#include <cubos/engine/prelude.hpp>
+#include <cubos/engine/settings/plugin.hpp>
+
+using namespace cubos::engine;
+using namespace cubos::bindings::lua;
+
+int main(int argc, char** argv)
+{
+    Cubos cubos{argc, argv};
+
+    cubos.plugin(settingsPlugin);
+    cubos.plugin(luaBindingsPlugin);
+
+    cubos.startupSystem("set ShouldQuit to false").call([](ShouldQuit& quit) { quit.value = false; });
+
+    cubos.startupSystem("configure Assets").before(settingsTag).call([](Settings& settings) {
+        settings.setString("scripts.lua.app.osPath", APP_SCRIPTS_PATH);
+    });
+
+    cubos.run();
+    return 0;
+}

--- a/bindings/lua/samples/systems/scripts/test.lua
+++ b/bindings/lua/samples/systems/scripts/test.lua
@@ -1,0 +1,13 @@
+local counter = 0
+
+cubos.startupSystem("print startup"):call(function()
+	print("Startup lua system called!")
+end)
+
+cubos.system("inc counter"):call(function()
+	counter = counter + 1
+	if counter == 1000000 then
+		print("Counter reached 1000000!")
+		counter = 0
+	end
+end)

--- a/bindings/lua/src/cubos.cpp
+++ b/bindings/lua/src/cubos.cpp
@@ -1,0 +1,36 @@
+#include <string_view>
+
+#include <cubos/core/reflection/external/string_view.hpp>
+#include <cubos/core/tel/logging.hpp>
+
+#include <cubos/engine/prelude.hpp>
+
+#include "cubos.hpp"
+#include "systems.hpp"
+
+using cubos::engine::Cubos;
+
+static void pushFunction(lua_State* state, const char* name, lua_CFunction fn)
+{
+    lua_pushcfunction(state, fn);
+    lua_setfield(state, -2, name);
+}
+
+void cubos::bindings::lua::injectCubos(lua_State* state, Cubos* cubos)
+{
+    lua_pushstring(state, "cubos");
+    lua_pushlightuserdata(state, cubos);
+    lua_settable(state, LUA_REGISTRYINDEX);
+
+    lua_newtable(state);
+    pushFunction(state, "startupSystem", startupSystem);
+    pushFunction(state, "system", system);
+    lua_setglobal(state, "cubos");
+}
+
+Cubos* cubos::bindings::lua::getCubos(lua_State* state)
+{
+    lua_pushstring(state, "cubos");
+    lua_gettable(state, LUA_REGISTRYINDEX);
+    return static_cast<Cubos*>(lua_touserdata(state, -1));
+}

--- a/bindings/lua/src/cubos.hpp
+++ b/bindings/lua/src/cubos.hpp
@@ -1,0 +1,26 @@
+/// @dir
+/// @brief @ref lua-bindings-plugin plugin directory.
+
+/// @file
+/// @brief Base cubos lua api.
+/// @ingroup lua-bindings-plugin
+#pragma once
+
+#include <lua.hpp>
+
+#include <cubos/engine/prelude.hpp>
+
+namespace cubos::bindings::lua
+{
+    /// @brief Injects the cubos table into the lua VM.
+    /// @param state The current lua state.
+    /// @param cubos The @ref cubos::engine::Cubos instance to be stored.
+    /// @ingroup lua-bindings-plugin
+    void injectCubos(lua_State* state, cubos::engine::Cubos* cubos);
+
+    /// @brief Gets the injected cubos table from the lua VM.
+    /// @param state The current lua state.
+    /// @returns Pointer to the stored @ref cubos::engine::Cubos instance.
+    /// @ingroup lua-bindings-plugin
+    cubos::engine::Cubos* getCubos(lua_State* state);
+} // namespace cubos::bindings::lua

--- a/bindings/lua/src/plugin.cpp
+++ b/bindings/lua/src/plugin.cpp
@@ -1,40 +1,26 @@
 #include <algorithm>
+#include <string>
 
 #include <cubos/bindings/lua/plugin.hpp>
 #include <lua.hpp>
 
 #include <cubos/core/data/fs/file_system.hpp>
 #include <cubos/core/data/fs/standard_archive.hpp>
+#include <cubos/core/ecs/system/arguments/plugins.hpp>
 
 #include <cubos/engine/settings/plugin.hpp>
+
+#include "cubos.hpp"
+#include "cubos/engine/prelude.hpp"
 
 using namespace cubos::engine;
 using cubos::core::data::FileSystem;
 using cubos::core::data::StandardArchive;
+using cubos::core::ecs::Plugins;
 
-static constexpr std::string_view ScriptsMountPoint = "/scripts/lua";
+static const std::string ScriptsMountPoint = "/scripts/lua";
 
-namespace
-{
-    struct State
-    {
-        CUBOS_ANONYMOUS_REFLECT(State);
-
-        lua_State* luaState;
-
-        State(lua_State* state)
-            : luaState(state)
-        {
-        }
-
-        ~State()
-        {
-            lua_close(luaState);
-        }
-    };
-} // namespace
-
-static void loadScripts(std::string_view path, State& state)
+static void loadScripts(std::string_view path, lua_State* state)
 {
     auto directory = FileSystem::find(path);
     if (directory != nullptr && directory->directory())
@@ -50,9 +36,9 @@ static void loadScripts(std::string_view path, State& state)
             {
                 std::string moduleName = std::string{child->path().substr(
                     ScriptsMountPoint.length() + 1, child->path().length() - 5 - ScriptsMountPoint.length())};
-                std::replace(moduleName.begin(), moduleName.end(), '/', '.');
+                std::ranges::replace(moduleName, '/', '.');
                 std::string execString = std::string{"require('"} + moduleName + "')";
-                luaL_dostring(state.luaState, execString.c_str());
+                luaL_dostring(state, execString.c_str());
             }
             child = child->sibling();
         }
@@ -63,7 +49,7 @@ static int searchModule(lua_State* state)
 {
     const char* moduleName = luaL_checkstring(state, 1);
     std::string module = moduleName;
-    std::replace(module.begin(), module.end(), '.', '/');
+    std::ranges::replace(module, '.', '/');
     module = module + ".lua";
 
     lua_pushstring(state, "scriptsPath");
@@ -91,7 +77,7 @@ static int searchModule(lua_State* state)
 static void setupCustomLoader(lua_State* state)
 {
     lua_pushstring(state, "scriptsPath");
-    lua_pushstring(state, ScriptsMountPoint.data());
+    lua_pushstring(state, ScriptsMountPoint.c_str());
     lua_settable(state, LUA_REGISTRYINDEX);
 
     lua_getglobal(state, "package");
@@ -102,21 +88,36 @@ static void setupCustomLoader(lua_State* state)
     lua_pop(state, lua_gettop(state));
 }
 
+namespace
+{
+    struct State
+    {
+        CUBOS_ANONYMOUS_REFLECT(State);
+
+        lua_State* luaState;
+
+        State(Cubos& cubos)
+            : luaState(luaL_newstate())
+        {
+            luaL_openlibs(luaState);
+            setupCustomLoader(luaState);
+            cubos::bindings::lua::injectCubos(luaState, &cubos);
+        }
+
+        ~State()
+        {
+            lua_close(luaState);
+        }
+    };
+} // namespace
+//
 void cubos::bindings::lua::luaBindingsPlugin(Cubos& cubos)
 {
     cubos.depends(settingsPlugin);
 
-    cubos.uninitResource<State>();
+    cubos.resource<State>(cubos);
 
-    cubos.startupSystem("initialize lua bindings").before(settingsTag).call([](Commands cmds) {
-        lua_State* state = luaL_newstate();
-        luaL_openlibs(state);
-        setupCustomLoader(state);
-        // TODO: add custom cubos functions here
-        cmds.emplaceResource<State>(state);
-    });
-
-    cubos.startupSystem("load lua scripts").after(settingsTag).call([](Settings& settings, State& state) {
+    cubos.startupSystem("load lua scripts").after(settingsTag).call([](Settings& settings, Plugins plugins) {
         std::string scriptsPath = settings.getString("scripts.lua.app.osPath", "");
         if (!scriptsPath.empty())
         {
@@ -129,8 +130,11 @@ void cubos::bindings::lua::luaBindingsPlugin(Cubos& cubos)
             {
                 CUBOS_ERROR("Couldn't mount scripts directory with path {}", scriptsPath);
             }
-
-            loadScripts(ScriptsMountPoint, state);
+            (void)plugins;
+            plugins.add([](Cubos& other) {
+                auto& state = other.world().resource<State>();
+                loadScripts(ScriptsMountPoint, state.luaState);
+            });
         }
     });
 }

--- a/bindings/lua/src/systems.cpp
+++ b/bindings/lua/src/systems.cpp
@@ -1,0 +1,70 @@
+#include "systems.hpp"
+
+#include <cubos/engine/prelude.hpp>
+
+#include "cubos.hpp"
+
+using cubos::bindings::lua::getCubos;
+using cubos::bindings::lua::SystemType;
+using cubos::engine::Cubos;
+
+static int luaSystemCall(lua_State* state)
+{
+    luaL_checktype(state, 1, LUA_TTABLE);
+    luaL_checktype(state, 2, LUA_TFUNCTION);
+    int ref = luaL_ref(state, LUA_REGISTRYINDEX);
+
+    Cubos* cubos = getCubos(state);
+
+    lua_getfield(state, 1, "systemName");
+    const char* systemName = lua_tostring(state, -1);
+    lua_getfield(state, 1, "systemType");
+    auto type = static_cast<SystemType>(lua_tonumber(state, -1));
+    switch (type)
+    {
+    case SystemType::Startup:
+        cubos->startupSystem(systemName).call([state, ref]() {
+            lua_rawgeti(state, LUA_REGISTRYINDEX, ref);
+            lua_pcall(state, 0, 0, 0);
+        });
+        break;
+
+    case SystemType::Update:
+        cubos->system(systemName).call([state, ref]() {
+            lua_rawgeti(state, LUA_REGISTRYINDEX, ref);
+            lua_pcall(state, 0, 0, 0);
+        });
+        break;
+    }
+    return 0;
+}
+
+static void pushSystem(lua_State* state, const char* systemName, SystemType type)
+{
+    lua_newtable(state);
+    lua_pushstring(state, systemName);
+    lua_setfield(state, -2, "systemName");
+    lua_pushnumber(state, static_cast<int>(type));
+    lua_setfield(state, -2, "systemType");
+    lua_pushcfunction(state, luaSystemCall);
+    lua_setfield(state, -2, "call");
+}
+
+namespace cubos::bindings::lua
+{
+    int startupSystem(lua_State* state)
+    {
+        luaL_checktype(state, 1, LUA_TSTRING);
+        const char* systemName = lua_tostring(state, 1);
+        pushSystem(state, systemName, SystemType::Startup);
+        return 1;
+    };
+
+    int system(lua_State* state)
+    {
+        luaL_checktype(state, 1, LUA_TSTRING);
+        const char* systemName = lua_tostring(state, 1);
+        pushSystem(state, systemName, SystemType::Update);
+        return 1;
+    };
+} // namespace cubos::bindings::lua

--- a/bindings/lua/src/systems.hpp
+++ b/bindings/lua/src/systems.hpp
@@ -1,0 +1,32 @@
+/// @dir
+/// @brief @ref lua-bindings-plugin plugin directory.
+
+/// @file
+/// @brief Systems lua api.
+/// @ingroup lua-bindings-plugin
+#pragma once
+
+#include <cstdint>
+
+#include <lua.hpp>
+
+namespace cubos::bindings::lua
+{
+    /// @brief Possible system types that can be registered
+    /// @ingroup lua-bindings-plugin
+    enum class SystemType : uint8_t
+    {
+        Startup = 0,
+        Update = 1
+    };
+
+    /// @brief Lua api function to register a startup system (executed only once).
+    /// @param state The current lua state.
+    /// @ingroup lua-bindings-plugin
+    int startupSystem(lua_State* state);
+
+    /// @brief Lua api function to register a system (executed more than once).
+    /// @param state The current lua state.
+    /// @ingroup lua-bindings-plugin
+    int system(lua_State* state);
+} // namespace cubos::bindings::lua

--- a/core/include/cubos/core/ecs/cubos.hpp
+++ b/core/include/cubos/core/ecs/cubos.hpp
@@ -255,6 +255,10 @@ namespace cubos::core::ecs
         /// @return Whether the application should quit.
         bool shouldQuit() const;
 
+        /// @brief Returns the ECS world used.
+        /// @return The internal ECS world.
+        World& world();
+
     private:
         /// @brief Stores information regarding a plugin.
         struct PluginInfo

--- a/core/src/ecs/cubos.cpp
+++ b/core/src/ecs/cubos.cpp
@@ -452,6 +452,11 @@ bool Cubos::shouldQuit() const
     return mWorld->resource<ShouldQuit>().value;
 }
 
+cubos::core::ecs::World& Cubos::world()
+{
+    return *mWorld;
+}
+
 bool Cubos::isRegistered(const reflection::Type& type) const
 {
     return (mTypeToPlugin.contains(type) && this->isKnownPlugin(mTypeToPlugin.at(type), mPluginStack.back())) ||


### PR DESCRIPTION
# Description

Add `cubos.system` and `cubos.startupSystem` functions to lua bindings, currently without any system args

## Checklist

- [x] Self-review changes.
- [x] Evaluate impact on the documentation.
- [x] Ensure test coverage.
- [x] Write new samples.
- [x] Add entry to the changelog's unreleased section.