### PR TITLE
feat(tools): allow hiding components on the inspector

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CUBOS_CORE_SOURCE
 	"src/reflection/traits/vector.cpp"
 	"src/reflection/traits/wrapper.cpp"
 	"src/reflection/traits/constant.cpp"
+    "src/reflection/traits/hidden.cpp"
 	"src/reflection/external/primitives.cpp"
 	"src/reflection/external/const.cpp"
 	"src/reflection/external/carray.cpp"

--- a/core/include/cubos/core/ecs/reflection.hpp
+++ b/core/include/cubos/core/ecs/reflection.hpp
@@ -6,6 +6,7 @@
 
 #include <cubos/core/reflection/traits/constructible.hpp>
 #include <cubos/core/reflection/traits/fields.hpp>
+#include <cubos/core/reflection/traits/hidden.hpp>
 #include <cubos/core/reflection/traits/wrapper.hpp>
 #include <cubos/core/reflection/type.hpp>
 
@@ -92,6 +93,18 @@ namespace cubos::core::ecs
         TypeBuilder&& withField(std::string name, F T::* pointer) &&
         {
             mFields.addField(std::move(name), pointer);
+            return std::move(*this);
+        }
+
+        /// @brief Makes a type hidden in the UI by default.
+        ///
+        /// Useful for hiding internal components that can end up occupying
+        /// too much visual space in the entity inspector.
+        ///
+        /// @return Builder.
+        TypeBuilder&& hide() &&
+        {
+            mType.with(reflection::HiddenTrait(true));
             return std::move(*this);
         }
 

--- a/core/include/cubos/core/reflection/traits/hidden.hpp
+++ b/core/include/cubos/core/reflection/traits/hidden.hpp
@@ -1,0 +1,31 @@
+/// @file
+/// @brief Class @ref cubos::core::reflection::CategorizableTrait.
+/// @ingroup core-reflection
+
+#pragma once
+
+#include <cubos/core/reflection/reflect.hpp>
+
+namespace cubos::core::reflection
+{
+    /// @brief Allows for a component to be hidden in the UI.
+    /// @ingroup core-reflection
+    class CUBOS_CORE_API HiddenTrait
+    {
+
+    public:
+        CUBOS_REFLECT;
+
+        /// @brief Constructs.
+        /// @param hidden Hidden.
+        HiddenTrait(bool hidden);
+
+        /// @brief Gets the visibility of the type.
+        /// @return Type visibility.
+        bool hidden() const;
+
+    private:
+        bool mHidden;
+    };
+
+} // namespace cubos::core::reflection

--- a/core/src/reflection/traits/hidden.cpp
+++ b/core/src/reflection/traits/hidden.cpp
@@ -1,0 +1,19 @@
+#include <cubos/core/reflection/traits/hidden.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::HiddenTrait;
+
+CUBOS_REFLECT_IMPL(HiddenTrait)
+{
+    return Type::create("cubos::core::reflection::HiddenTrait");
+}
+
+HiddenTrait::HiddenTrait(bool hidden)
+    : mHidden{hidden}
+{
+}
+
+bool HiddenTrait::hidden() const
+{
+    return mHidden;
+}

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
 	reflection/traits/mask.cpp
 	reflection/traits/inherits.cpp
 	reflection/traits/vector.cpp
+	reflection/traits/hidden.cpp
 	reflection/external/primitives.cpp
 	reflection/external/const.cpp
 	reflection/external/cstring.cpp

--- a/core/tests/reflection/traits/hidden.cpp
+++ b/core/tests/reflection/traits/hidden.cpp
@@ -1,0 +1,50 @@
+#include <doctest/doctest.h>
+
+#include <cubos/core/reflection/traits/hidden.hpp>
+#include <cubos/core/reflection/type.hpp>
+
+using cubos::core::reflection::HiddenTrait;
+using cubos::core::reflection::reflect;
+using cubos::core::reflection::Type;
+
+namespace
+{
+    struct SimpleType
+    {
+        CUBOS_REFLECT;
+    };
+
+    struct HiddenType
+    {
+        CUBOS_REFLECT;
+        float mass;
+    };
+
+} // namespace
+
+CUBOS_REFLECT_IMPL(SimpleType)
+{
+    return Type::create("SimpleType");
+}
+
+CUBOS_REFLECT_IMPL(HiddenType) 
+{
+    return Type::create("HiddenType").with(HiddenTrait{true});
+}
+
+TEST_CASE("reflection::HiddenTrait")
+{
+    SUBCASE("Not hidden")
+    {
+        const auto& simpleType = reflect<SimpleType>();
+        REQUIRE_FALSE(simpleType.has<SimpleType>());
+    }
+
+    SUBCASE("Hidden")
+    {
+        const auto& hiddenType = reflect<HiddenType>();
+        REQUIRE(hiddenType.has<HiddenTrait>());
+        const auto& trait = hiddenType.get<HiddenTrait>();
+        REQUIRE(trait.hidden());
+    }
+}

--- a/engine/src/tools/entity_inspector/plugin.cpp
+++ b/engine/src/tools/entity_inspector/plugin.cpp
@@ -10,6 +10,8 @@
 #include <cubos/engine/tools/selection/plugin.hpp>
 #include <cubos/engine/tools/toolbox/plugin.hpp>
 
+#include "cubos/core/reflection/traits/hidden.hpp"
+
 using cubos::core::ecs::Name;
 using cubos::core::ecs::World;
 using cubos::core::memory::AnyValue;
@@ -27,6 +29,7 @@ namespace
         CUBOS_ANONYMOUS_REFLECT(State);
 
         const Type* relationType;
+        bool showHidden = false;
     };
 } // namespace
 
@@ -126,6 +129,8 @@ void cubos::engine::entityInspectorPlugin(Cubos& cubos)
                     ImGui::Text("Entity %s selected", getName(entity).c_str());
                     ImGui::SeparatorText("Components");
 
+                    ImGui::Checkbox("Show hidden components", &state.showHidden);
+
                     if (ImGui::Button("Add Component"))
                     {
                         ImGui::OpenPopup("Select Component Type");
@@ -149,6 +154,12 @@ void cubos::engine::entityInspectorPlugin(Cubos& cubos)
                     const Type* removed = nullptr;
                     for (auto [type, value] : world.components(entity))
                     {
+
+                        if (type->has<core::reflection::HiddenTrait>() && !state.showHidden)
+                        {
+                            continue;
+                        }
+
                         ImGui::PushID(type->name().c_str());
                         if (ImGui::Button("X"))
                         {


### PR DESCRIPTION
# Description

Created a `Hidden` Trait for components to be hidden by default in the UI. Added a checkbox on the entity inspector to view these hidden components.

## Checklist

- [X] Self-review changes.
- [X] Evaluate impact on the documentation.
- [X] Ensure test coverage.
- [ ] Write new samples.
- [ ] Add entry to the changelog's unreleased section.
